### PR TITLE
Delay was not passing scheduler through

### DIFF
--- a/lib/Rx/Operator/DelayOperator.php
+++ b/lib/Rx/Operator/DelayOperator.php
@@ -3,6 +3,7 @@
 namespace Rx\Operator;
 
 use Rx\Disposable\CompositeDisposable;
+use Rx\Disposable\EmptyDisposable;
 use Rx\ObservableInterface;
 use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
@@ -45,6 +46,8 @@ class DelayOperator implements OperatorInterface
 
         $disposable = new CompositeDisposable();
 
+        $sourceDisposable = new EmptyDisposable();
+
         $sourceDisposable = $observable->subscribe(new CallbackObserver(
             function ($x) use ($scheduler, $observer, &$lastScheduledTime, $disposable) {
                 $schedDisp = $scheduler->schedule(function () use ($x, $observer, &$schedDisp, $disposable) {
@@ -68,8 +71,9 @@ class DelayOperator implements OperatorInterface
                 }, $this->delay);
 
                 $disposable->add($schedDisp);
-            }
-        ));
+            }),
+            $scheduler
+        );
 
         $disposable->add($sourceDisposable);
 


### PR DESCRIPTION
Delay was not passing scheduler through. This was causing an issue where onCompleted was being called prior to the source subscription completing and before the sourceDisposable was set. onCompleted would attempt to call dispose on a null.

This PR corrects delay and passes the scheduler through, initializes the source disposable in case onCompleted is called prior to subscribe completing. Also has regression tests for both situations.
