### PR TITLE
Add utility to generate documentation for reactivex.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ phpunit.xml
 composer.lock
 composer.phar
 /vendor/
+docs/reactivex.github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ before_script: composer install
 script:
   - phpunit
   - php demo/test.php
+  - php docs/build-docs.php lint

--- a/docs/build-docs.php
+++ b/docs/build-docs.php
@@ -1,0 +1,95 @@
+<?php
+
+if (file_exists($file = __DIR__.'/../vendor/autoload.php')) {
+    $autoload = require_once $file;
+} else {
+    throw new RuntimeException('Install dependencies to run doc builder.');
+}
+
+require_once __DIR__ . '/doc-loader.php';
+require_once __DIR__ . '/doc-writer.php';
+require_once __DIR__ . '/utils.php';
+
+function println($line) {
+    $args = func_get_args();
+    echo call_user_func_array('sprintf', $args) . "\n";
+}
+
+function run_lint() {
+    $docs = load_all_docs();
+    println("Successfully loaded documentation for %d observables/operators\n",
+        count($docs)
+    );
+
+    foreach ($docs as $doc) {
+        println(
+            "- %s with %d demo(s) as %s",
+            $doc->methodName,
+            count($doc->demos),
+            $doc->isObservable ? 'observabe' : 'operator'
+        );
+    }
+
+    exit(0);
+}
+
+function run_reactivex() {
+    $docs = load_all_docs();
+
+    $repoRoot = __DIR__ . '/reactivex.github.io';
+    $docsPath = $repoRoot . '/documentation/operators/';
+    if (!is_dir($docsPath)) {
+        println("Expecting a valid reactivex.io checkout at @ $docsPath");
+        exit(1);
+    }
+
+    // Change to reactivex doc repository
+    chdir($repoRoot);
+    if (!is_clean_git_checkout(getcwd())) {
+        println("ReactiveX docs checkout should be clean at:");
+        println("  " . $repoRoot);
+        exit(1);
+    }
+
+    $reactivexDocs = load_all_reactivex_docs($docsPath);
+
+    $grouped_docs = group_by(
+        $docs,
+        function($item) { return $item->reactivexId; }
+    );
+
+    $diff = array_diff(array_keys($grouped_docs), array_keys($reactivexDocs));
+    if (count($diff) != 0) {
+        println("ReactiveX id(s) '%s' not found", implode(', ', $diff));
+        exit(1);
+    }
+
+    foreach ($grouped_docs as $id => $docs) {
+        update_documentation($reactivexDocs[$id], $docs);
+    }
+    exit(0);
+}
+
+function run_usage() {
+    println("Usage: $argv[0] <command>");
+    println("  lint      Verifies that documentation can be loaded");
+    println("  reactivex Updates the reactivex documentation");
+    exit(1);
+}
+
+function main($argv) {
+    if (count($argv) !== 2) {
+        run_usage();
+    }
+
+    switch ($argv[1]) {
+        case 'lint':
+            run_lint();
+        case 'reactivex':
+            run_reactivex();
+        default:
+            println("Unknown command $argv[1]");
+            run_usage();
+    }
+}
+main($argv);

