### PR TITLE
Added `concatAll` and `concatMap` and `concatMapTo` operators

### DIFF
--- a/demo/concat/concatAll.php
+++ b/demo/concat/concatAll.php
@@ -1,0 +1,11 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$source = Rx\Observable::range(0, 3)
+    ->map(function ($x) {
+        return \Rx\Observable::range($x, 3);
+    })
+    ->concatAll();
+
+$subscription = $source->subscribe($stdoutObserver);

--- a/demo/concat/concatAll.php.expect
+++ b/demo/concat/concatAll.php.expect
@@ -1,0 +1,10 @@
+Next value: 0
+Next value: 1
+Next value: 2
+Next value: 1
+Next value: 2
+Next value: 3
+Next value: 2
+Next value: 3
+Next value: 4
+Complete!

--- a/demo/concat/concatMap.php
+++ b/demo/concat/concatMap.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$loop      = \React\EventLoop\Factory::create();
+$scheduler = new \Rx\Scheduler\EventLoopScheduler($loop);
+
+$source = Rx\Observable::range(0, 5)
+    ->concatMap(function ($x, $i) use ($scheduler) {
+        return \Rx\Observable::interval(100, $scheduler)
+            ->take($x)
+            ->map(function () use ($i) {
+                return $i;
+            });
+    });
+
+$subscription = $source->subscribe($stdoutObserver);
+
+$loop->run();

--- a/demo/concat/concatMap.php.expect
+++ b/demo/concat/concatMap.php.expect
@@ -1,0 +1,11 @@
+Next value: 1
+Next value: 2
+Next value: 2
+Next value: 3
+Next value: 3
+Next value: 3
+Next value: 4
+Next value: 4
+Next value: 4
+Next value: 4
+Complete!

--- a/demo/concat/concatMapTo.php
+++ b/demo/concat/concatMapTo.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$loop      = \React\EventLoop\Factory::create();
+$scheduler = new \Rx\Scheduler\EventLoopScheduler($loop);
+
+$obs = \Rx\Observable::interval(100, $scheduler)
+    ->take(3)
+    ->mapWithIndex(function ($i) {
+        return $i;
+    });
+
+$source = Rx\Observable::range(0, 5)
+    ->concatMapTo($obs);
+
+$subscription = $source->subscribe($stdoutObserver);
+
+$loop->run();

--- a/demo/concat/concatMapTo.php.expect
+++ b/demo/concat/concatMapTo.php.expect
@@ -1,0 +1,16 @@
+Next value: 0
+Next value: 1
+Next value: 2
+Next value: 3
+Next value: 4
+Next value: 5
+Next value: 6
+Next value: 7
+Next value: 8
+Next value: 9
+Next value: 10
+Next value: 11
+Next value: 12
+Next value: 13
+Next value: 14
+Complete!

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -19,6 +19,8 @@ use Rx\Operator\AsObservableOperator;
 use Rx\Operator\BufferWithCountOperator;
 use Rx\Operator\CatchErrorOperator;
 use Rx\Operator\CombineLatestOperator;
+use Rx\Operator\ConcatAllOperator;
+use Rx\Operator\ConcatMapOperator;
 use Rx\Operator\ConcatOperator;
 use Rx\Operator\CountOperator;
 use Rx\Operator\DefaultIfEmptyOperator;
