### PR TITLE
Update `map()` documentation

### DIFF
--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -230,8 +230,14 @@ class Observable implements ObservableInterface
     }
 
     /**
+     * It takes a transforming function that operates on each element.
+     *
      * @param callable $selector
      * @return AnonymousObservable
+     *
+     * @demo map/map.php
+     * @operator
+     * @reactivex map
      */
     public function map(callable $selector)
     {


### PR DESCRIPTION
Update the `map()` documentatation to include the relevant annotations
to be included by the documentation builder and add a short description.
