### PR TITLE
Fix double subscription issue with `concatAll`

### DIFF
--- a/lib/Rx/Operator/ConcatAllOperator.php
+++ b/lib/Rx/Operator/ConcatAllOperator.php
@@ -58,8 +58,6 @@ class ConcatAllOperator implements OperatorInterface
                         return;
                     }
 
-                    $this->startBuffering = true;
-
                     $onCompleted = function () use (&$subscribeToInner, $observer) {
 
                         $this->disposable->remove($this->innerDisposable);
@@ -69,14 +67,14 @@ class ConcatAllOperator implements OperatorInterface
 
                         $obs = array_shift($this->buffer);
 
+                        if (empty($this->buffer)) {
+                            $this->startBuffering = false;
+                        }
+
                         if ($obs) {
                             $subscribeToInner($obs);
                         } elseif ($this->sourceCompleted === true) {
                             $observer->onCompleted();
-                        }
-
-                        if (empty($this->buffer)) {
-                            $this->startBuffering = false;
                         }
                     };
 
@@ -88,6 +86,7 @@ class ConcatAllOperator implements OperatorInterface
                         );
 
                         $this->innerCompleted = false;
+                        $this->startBuffering = true;
 
                         $this->innerDisposable = $observable->subscribe($callbackObserver, $scheduler);
                         $this->disposable->add($this->innerDisposable);

--- a/test/Rx/Functional/Operator/ConcatAllTest.php
+++ b/test/Rx/Functional/Operator/ConcatAllTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use Rx\Functional\FunctionalTestCase;
+use Rx\Observable;
+
+class ConcatAllTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function concatAll_timer_missing_item()
+    {
+        $xs = $this->createHotObservable([
+            onNext(201, 0),
+            onNext(206, 1),
+            onNext(211, 2),
+            onCompleted(212)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->map(function ($x) {
+                return Observable::timer(5)->mapTo($x);
+            })->concatAll();
+        });
+
+        $this->assertMessages([
+            onNext(206, 0),
+            onNext(211, 1),
+            onNext(216, 2),
+            onCompleted(216)
+        ], $results->getMessages());
+    }
+}


### PR DESCRIPTION
ConcatAll had an issue if it received an onCompleted in the same tick as onNext. It would not start buffering new items on the source observable even though it was subscribed to an inner observable.