@@ -651,6 +653,71 @@ class Observable implements ObservableInterface
     {
         return $this->lift(function () use ($observable) {
             return new ConcatOperator($observable);
+        });
+    }
+
+    /**
+     * Projects each element of an observable sequence to an observable sequence and concatenates the resulting
+     * observable sequences into one observable sequence.
+     *
+     * @param callable $selector A transform function to apply to each element from the source sequence onto.
+     * The selector is called with the following information:
+     *   - the value of the element
+     *   - the index of the element
+     *   - the Observable object being subscribed
+     *
+     * @param callable $resultSelector A transform function to apply to each element of the intermediate sequence.
+     * The resultSelector is called with the following information:
+     *   - the value of the outer element
+     *   - the value of the inner element
+     *   - the index of the outer element
+     *   - the index of the inner element
+     *
+     * @return AnonymousObservable - An observable sequence whose elements are the result of invoking the one-to-many
+     * transform function collectionSelector on each element of the input sequence and then mapping each of those
+     * sequence elements and their corresponding source element to a result element.
+     */
+    public function concatMap(callable $selector, callable $resultSelector = null)
+    {
+        return $this->lift(function () use ($selector, $resultSelector) {
+            return new ConcatMapOperator($selector, $resultSelector);
+        });
+    }
+
+    /**
+     * Projects each element of the source observable sequence to the other observable sequence and merges the
+     * resulting observable sequences into one observable sequence.
+     *
+     * @param ObservableInterface $observable - An an observable sequence to project each element from the source
+     * sequence onto.
+     *
+     * @param callable $resultSelector A transform function to apply to each element of the intermediate sequence.
+     * The resultSelector is called with the following information:
+     *   - the value of the outer element
+     *   - the value of the inner element
+     *   - the index of the outer element
+     *   - the index of the inner element
+     *
+     * @return AnonymousObservable An observable sequence whose elements are the result of invoking the one-to-many
+     * transform function collectionSelector on each element of the input sequence and then mapping each of those
+     * sequence elements and their corresponding source element to a result element.
+     */
+    public function concatMapTo(ObservableInterface $observable, callable $resultSelector = null)
+    {
+        return $this->concatMap(function () use ($observable) {
+            return $observable;
+        }, $resultSelector);
+    }
+
+    /**
+     * Concatenates a sequence of observable sequences into a single observable sequence.
+     *
+     * @return AnonymousObservable The observable sequence that merges the elements of the inner sequences.
+     */
+    public function concatAll()
+    {
+        return $this->lift(function () {
+            return new ConcatAllOperator();
         });
     }
 

