### PR TITLE
Update demos which use \Rx\React\Interval

### DIFF
--- a/demo/share/share.php
+++ b/demo/share/share.php
@@ -3,11 +3,10 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 $loop = \React\EventLoop\Factory::create();
+$scheduler  = new \Rx\Scheduler\EventLoopScheduler($loop);
 
 //Without Share
-$interval = new \Rx\React\Interval(1000, $loop);
-
-$source = $interval
+$source = \Rx\Observable::interval(1000, $scheduler)
     ->take(2)
     ->doOnNext(function ($x) {
         echo "Side effect\n";
@@ -30,10 +29,7 @@ $loop->run();
 
 
 //With Share
-
-$interval = new \Rx\React\Interval(1000, $loop);
-
-$source = $interval
+$source = \Rx\Observable::interval(1000, $scheduler)
     ->take(2)
     ->doOnNext(function ($x) {
         echo "Side effect\n";

--- a/demo/takeUntil/takeUntil.php
+++ b/demo/takeUntil/takeUntil.php
@@ -11,7 +11,8 @@ $timeout = \Rx\Observable::create(function (\Rx\ObserverInterface $o) use ($loop
     return new \Rx\Disposable\EmptyDisposable();
 });
 
-$source = (new \Rx\React\Interval(1000, $loop))->takeUntil($timeout);
+$scheduler  = new \Rx\Scheduler\EventLoopScheduler($loop);
+$source = \Rx\Observable::interval(1000, $scheduler)->takeUntil($timeout);
 
 $subscription = $source->subscribe($stdoutObserver);
 


### PR DESCRIPTION
Hey guys,

I was running demos to learn how RxPHP works and found that `takeUntil` and `share` demos still use `\Rx\React\Interval` which was removed about one month ago. I replaced it with `\Rx\Observable\IntervalObservable`.

Best regards,
Ihor