--- a/docs/doc-loader.php
+++ b/docs/doc-loader.php
@@ -1,0 +1,144 @@
+<?php
+
+class DocumentedMethod
+{
+    public $methodName;
+    public $reactivexId;
+    public $description;
+    public $demos;
+    public $isObservable;
+
+    private function __construct(
+        $methodName,
+        $reactivexId,
+        $description,
+        $demos,
+        $isObservable
+    ) {
+        $this->methodName = $methodName;
+        $this->reactivexId = $reactivexId;
+        $this->description = $description;
+        $this->demos = $demos;
+        $this->isObservable = $isObservable;
+    }
+
+    public static function fromReflectionMethod(
+        \ReflectionMethod $method
+    ) {
+        $methodName = $method->getName();
+        $docComment = $method->getDocComment();
+
+        $reactivexId = extract_doc_annotation($docComment, '@reactivex');
+        $demoFiles = extract_doc_annotations($docComment, '@demo');
+
+        $description = extract_doc_description($docComment);
+
+        $isObservable = Str::contains($docComment, '@observable');
+
+        $demos = array_map(
+            function($path) { return Demo::fromPath($path); },
+            $demoFiles
+        );
+
+        return new DocumentedMethod(
+            $methodName,
+            $reactivexId,
+            $description,
+            $demos,
+            $isObservable
+        );
+    }
+}
+
+class Demo
+{
+    const BASE_DEMO_URL = 'https://github.com/ReactiveX/RxPHP/blob/master/demo';
+    public $demoCode;
+    public $demoOutput;
+    public $path;
+
+    private function __construct($path, $demoCode, $demoOutput) {
+        $this->path = $path;
+        $this->demoCode = $demoCode;
+        $this->demoOutput = $demoOutput;
+    }
+
+    public function getURL() {
+        return self::BASE_DEMO_URL . '/' . $this->path;
+    }
+
+    public static function fromPath($path) {
+        $codePath = __DIR__ . '/../demo/' . $path;
+        $outputPath = __DIR__ . '/../demo/' . $path . '.expect';
+
+        assert(file_exists($codePath), "code does not exist $codePath");
+        assert(file_exists($outputPath), "output does not exist $outputPath");
+
+        return new Demo(
+            $path,
+            file_get_contents($codePath),
+            trim(file_get_contents($outputPath))
+        );
+    }
+}
+
+function extract_doc_annotation($comment, $annotation) {
+    $values = extract_doc_annotations($comment, $annotation);
+    assert(count($values) === 1, "Expected only one value for $annotation");
+    return $values[0];
+}
+
+function extract_doc_annotations($comment, $annotation) {
+    $values = [];
+    foreach(explode("\n", $comment) as $line) {
+        if (!Str::startsWith(trim($line), '* ' . $annotation)) {
+            continue;
+        }
+
+        $value = Str::substringAfter($line, $annotation);
+        if ($value !== '') {
+            $values[] = trim($value);
+        }
+    }
+    return $values;
+}
+
+function extract_doc_description($docComment) {
+    $rawDescription = Str::substringUntil(
+        Str::substringUntil($docComment, '@return'),
+        '@param'
+    );
+
+    $lines = explode("\n", $rawDescription);
+    array_shift($lines); // drop /*
+
+    $cleaned = array_map(
+        function($line) { return trim(str_replace('*', '', $line)); },
+        $lines
+    );
+
+    return trim(implode(' ', $cleaned));
+}
+
+function has_documentation_tag(\ReflectionMethod $method) {
+    return Str::contains($method->getDocComment(), '@operator')
+        || Str::contains($method->getDocComment(), '@observable');
+}
+
+function load_all_docs() {
+    $observable = new \ReflectionClass('Rx\Observable');
+
+    $possibleMethods = $observable
+        ->getMethods(ReflectionMethod::IS_STATIC|ReflectionMethod::IS_PUBLIC);
+
+    $taggedMethods = array_filter($possibleMethods, 'has_documentation_tag');
+
+    $documentedMethods = [];
+    foreach ($taggedMethods as $taggedMethod) {
+        $documentedMethods[] = DocumentedMethod::fromReflectionMethod(
+            $taggedMethod
+        );
+    }
+
+    return $documentedMethods;
+}

--- a/docs/doc-writer.php
+++ b/docs/doc-writer.php
@@ -1,0 +1,154 @@
+<?php
+
+function load_all_reactivex_docs($docsPath) {
+    $documentationFiles = glob($docsPath . '/*.html');
+    $docsPerId = [];
+    foreach ($documentationFiles as $file) {
+        $contents = file_get_contents($file);
+        $lines = explode("\n", $contents);
+        $id = Str::substringAfter($lines[3], 'id:');
+        $docsPerId[$id] = $file;
+    }
+    return $docsPerId;
+}
+
+function update_documentation($path, $docs) {
+    $htmlDocs = build_documentation($docs);
+    $currentDocumentation = file_get_contents($path);
+    $currentLines = explode("\n", $currentDocumentation);
+
+    $newLines = explode("\n", $htmlDocs);
+
+    if (!Str::contains($currentDocumentation, 'RxPHP')) {
+        $insertPosition = get_insert_position($currentLines);
+        $newLines[] = ""; // extra new line at the end
+        array_splice($currentLines, $insertPosition, 0, $newLines);
+    } else {
+        list($position, $length) = get_replace_position($currentLines);
+        array_splice($currentLines, $position, $length);
+        array_splice($currentLines, $position, 0, $newLines);
+    }
+
+    file_put_contents($path, implode("\n", $currentLines));
+}
+
+function get_insert_position($lines) {
+    $docPositions = array_filter(
+        $lines,
+        function($line) { return Str::contains($line, '{% lang_operator'); }
+    );
+
+    $documentedLibraries = array_map(
+        function($line) {
+            return Str::firstWord(Str::substringAfter($line, 'lang_operator'));
+        },
+        $docPositions
+    );
+
+    foreach ($documentedLibraries as $position => $library) {
+        if (strcmp($library, 'RxPHP') <= 0) {
+            continue;
+        }
+        return $position;
+    }
+
+    return count($lines) - 2; // at the end of the file by default
+}
+
+function get_replace_position($lines) {
+    $start = -1;
+    foreach ($lines as $position => $line) {
+        if (Str::contains($line, '{% lang_operator RxPHP')) {
+            $start = $position;
+            continue;
+        }
+        if ($start != -1 && Str::contains($line, '{% endlang_operator')) {
+            $end = $position;
+            break;
+        }
+    }
+    return array($start, $end - $start + 1);
+}
+
+function build_documentation($docs) {
+    usort(
+        $docs,
+        function($a, $b) { return strcmp($a->methodName, $b->methodName); }
+    );
+    $names = array_map(
+        function($doc) { return $doc->methodName; },
+        $docs
+    );
+
+    $langOperatorNames = implode(' ', $names);
+
+    $htmlDocs = '';
+    for ($i = 0; $i < count($docs); $i++) {
+        $htmlDocs .= build_variant_documentation($i, $docs[$i]);
+    }
+
+    $docs = <<<DOCUMENTATION
+  {% lang_operator RxPHP $langOperatorNames %}
+$htmlDocs
+  {% endlang_operator %}
+DOCUMENTATION;
+    return $docs;
+}
+
+function build_variant_documentation($index, $doc) {
+    $introduction = build_documentation_introduction($index, $doc);
+
+    $demos = array_map('build_code_samples', $doc->demos);
+
+    $sampleCode = '';
+    if (count($demos) > 0) {
+        $sampleCode = '<h4>Sample Code</h4>'."\n";
+        $sampleCode .= implode("\n\n", $demos);
+    }
+    return <<<DOCUMENTATION
+<figure class="variant">
+    <figcaption>
+    <p>
+    $introduction
+    </p>
+$sampleCode
+    </figcaption>
+</figure>
+DOCUMENTATION;
+}
+
+function build_documentation_introduction($index, $doc) {
+    $template = $index === 0
+        ? 'RxPHP implements this operator as <code>%s</code>. %s'
+        : 'RxPHP also has an operator <code>%s</code>. %s';
+    return sprintf($template, $doc->methodName, $doc->description);
+}
+
+function build_code_samples(Demo $demo) {
+    $lines = explode("\n", $demo->demoCode);
+    $start = -1;
+    foreach ($lines as $position => $line) {
+        if (Str::contains($line, 'require_once')) {
+            $start = $position;
+            break;
+        }
+    }
+    array_splice($lines, 0, $start + 2);
+    $demoCode = implode("\n", $lines);
+    $url = $demo->getURL();
+
+    return <<<DEMO
+<div class="code php">
+    <pre>
+// from $url
+
+$demoCode
+   </pre>
+</div>
+<div class="output">
+    <pre>
+$demo->demoOutput
+    </pre>
+</div>
+DEMO;
+}