--- a/lib/Rx/Operator/ConcatAllOperator.php
+++ b/lib/Rx/Operator/ConcatAllOperator.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Rx\Operator;
+
+use Rx\Disposable\CompositeDisposable;
+use Rx\Disposable\EmptyDisposable;
+use Rx\Disposable\SerialDisposable;
+use Rx\Observable;
+use Rx\ObservableInterface;
+use Rx\Observer\CallbackObserver;
+use Rx\ObserverInterface;
+use Rx\SchedulerInterface;
+
+class ConcatAllOperator implements OperatorInterface
+{
+    /** @var  array */
+    private $buffer;
+
+    /** @var CompositeDisposable */
+    private $disposable;
+
+    /** @var SerialDisposable */
+    private $innerDisposable;
+
+    /** @var bool */
+    private $startBuffering;
+
+    /** @var bool */
+    private $sourceCompleted;
+
+    /** @var bool */
+    private $innerCompleted;
+
+    public function __construct()
+    {
+        $this->buffer          = [];
+        $this->disposable      = new CompositeDisposable();
+        $this->innerDisposable = new EmptyDisposable();
+        $this->startBuffering  = false;
+        $this->sourceCompleted = false;
+        $this->innerCompleted  = true;
+    }
+
+    /**
+     * @param ObservableInterface $observable
+     * @param ObserverInterface $observer
+     * @param SchedulerInterface|null $scheduler
+     * @return CompositeDisposable
+     */
+    public function __invoke(ObservableInterface $observable, ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    {
+        $subscription = $observable->subscribe(new CallbackObserver(
+            function (ObservableInterface $innerObservable) use ($observable, $observer, $scheduler) {
+                try {
+
+                    if ($this->startBuffering === true) {
+                        $this->buffer[] = $innerObservable;
+                        return;
+                    }
+
+                    $this->startBuffering = true;
+
+                    $onCompleted = function () use (&$subscribeToInner, $observer) {
+
+                        $this->disposable->remove($this->innerDisposable);
+                        $this->innerDisposable->dispose();
+
+                        $this->innerCompleted = true;
+
+                        $obs = array_shift($this->buffer);
+
+                        if ($obs) {
+                            $subscribeToInner($obs);
+                        } elseif ($this->sourceCompleted === true) {
+                            $observer->onCompleted();
+                        }
+
+                        if (empty($this->buffer)) {
+                            $this->startBuffering = false;
+                        }
+                    };
+
+                    $subscribeToInner = function ($observable) use ($observer, $scheduler, &$onCompleted) {
+                        $callbackObserver = new CallbackObserver(
+                            [$observer, 'onNext'],
+                            [$observer, 'onError'],
+                            $onCompleted
+                        );
+
+                        $this->innerCompleted = false;
+
+                        $this->innerDisposable = $observable->subscribe($callbackObserver, $scheduler);
+                        $this->disposable->add($this->innerDisposable);
+                    };
+
+                    $subscribeToInner($innerObservable);
+
+                } catch (\Exception $e) {
+                    $observer->onError($e);
+                }
+            },
+            [$observer, 'onError'],
+            function () use ($observer) {
+                $this->sourceCompleted = true;
+                if ($this->innerCompleted === true) {
+                    $observer->onCompleted();
+                }
+            }
+        ), $scheduler);
+
+        $this->disposable->add($subscription);
+
+        return $this->disposable;
+    }
+}

--- a/lib/Rx/Operator/ConcatMapOperator.php
+++ b/lib/Rx/Operator/ConcatMapOperator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rx\Operator;
+
+use Rx\Observable;
+use Rx\ObservableInterface;
+use Rx\ObserverInterface;
+use Rx\SchedulerInterface;
+
+class ConcatMapOperator implements OperatorInterface
+{
+    /** @var int */
+    private $count;
+
+    /** @var callable */
+    private $selector;
+
+    /** @var callable */
+    private $resultSelector;
+
+    public function __construct(callable $selector, callable $resultSelector = null)
+    {
+        $this->selector       = $selector;
+        $this->count          = 0;
+        $this->resultSelector = $resultSelector;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(ObservableInterface $observable, ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    {
+        return $observable->mapWithIndex(function ($index, $value) use ($observable, $observer) {
+
+            try {
+                $result = call_user_func_array($this->selector, [$value, $index, $observable]);
+
+                if (!$result instanceof Observable) {
+                    throw new \Exception('concatMap Error:  You must return an Observable from the concatMap selector');
+                }
+
+                if ($this->resultSelector) {
+                    return $result->mapWithIndex(function ($innerIndex, $innerValue) use ($value, $index) {
+                        return call_user_func_array($this->resultSelector, [$value, $innerValue, $index, $innerIndex]);
+                    });
+                }
+
+                return $result;
+
+            } catch (\Exception $e) {
+                $observer->onError($e);
+            }
+        })
+            ->concatAll()
+            ->subscribe($observer, $scheduler);
+    }
+}

--- a/test/Rx/Functional/Operator/ConcatMapTest.php
+++ b/test/Rx/Functional/Operator/ConcatMapTest.php
@@ -1,0 +1,1074 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use Rx\Functional\FunctionalTestCase;
+use Rx\Observable;
+use Exception;
+
+class ConcatMapTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Complete_Task()
+    {
+        $xs = Observable::fromArray([4, 3, 2, 1]);
+        $ys = Observable::just(42);
+
+        $results   = [];
+        $completed = false;
+
+        $xs->concatMapTo($ys)
+            ->subscribeCallback(
+                function ($x) use (&$results) {
+                    $results[] = $x;
+                },
+                function ($e) {
+                    $this->fail();
+                },
+                function () use (&$completed) {
+                    $completed = true;
+                }
+            );
+
+        $this->assertTrue($completed);
+        $this->assertEquals([42, 42, 42, 42], $results);
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Error_Task()
+    {
+        $xs = Observable::fromArray([4, 3, 2, 1]);
+        $ys = Observable::error(new \Exception("test"));
+
+        $results   = [];
+        $completed = false;
+        $error     = false;
+
+        $xs->concatMapTo($ys)
+            ->subscribeCallback(
+                function ($x) use (&$results) {
+                    $results[] = $x;
+                },
+                function (\Exception $e) use (&$results, &$error) {
+                    $error = true;
+                    $this->assertSame("test", $e->getMessage());
+                },
+                function () use (&$completed) {
+                    $completed = true;
+                }
+            );
+
+        $this->assertFalse($completed);
+        $this->assertTrue($error);
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_result_Complete_Task()
+    {
+        $xs = Observable::fromArray([4, 3, 2, 1]);
+
+        $results   = [];
+        $completed = false;
+
+        $xs->concatMap(
+            function ($x, $i) {
+                return Observable::just($x + $i);
+            },
+            function ($x, $y, $oi, $ii) {
+                $this->assertEquals(0, $ii);
+                return $x + $y + $oi;
+            })
+            ->subscribeCallback(
+                function ($x) use (&$results) {
+                    $results[] = $x;
+                },
+                function ($e) {
+                    $this->fail();
+                },
+                function () use (&$completed) {
+                    $completed = true;
+                }
+            );
+
+        $this->assertTrue($completed);
+        $this->assertEquals([8, 8, 8, 8], $results);
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_result_Error_Task()
+    {
+        $xs = Observable::fromArray([4, 3, 2, 1]);
+
+        $results     = [];
+        $completed   = false;
+        $error       = new \Exception();
+        $returnError = null;
+
+        $xs->concatMap(
+            function ($x, $i) {
+                return Observable::just($x + $i);
+            },
+            function ($x, $y, $i) use ($error) {
+                throw $error;
+            })
+            ->subscribeCallback(
+                function ($x) use (&$results) {
+                    $results[] = $x;
+                },
+                function ($e) use (&$returnError) {
+                    $returnError = $e;
+                },
+                function () use (&$completed) {
+                    $completed = true;
+                }
+            );
+
+        $this->assertFalse($completed);
+        $this->assertSame($error, $returnError);
+        $this->assertEquals([], $results);
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Then_Complete_Task()
+    {
+        $xs = Observable::fromArray([4, 3, 2, 1]);
+
+        $results   = [];
+        $completed = false;
+
+        $xs->concatMap(function ($x, $i) {
+            return Observable::just($x + $i);
+        })
+            ->subscribeCallback(
+                function ($x) use (&$results) {
+                    $results[] = $x;
+                },
+                function ($e) {
+                    $this->fail('Should not get an error');
+                },
+                function () use (&$completed) {
+                    $completed = true;
+                }
+            );
+
+        $this->assertTrue($completed);
+        $this->assertEquals([4, 4, 4, 4], $results);
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Then_Error_Task()
+    {
+        $xs = Observable::fromArray([4, 3, 2, 1]);
+
+        $results   = [];
+        $completed = false;
+        $error     = false;
+
+        $xs->concatMap(function ($x, $i) {
+            return Observable::error(new Exception($x + $i));
+        })
+            ->subscribeCallback(
+                function ($x) use (&$results) {
+                    $results[] = $x;
+                },
+                function (\Exception $e) use (&$results, &$error) {
+                    $error = true;
+                    $this->assertEquals(4, $e->getMessage());
+                },
+                function () use (&$completed) {
+                    $completed = true;
+                }
+            );
+
+        $this->assertFalse($completed);
+        $this->assertTrue($error);
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Complete_Complete()
+    {
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onCompleted(500)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux'),
+                onCompleted(250)
+            ]
+        );
+
+        $results = $this->scheduler->startWithDispose(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        }, 2000);
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux'),
+                onNext(600, 'foo'),
+                onNext(650, 'bar'),
+                onNext(700, 'baz'),
+                onNext(750, 'qux'),
+                onNext(850, 'foo'),
+                onNext(900, 'bar'),
+                onNext(950, 'baz'),
+                onNext(1000, 'qux'),
+                onNext(1100, 'foo'),
+                onNext(1150, 'bar'),
+                onNext(1200, 'baz'),
+                onNext(1250, 'qux'),
+                onCompleted(1300)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 700)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 550),
+            subscribe(550, 800),
+            subscribe(800, 1050),
+            subscribe(1050, 1300)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Complete_Complete_2()
+    {
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onCompleted(700)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux'),
+                onCompleted(250)
+            ]
+        );
+
+        $results = $this->scheduler->startWithDispose(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        }, 2000);
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux'),
+                onNext(600, 'foo'),
+                onNext(650, 'bar'),
+                onNext(700, 'baz'),
+                onNext(750, 'qux'),
+                onNext(850, 'foo'),
+                onNext(900, 'bar'),
+                onNext(950, 'baz'),
+                onNext(1000, 'qux'),
+                onNext(1100, 'foo'),
+                onNext(1150, 'bar'),
+                onNext(1200, 'baz'),
+                onNext(1250, 'qux'),
+                onCompleted(1300)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 900)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 550),
+            subscribe(550, 800),
+            subscribe(800, 1050),
+            subscribe(1050, 1300)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Never_Complete()
+    {
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onNext(500, 5),
+                onNext(700, 0)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux'),
+                onCompleted(250)
+            ]
+        );
+
+        $results = $this->scheduler->startWithDispose(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        }, 2000);
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux'),
+                onNext(600, 'foo'),
+                onNext(650, 'bar'),
+                onNext(700, 'baz'),
+                onNext(750, 'qux'),
+                onNext(850, 'foo'),
+                onNext(900, 'bar'),
+                onNext(950, 'baz'),
+                onNext(1000, 'qux'),
+                onNext(1100, 'foo'),
+                onNext(1150, 'bar'),
+                onNext(1200, 'baz'),
+                onNext(1250, 'qux'),
+                onNext(1350, 'foo'),
+                onNext(1400, 'bar'),
+                onNext(1450, 'baz'),
+                onNext(1500, 'qux'),
+                onNext(1600, 'foo'),
+                onNext(1650, 'bar'),
+                onNext(1700, 'baz'),
+                onNext(1750, 'qux')
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 2000)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 550),
+            subscribe(550, 800),
+            subscribe(800, 1050),
+            subscribe(1050, 1300),
+            subscribe(1300, 1550),
+            subscribe(1550, 1800)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Complete_Never()
+    {
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onCompleted(500)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux')
+            ]
+        );
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        });
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux')
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 700)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 1000)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Complete_Error()
+    {
+
+        $ex = new Exception();
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onCompleted(500)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux'),
+                onError(300, $ex)
+            ]
+        );
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        });
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux'),
+                onError(600, $ex)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 600)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 600)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Error_Complete()
+    {
+
+        $ex = new Exception();
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onError(500, $ex)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux'),
+                onCompleted(250)
+            ]
+        );
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        });
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux'),
+                onNext(600, 'foo'),
+                onNext(650, 'bar'),
+                onError(700, $ex)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 700)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 550),
+            subscribe(550, 700)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMapTo_Then_Error_Error()
+    {
+
+        $ex = new Exception();
+
+        $xs = $this->createColdObservable(
+            [
+                onNext(100, 4),
+                onNext(200, 2),
+                onNext(300, 3),
+                onNext(400, 1),
+                onError(500, $ex)
+            ]
+        );
+
+        $ys = $this->createColdObservable(
+            [
+                onNext(50, 'foo'),
+                onNext(100, 'bar'),
+                onNext(150, 'baz'),
+                onNext(200, 'qux'),
+                onError(250, $ex)
+            ]
+        );
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs, $ys) {
+            return $xs->concatMapTo($ys);
+        });
+
+        $this->assertMessages(
+            [
+                onNext(350, 'foo'),
+                onNext(400, 'bar'),
+                onNext(450, 'baz'),
+                onNext(500, 'qux'),
+                onError(550, $ex)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 550)
+        ], $xs->getSubscriptions());
+
+        $this->assertSubscriptions([
+            subscribe(300, 550)
+        ], $ys->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Complete()
+    {
+
+        $xs = $this->createHotObservable([
+            onNext(5, $this->createColdObservable([
+                onError(1, new Exception('ex1'))
+            ])),
+            onNext(105, $this->createColdObservable([
+                onError(1, new Exception('ex2'))
+            ])),
+            onNext(300, $this->createColdObservable([
+                onNext(10, 102),
+                onNext(90, 103),
+                onNext(110, 104),
+                onNext(190, 105),
+                onNext(440, 106),
+                onCompleted(460)
+            ])),
+            onNext(400, $this->createColdObservable([
+                onNext(180, 202),
+                onNext(190, 203),
+                onCompleted(205)
+            ])),
+            onNext(550, $this->createColdObservable([
+                onNext(10, 301),
+                onNext(50, 302),
+                onNext(70, 303),
+                onNext(260, 304),
+                onNext(310, 305),
+                onCompleted(410)
+            ])),
+            onNext(750, $this->createColdObservable([
+                onCompleted(40)
+            ])),
+            onNext(850, $this->createColdObservable([
+                onNext(80, 401),
+                onNext(90, 402),
+                onCompleted(100)
+            ])),
+            onCompleted(900)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->concatMap(function (Observable $obs) {
+                return $obs;
+            });
+        });
+
+        $this->assertMessages(
+            [
+                onNext(310, 102),
+                onNext(390, 103),
+                onNext(410, 104),
+                onNext(490, 105),
+                onNext(740, 106),
+                onNext(940, 202),
+                onNext(950, 203),
+                onNext(975, 301)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 900)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Complete_OuterNotComplete()
+    {
+
+
+        $xs = $this->createHotObservable([
+            onNext(5, $this->createColdObservable([
+                onError(1, new Exception('ex1'))
+            ])),
+            onNext(105, $this->createColdObservable([
+                onError(1, new Exception('ex2'))
+            ])),
+            onNext(300, $this->createColdObservable([
+                onNext(10, 102),
+                onNext(90, 103),
+                onNext(110, 104),
+                onNext(190, 105),
+                onNext(440, 106),
+                onCompleted(460)
+            ])),
+            onNext(400, $this->createColdObservable([
+                onNext(180, 202),
+                onNext(190, 203),
+                onCompleted(205)
+            ])),
+            onNext(550, $this->createColdObservable([
+                onNext(10, 301),
+                onNext(50, 302),
+                onNext(70, 303),
+                onNext(260, 304),
+                onNext(310, 305),
+                onCompleted(410)
+            ])),
+            onNext(750, $this->createColdObservable([
+                onCompleted(40)
+            ])),
+            onNext(850, $this->createColdObservable([
+                onNext(80, 401),
+                onNext(90, 402),
+                onCompleted(100)
+            ]))
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->concatMap(function (Observable $obs) {
+                return $obs;
+            });
+        });
+
+        $this->assertMessages(
+            [
+                onNext(310, 102),
+                onNext(390, 103),
+                onNext(410, 104),
+                onNext(490, 105),
+                onNext(740, 106),
+                onNext(940, 202),
+                onNext(950, 203),
+                onNext(975, 301)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 1000)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Error_Outer()
+    {
+        $ex = new Exception();
+
+        $xs = $this->createHotObservable([
+            onNext(5, $this->createColdObservable([
+                onError(1, new Exception('ex1'))
+            ])),
+            onNext(105, $this->createColdObservable([
+                onError(1, new Exception('ex2'))
+            ])),
+            onNext(300, $this->createColdObservable([
+                onNext(10, 102),
+                onNext(90, 103),
+                onNext(110, 104),
+                onNext(190, 105),
+                onNext(440, 106),
+                onCompleted(460)
+            ])),
+            onNext(400, $this->createColdObservable([
+                onNext(180, 202),
+                onNext(190, 203),
+                onCompleted(205)
+            ])),
+            onNext(550, $this->createColdObservable([
+                onNext(10, 301),
+                onNext(50, 302),
+                onNext(70, 303),
+                onNext(260, 304),
+                onNext(310, 305),
+                onCompleted(410)
+            ])),
+            onNext(750, $this->createColdObservable([
+                onCompleted(40)
+            ])),
+            onNext(850, $this->createColdObservable([
+                onNext(80, 401),
+                onNext(90, 402),
+                onCompleted(100)
+            ])),
+            onError(900, $ex)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->concatMap(function (Observable $obs) {
+                return $obs;
+            });
+        });
+
+        $this->assertMessages(
+            [
+                onNext(310, 102),
+                onNext(390, 103),
+                onNext(410, 104),
+                onNext(490, 105),
+                onNext(740, 106),
+                onError(900, $ex)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 900)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Error_Inner()
+    {
+        $ex = new Exception();
+
+        $xs = $this->createHotObservable([
+            onNext(5, $this->createColdObservable([
+                onError(1, new Exception('ex1'))
+            ])),
+            onNext(105, $this->createColdObservable([
+                onError(1, new Exception('ex2'))
+            ])),
+            onNext(300, $this->createColdObservable([
+                onNext(10, 102),
+                onNext(90, 103),
+                onNext(110, 104),
+                onNext(190, 105),
+                onNext(440, 106),
+                onError(460, $ex)
+            ])),
+            onNext(400, $this->createColdObservable([
+                onNext(180, 202),
+                onNext(190, 203),
+                onCompleted(205)
+            ])),
+            onNext(550, $this->createColdObservable([
+                onNext(10, 301),
+                onNext(50, 302),
+                onNext(70, 303),
+                onNext(260, 304),
+                onNext(310, 305),
+                onCompleted(410)
+            ])),
+            onNext(750, $this->createColdObservable([
+                onCompleted(40)
+            ])),
+            onNext(850, $this->createColdObservable([
+                onNext(80, 401),
+                onNext(90, 402),
+                onCompleted(100)
+            ])),
+            onCompleted(900)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->concatMap(function (Observable $obs) {
+                return $obs;
+            });
+        });
+
+        $this->assertMessages(
+            [
+                onNext(310, 102),
+                onNext(390, 103),
+                onNext(410, 104),
+                onNext(490, 105),
+                onNext(740, 106),
+                onError(760, $ex)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 760)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Dispose()
+    {
+
+        $xs = $this->createHotObservable([
+            onNext(5, $this->createColdObservable([
+                onError(1, new Exception('ex1'))
+            ])),
+            onNext(105, $this->createColdObservable([
+                onError(1, new Exception('ex2'))
+            ])),
+            onNext(300, $this->createColdObservable([
+                onNext(10, 102),
+                onNext(90, 103),
+                onNext(110, 104),
+                onNext(190, 105),
+                onNext(440, 106),
+                onCompleted(460)
+            ])),
+            onNext(400, $this->createColdObservable([
+                onNext(180, 202),
+                onNext(190, 203),
+                onCompleted(205)
+            ])),
+            onNext(550, $this->createColdObservable([
+                onNext(10, 301),
+                onNext(50, 302),
+                onNext(70, 303),
+                onNext(260, 304),
+                onNext(310, 305),
+                onCompleted(410)
+            ])),
+            onNext(750, $this->createColdObservable([
+                onCompleted(40)
+            ])),
+            onNext(850, $this->createColdObservable([
+                onNext(80, 401),
+                onNext(90, 402),
+                onCompleted(100)
+            ])),
+            onCompleted(900)
+        ]);
+
+        $results = $this->scheduler->startWithDispose(function () use ($xs) {
+            return $xs->concatMap(function (Observable $obs) {
+                return $obs;
+            });
+        }, 700);
+
+        $this->assertMessages(
+            [
+                onNext(310, 102),
+                onNext(390, 103),
+                onNext(410, 104),
+                onNext(490, 105)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 700)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_Throw()
+    {
+        $invoked = 0;
+        $ex      = new Exception('ex');
+
+        $xs = $this->createHotObservable([
+            onNext(5, $this->createColdObservable([
+                onError(1, new Exception('ex1'))
+            ])),
+            onNext(105, $this->createColdObservable([
+                onError(1, new Exception('ex2'))
+            ])),
+            onNext(300, $this->createColdObservable([
+                onNext(10, 102),
+                onNext(90, 103),
+                onNext(110, 104),
+                onNext(190, 105),
+                onNext(440, 106),
+                onCompleted(460)
+            ])),
+            onNext(400, $this->createColdObservable([
+                onNext(180, 202),
+                onNext(190, 203),
+                onCompleted(205)
+            ])),
+            onNext(550, $this->createColdObservable([
+                onNext(10, 301),
+                onNext(50, 302),
+                onNext(70, 303),
+                onNext(260, 304),
+                onNext(310, 305),
+                onCompleted(410)
+            ])),
+            onNext(750, $this->createColdObservable([
+                onCompleted(40)
+            ])),
+            onNext(850, $this->createColdObservable([
+                onNext(80, 401),
+                onNext(90, 402),
+                onCompleted(100)
+            ])),
+            onCompleted(900)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs, &$invoked, $ex) {
+            return $xs->concatMap(function (Observable $obs) use (&$invoked, $ex) {
+                $invoked++;
+                if ($invoked === 3) {
+                    throw $ex;
+                }
+                return $obs;
+            });
+        });
+
+        $this->assertMessages(
+            [
+                onNext(310, 102),
+                onNext(390, 103),
+                onNext(410, 104),
+                onNext(490, 105),
+                onError(550, $ex)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 550)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function concatMap_UseFunction()
+    {
+        $xs = $this->createHotObservable([
+            onNext(210, 4),
+            onNext(220, 3),
+            onNext(250, 5),
+            onNext(270, 1),
+            onCompleted(290)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->concatMap(function ($x) {
+                return Observable::interval(10, $this->scheduler)
+                    ->map(function () use ($x) {
+                        return $x;
+                    })->take($x);
+            });
+        });
+
+        $this->assertMessages(
+            [
+                onNext(220, 4),
+                onNext(230, 4),
+                onNext(240, 4),
+                onNext(250, 4),
+                onNext(260, 3),
+                onNext(270, 3),
+                onNext(280, 3),
+                onNext(290, 5),
+                onNext(300, 5),
+                onNext(310, 5),
+                onNext(320, 5),
+                onNext(330, 5),
+                onNext(340, 1),
+                onCompleted(340)
+            ],
+            $results->getMessages()
+        );
+
+        $this->assertSubscriptions([
+            subscribe(200, 290)
+        ], $xs->getSubscriptions());
+    }
+}

--- a/test/Rx/Functional/Operator/ConcatTest.php
+++ b/test/Rx/Functional/Operator/ConcatTest.php
@@ -11,11 +11,11 @@ class ConcatTest extends FunctionalTestCase
 {
     public function testConcatEmptyEmpty()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(230)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(250)
         ]);
@@ -27,11 +27,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatEmptyNever()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(230)
         ]);
-        $e2 = Observable::never();
+        $e2      = Observable::never();
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
             return $e1->concat($e2);
         });
@@ -40,11 +40,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatNeverEmpty()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(230)
         ]);
-        $e2 = Observable::never();
+        $e2      = Observable::never();
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
             return $e2->concat($e1);
         });
@@ -53,8 +53,8 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatNeverNever()
     {
-        $e1 = Observable::never();
-        $e2 = Observable::never();
+        $e1      = Observable::never();
+        $e2      = Observable::never();
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
             return $e1->concat($e2);
         });
@@ -63,11 +63,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatEmptyThrow()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(230)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onError(250, new \Exception('error'))
         ]);
