### PR TITLE
For Rx\React\Promise::toObservable, wrap non-exceptions on reject.

### DIFF
--- a/lib/Rx/React/Promise.php
+++ b/lib/Rx/React/Promise.php
@@ -76,7 +76,10 @@ final class Promise
                         $subject->onNext($value);
                         $subject->onCompleted();
                     },
-                    [$subject, "onError"]
+                    function ($error) use ($subject) {
+                        $error = $error instanceof \Exception ? $error : new RejectedPromiseException($error);
+                        $subject->onError($error);
+                    }
                 );
 
                 return $subject;

--- a/lib/Rx/React/RejectedPromiseException.php
+++ b/lib/Rx/React/RejectedPromiseException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rx\React;
+
+class RejectedPromiseException extends \Exception
+{
+    private $rejectValue;
+
+    /**
+     * RejectedPromiseException constructor.
+     */
+    public function __construct($rejectValue)
+    {
+        $this->rejectValue = $rejectValue;
+
+        parent::__construct("Promise rejected with non-exception");
+    }
+
+    /**
+     * @return string
+     */
+    public function getRejectValue()
+    {
+        return $this->rejectValue;
+    }
+}


### PR DESCRIPTION
Fixes #33