--- a/docs/utils.php
+++ b/docs/utils.php
@@ -1,0 +1,66 @@
+<?php
+
+abstract class Str {
+    public static function contains($haystack, $needle) {
+        return false !== strpos($haystack, $needle);
+    }
+
+    public static function containsAny($haystack, $needles) {
+        foreach ($needles as $needle) {
+            if (Str::contains($haystack, $needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static function firstWord($haystack) {
+        $words = explode(' ', $haystack);
+        return $words[0];
+    }
+
+    public static function startsWith($haystack, $needle) {
+        return 0 === strpos($haystack, $needle);
+    }
+
+    public static function substringAfter($haystack, $needle) {
+        $pos = strpos($haystack, $needle);
+        if (false === $pos) {
+            return $haystack;
+        }
+        return trim(substr($haystack, $pos + strlen($needle)));
+    }
+
+    public static function substringUntil($haystack, $needle) {
+        $pos = strpos($haystack, $needle);
+        if (false === $pos) {
+            return $haystack;
+        }
+        return trim(substr($haystack, 0, $pos));
+    }
+}
+
+function group_by($collection, callable $groupSelector) {
+    $grouped = [];
+    foreach ($collection as $item) {
+        $group = $groupSelector($item);
+        if (!isset($grouped[$group])) {
+            $grouped[$group] = [];
+        }
+        $grouped[$group][] = $item;
+    }
+    return $grouped;
+}
+
+function is_clean_git_checkout($path) {
+    list($exitCode, $output) = run_cmd("git status --porcelain $path");
+    return $exitCode === 0
+        && count($output) === 0;
+}
+
+function run_cmd($cmd) {
+    $output = [];
+    $exitCode = 0;
+    exec($cmd, $output, $exitCode);
+    return array($exitCode, $output);
+}


### PR DESCRIPTION
In order to provide up-to-date documentation on reactivex.io we'll
extract the operator documentation directly from the source code. Most
operators already have demo code including expected output in the demo
directory.

In order for an operator to get added to the documentation the docblock
of the method in `Rx\Observable` needs a few additions:
- `@observable` or `@operator` annotation. This will flag the method for
  extraction by the documentation builder.
- `@reactivex` the id of the operator in the reactivex.io repository
- `@demo` (optional) one or multiple annotations containing the path to
  a demo inside the demo directory

For example the `map()` operation:

```
/**
 * It takes a transforming function that operates on each element.
 *
 * @param callable $selector
 * @return AnonymousObservable
 *
 * @demo map/map.php
 * @operator
 * @reactivex map
 */
public function map(callable $selector) { {
    ...
}
```

Usage:

```
$ php docs/build-docs.php
Usage:  <command>
  lint      Verifies that documentation can be loaded
  reactivex Updates the reactivex documentation
```

Note: the command currently assumes a valid checkout of the reactivex
site repository under `docs/reactivex.github.io`.