@@ -79,11 +79,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatThrowEmpty()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onError(230, new \Exception('error'))
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(250)
         ]);
@@ -95,11 +95,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatThrowThrow()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onError(230, new \ErrorException())
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onError(250, new \Exception())
         ]);
@@ -111,12 +111,12 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatReturnEmpty()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onNext(210, 2),
             onCompleted(230)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(250)
         ]);
@@ -128,11 +128,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatEmptyReturn()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onCompleted(230)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onNext(240, 2),
             onCompleted(250)
@@ -145,12 +145,12 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatReturnNever()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onNext(210, 2),
             onCompleted(230)
         ]);
-        $e2 = Observable::never();
+        $e2      = Observable::never();
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
             return $e1->concat($e2);
         });
@@ -159,12 +159,12 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatNeverReturn()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onNext(210, 2),
             onCompleted(230)
         ]);
-        $e2 = Observable::never();
+        $e2      = Observable::never();
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
             return $e2->concat($e1);
         });
@@ -173,12 +173,12 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatReturnReturn()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onNext(220, 2),
             onCompleted(230)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onNext(240, 3),
             onCompleted(250)
@@ -191,11 +191,11 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatThrowReturn()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onError(220, new \Exception())
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onNext(240, 3),
             onCompleted(250)
@@ -208,12 +208,12 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatReturnThrow()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onNext(220, 2),
             onCompleted(230)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onError(250, new \Exception())
         ]);
