### PR TITLE
Combinelatest operator argument order issue

### DIFF
--- a/lib/Rx/Operator/CombineLatestOperator.php
+++ b/lib/Rx/Operator/CombineLatestOperator.php
@@ -47,7 +47,7 @@ class CombineLatestOperator implements OperatorInterface
         $observables         = &$this->observables;
         $compositeDisposable = new CompositeDisposable();
         $hasValue            = [];
-        $values              = [];
+        $values              = array_keys($observables);
         $count               = count($observables);
         $waitingToComplete   = $count;
         $waitingForValues    = $count;

--- a/test/Rx/Functional/Operator/CombineLatestTest.php
+++ b/test/Rx/Functional/Operator/CombineLatestTest.php
@@ -927,4 +927,47 @@ class CombineLatestTest extends FunctionalTestCase
         $this->assertEquals([0, 0, 0], $result);
         $this->assertTrue($completed);
     }
+
+    /**
+     * @test
+     */
+    public function combineLatest_args_order()
+    {
+
+        $e1 = $this->createHotObservable(
+            [
+                onNext(150, 1),
+                onNext(600, 2),
+                onCompleted(650)
+            ]
+        );
+
+        $e2 = $this->createHotObservable(
+            [
+                onNext(150, 1),
+                onNext(220, 1),
+                onCompleted(250)
+            ]
+        );
+
+        $e3 = $this->createHotObservable(
+            [
+                onNext(150, 1),
+                onNext(700, 3),
+                onCompleted(750)
+            ]
+        );
+
+        $results = $this->scheduler->startWithCreate(function () use ($e1, $e2, $e3) {
+            return $e1->combineLatest([$e2, $e3]);
+        });
+
+        $this->assertMessages(
+            [
+                onNext(700, [2, 1, 3]),
+                onCompleted(750)
+            ],
+            $results->getMessages()
+        );
+    }
 }


### PR DESCRIPTION
Fixed an issue with combineLatest where when passing values to `call_user_func_array` the arguments are out of order.  

The fix is to pre create the values array with all keys, so everything stays in the correct order when passed to `call_user_func_array`
