### PR TITLE
New EventLoopScheduler and adjustments

### DIFF
--- a/demo/delay/delay.php
+++ b/demo/delay/delay.php
@@ -9,7 +9,7 @@ $scheduler  = new \Rx\Scheduler\EventLoopScheduler($loop);
     ->doOnNext(function ($x) {
         echo "Side effect: " . $x . "\n";
     })
-    ->delay(1000)
+    ->delay(500)
     ->take(5)
     ->subscribe($createStdoutObserver(), $scheduler);
 

--- a/demo/flatMap/flatMap.php.expect
+++ b/demo/flatMap/flatMap.php.expect
@@ -4,13 +4,13 @@ Next value: 2
 Next value: 1
 Next value: 2
 Next value: 1
-Next value: 2
 Next value: 3
+Next value: 2
 Next value: 1
+Next value: 3
 Next value: 2
-Next value: 3
-Next value: 3
 Next value: 4
+Next value: 3
 Next value: 4
 Next value: 5
 Complete!

--- a/demo/take/takeUntil.php
+++ b/demo/take/takeUntil.php
@@ -12,7 +12,7 @@ $timeout = \Rx\Observable::create(function (\Rx\ObserverInterface $o) use ($loop
 });
 
 $scheduler  = new \Rx\Scheduler\EventLoopScheduler($loop);
-$source = \Rx\Observable::interval(100, $scheduler)->takeUntil($timeout);
+$source = \Rx\Observable::interval(105, $scheduler)->takeUntil($timeout);
 
 $subscription = $source->subscribe($stdoutObserver);
 

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -201,9 +201,11 @@ class Observable implements ObservableInterface
      */
     public function merge(ObservableInterface $otherObservable)
     {
-        return self::mergeAll(
-            self::fromArray([$this, $otherObservable])
-        );
+        return self::mergeAll(new AnonymousObservable(function (ObserverInterface $observer, SchedulerInterface $schedule) use ($otherObservable) {
+            $observer->onNext($this);
+            $observer->onNext($otherObservable);
+            $observer->onCompleted();
+        }));
     }
 
     /**

--- a/lib/Rx/Scheduler/EventLoopScheduler.php
+++ b/lib/Rx/Scheduler/EventLoopScheduler.php
@@ -3,106 +3,60 @@
 namespace Rx\Scheduler;
 
 use React\EventLoop\LoopInterface;
-use Rx\Disposable\CallbackDisposable;
-use Rx\Disposable\CompositeDisposable;
-use Rx\SchedulerInterface;
 
-class EventLoopScheduler implements SchedulerInterface
+final class EventLoopScheduler extends VirtualTimeScheduler
 {
-    private $loop;
+    /** @var callable */
+    private $timerCallable;
 
-    public function __construct(LoopInterface $loop)
-    {
-        $this->loop = $loop;
-    }
+    private $nextTimer = PHP_INT_MAX;
 
     /**
-     * @param callable $action
-     * @param $delay
-     * @return CallbackDisposable
+     * NewEventLoopScheduler constructor.
+     * @param callable|LoopInterface $timerCallableOrLoop
      */