@@ -225,13 +225,13 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatSomeDataOnBothSides()
     {
-        $e1 = $this->createHotObservable([
+        $e1      = $this->createHotObservable([
             onNext(150, 1),
             onNext(210, 2),
             onNext(220, 3),
             onCompleted(225)
         ]);
-        $e2 = $this->createHotObservable([
+        $e2      = $this->createHotObservable([
             onNext(150, 1),
             onNext(230, 4),
             onNext(240, 5),
@@ -252,18 +252,18 @@ class ConcatTest extends FunctionalTestCase
 
     public function testConcatAsArguments()
     {
-        $xs1 = $this->createColdObservable([
+        $xs1     = $this->createColdObservable([
             onNext(10, 1),
             onNext(20, 2),
             onNext(30, 3),
             onCompleted(40)
         ]);
-        $xs2 = $this->createColdObservable([
+        $xs2     = $this->createColdObservable([
             onNext(10, 4),
             onNext(20, 5),
             onCompleted(30)
         ]);
-        $xs3 = $this->createColdObservable([
+        $xs3     = $this->createColdObservable([
             onNext(10, 6),
             onNext(20, 7),
             onNext(30, 8),
@@ -295,6 +295,69 @@ class ConcatTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(201, 241)], $xs1->getSubscriptions());
         $this->assertSubscriptions([subscribe(241, 271)], $xs2->getSubscriptions());
         $this->assertSubscriptions([subscribe(271, 321)], $xs3->getSubscriptions());
+
+    }
+
+
+    public function testConcatAll()
+    {
+
+        $sources = Observable::fromArray([
+            Observable::just(0),
+            Observable::just(1),
+            Observable::just(2),
+            Observable::just(3),
+        ]);
+
+        $res       = [];
+        $completed = false;
+
+        $sources->concatAll()->subscribeCallback(
+            function ($x) use (&$res) {
+                $res[] = $x;
+            },
+            function ($e) {
+                $this->fail();
+            },
+            function () use (&$completed) {
+                $completed = true;
+            }
+        );
+
+        $this->assertEquals([0, 1, 2, 3], $res);
+        $this->assertTrue($completed);
+    }
+
+
+    public function testConcatAllError()
+    {
+
+        $sources = Observable::fromArray([
+            Observable::just(0),
+            Observable::error(new \Exception()),
+            Observable::just(2),
+            Observable::just(3),
+        ]);
+
+        $res       = [];
+        $error     = false;
+        $completed = false;
+
+        $sources->concatAll()->subscribeCallback(
+            function ($x) use (&$res) {
+                $res[] = $x;
+            },
+            function ($e) use (&$res, &$error) {
+                $this->assertEquals([0], $res);
+                $error = true;
+            },
+            function () use (&$completed) {
+                $completed = true;
+            }
+        );
+
+        $this->assertTrue($error);
+        $this->assertFalse($completed);
 
     }
 }


### PR DESCRIPTION
There are a couple of differences between the way `concatMap` is implemented in RxPHP and RxJS:
1. The operator is split into `concatMap`, which takes a selector and resultSelector, and `concatMapTo`, which takes an observable and a resultSelector.
2. You can only return an Observable from the selector.  I think it's confusing to have multiple return types and an Observable covers all use cases.
