### PR TITLE
Update schedulers to return ms on `now`

### DIFF
--- a/lib/Rx/Scheduler/EventLoopScheduler.php
+++ b/lib/Rx/Scheduler/EventLoopScheduler.php
@@ -97,13 +97,13 @@ class EventLoopScheduler implements SchedulerInterface
     }
 
     /**
-     * @inheritDoc
+     * Returns milliseconds since the start of the epoch.
      */
     public function now()
     {
         if (function_exists('microtime')) {
-            return microtime(true);
+            return $milliseconds = floor(microtime(true) * 1000);
         }
-        return time();
+        return time() * 1000;
     }
 }

--- a/lib/Rx/Scheduler/ImmediateScheduler.php
+++ b/lib/Rx/Scheduler/ImmediateScheduler.php
@@ -55,13 +55,13 @@ class ImmediateScheduler implements SchedulerInterface
     }
 
     /**
-     * @inheritDoc
+     * Returns milliseconds since the start of the epoch.
      */
     public function now()
     {
         if (function_exists('microtime')) {
-            return microtime(true);
+            return $milliseconds = floor(microtime(true) * 1000);
         }
-        return time();
+        return time() * 1000;
     }
 }

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -11,12 +11,12 @@ class EventLoopSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function now_returns_the_time()
+    public function now_returns_time_since_epoch_in_ms()
     {
         $loop      = Factory::create();
         $scheduler = new EventLoopScheduler($loop);
 
-        $this->assertTrue(abs(time() - $scheduler->now()) < 1, "time difference is less than or equal to 1");
+        $this->assertTrue(abs(time() * 1000 - $scheduler->now()) < 1000, "time difference is less than or equal to 1");
     }
 
     /**

--- a/test/Rx/Scheduler/ImmediateSchedulerTest.php
+++ b/test/Rx/Scheduler/ImmediateSchedulerTest.php
@@ -14,6 +14,6 @@ class ImmediateSchedulerTest extends TestCase
     public function now_returns_the_time() {
         $scheduler = new ImmediateScheduler();
 
-        $this->assertTrue(abs(time() - $scheduler->now()) < 1, "time difference is less than or equal to 1");
+        $this->assertTrue(abs(time() * 1000 - $scheduler->now()) < 1000, "time difference is less than or equal to 1");
     }
 }


### PR DESCRIPTION
This PR changes the `now` method on the `ImmediateScheduler` and the `EventLoopScheduler` to return milliseconds since 1970. This change brings these schedulers into line with [RxJS](https://github.com/Reactive-Extensions/RxJS/blob/9d6ea94244c2f40a29373f9ed6b12d951d3f2238/src/core/headers/coreheader.js#L4) and also [RxJava](https://github.com/ReactiveX/RxJava/blob/1.x/src/main/java/rx/Scheduler.java#L181)

This change is necessary in order for the `timestamp` operator to work and also is part of reworking the way that the `delay` operator works (to use `materialize`/`timestamp`/`dematerialize`).