-    public function schedule(callable $action, $delay = 0)
+    public function __construct($timerCallableOrLoop)
     {
-        $delay = $delay / 1000; // switch from ms to seconds for react
-        $timer = $this->loop->addTimer($delay, $action);
+        // passing a loop directly into the scheduler will be deprecated in the next major release
+        $this->timerCallable = $timerCallableOrLoop instanceof LoopInterface ?
+            function ($ms, $callable) use ($timerCallableOrLoop) {
+                $timerCallableOrLoop->addTimer($ms / 1000, $callable);
+            } :
+            $timerCallableOrLoop;
 
-        return new CallbackDisposable(function () use ($timer) {
-            $timer->cancel();
+        parent::__construct($this->now(), function ($a, $b) {
+            return $a - $b;
         });
+
+        call_user_func($this->timerCallable, 0, [$this, 'start']);
     }
 
-    public function scheduleRecursive(callable $action)
+    public function start()
     {
-        $group = new CompositeDisposable();
+        $this->clock = $this->now();
 
-        $recursiveAction = null;
+        while ($this->queue->count() > 0) {
+            if ($this->queue->peek()->getDueTime() > $this->clock) {
+                $this->nextTimer = $this->queue->peek()->getDueTime();
+                $timerCallable = $this->timerCallable;
+                $timerCallable($this->nextTimer - $this->clock, [$this, "start"]);
+                break;
+            }
 
-        $recursiveAction = function () use ($action, &$group, &$recursiveAction) {
-            $action(
-                function () use (&$group, &$recursiveAction) {
-                    $isAdded = false;
-                    $isDone  = false;
-
-                    $d = null;
-                    $d = $this->schedule(function () use (&$isAdded, &$isDone, &$group, &$recursiveAction, &$d) {
-                        if (is_callable($recursiveAction)) {
-                            $recursiveAction();
-                        } else {
-                            throw new \Exception("recursiveAction is not callable");
-                        }
-
-                        if ($isAdded) {
-                            $group->remove($d);
-                        } else {
-                            $isDone = true;
-                        }
-                    });
-
-                    if (!$isDone) {
-                        $group->add($d);
-                        $isAdded = true;
-                    }
-                }
-            );
-        };
-
-        $group->add($this->schedule($recursiveAction));
-
-        return $group;
+            $next = $this->getNext();
+            if ($next !== null) {
+                $next->inVoke();
+            }
+        }
     }
 
     /**
      * @inheritDoc
      */
-    public function schedulePeriodic(callable $action, $delay, $period)
-    {
-        $delay = $delay / 1000;
-        $period = $period / 1000;
-
-        $disposed = false;
-
-        $timer = $this->loop->addTimer($delay, function () use ($action, $period, &$timer, &$disposed) {
-            $action();
-            if (!$disposed) {
-                $timer = $this->loop->addPeriodicTimer($period, function () use ($action) {
-                    $action();
-                });
-            }
-        });
-
-        return new CallbackDisposable(function () use (&$timer, &$disposed) {
-            $disposed = true;
-            $timer->cancel();
-        });
-    }
-
-    /**
-     * Returns milliseconds since the start of the epoch.
-     */
     public function now()
     {
         if (function_exists('microtime')) {
-            return $milliseconds = floor(microtime(true) * 1000);
+            return (int)floor(microtime(true) * 1000);
         }
         return time() * 1000;
     }

--- a/test/Rx/Functional/Operator/MergeTest.php
+++ b/test/Rx/Functional/Operator/MergeTest.php
@@ -33,18 +33,18 @@ class MergeTest extends FunctionalTestCase
         });
 
         $this->assertMessages(array(
-            onNext(252, 'foo'),
-            onNext(301, 4),
-            onNext(302, 'bar'),
-            onNext(352, 'baz'),
-            onNext(401, 2),
-            onNext(402, 'qux'),
-            onNext(501, 3),
-            onNext(601, 1),
-            onCompleted(701)
+            onNext(250, 'foo'),
+            onNext(300, 4),
+            onNext(300, 'bar'),
+            onNext(350, 'baz'),
+            onNext(400, 2),
+            onNext(400, 'qux'),
+            onNext(500, 3),
+            onNext(600, 1),
+            onCompleted(700)
         ), $results->getMessages());
 
-        $this->assertSubscriptions(array(subscribe(201, 701)), $xs->getSubscriptions());
-        $this->assertSubscriptions(array(subscribe(202, 452)), $ys->getSubscriptions());
+        $this->assertSubscriptions(array(subscribe(200, 700)), $xs->getSubscriptions());
+        $this->assertSubscriptions(array(subscribe(200, 450)), $ys->getSubscriptions());
     }
 }

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -56,12 +56,14 @@ class EventLoopSchedulerTest extends TestCase
         $actionCalled = false;
         $count        = 0;
 
-        $action = function ($reschedule) use (&$actionCalled, &$count) {
+        $action = function ($reschedule) use (&$actionCalled, &$count, $loop) {
             $actionCalled = true;
             $count++;
             if ($count < 5) {
                 $reschedule();
+                return;
             }
+            $loop->stop();
         };
 
         $disposable = $scheduler->scheduleRecursive($action);
@@ -70,24 +72,9 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertFalse($actionCalled);
         $this->assertEquals(0, $count);
 
-        $loop->tick();
-        $this->assertEquals(1, $count);
-
-        $loop->tick();
-        $this->assertEquals(2, $count);
-
-        $loop->tick();
-        $this->assertEquals(3, $count);
-
-        $loop->tick();
-        $this->assertEquals(4, $count);
-
-        $loop->tick();
+        $loop->run();
+        
         $this->assertEquals(5, $count);
-
-        $loop->tick();
         $this->assertTrue($actionCalled);
-        $this->assertEquals(5, $count);
-
     }
 }


### PR DESCRIPTION
This is a new `EventLoopScheduler` that aims to have this Scheduler perform as closely to the `TestScheduler` as possible. This allows the tests to more accurately cover the Scheduler that is most likely to be used in production.

This new `EventLoopScheduler` is also designed to be decoupled from the underlying event loop implementation. The single constructor argument is now a callable that takes 2 arguments: milliseconds in the future to schedule, and callable to schedule. An example:

``` php
// for amphp event loop
$scheduler = new \Rx\Scheduler\EventLoopScheduler(function ($milliseconds, $callable) {
    Amp\once($callable, $milliseconds);
});
```

The `EventLoopScheduler` will still allow you to pass an instance of `React\EventLoop\LoopInterface` to the constructor to maintain backwards compatibility. This behavior is deprecated, however, and will be removed in the 2.x.x releases.

There are also adjustments to some of the demos as scheduling order was corrected to match the TestScheduler.

`Observable::merge` was also changed to subscribe immediately to both the source observable and the observable that is passed in instead of scheduling the subscriptions through `fromArray`. This maintains consistency with other Rx libraries and also allows `merge` to function in a more intuitive way.

This PR unblocks #22 
This PR supersedes #37 
This PR fixes #36 
