### PR TITLE
Remove skipped `retryWhen` test make `retryWhen` correction

### DIFF
--- a/lib/Rx/Operator/RetryWhenOperator.php
+++ b/lib/Rx/Operator/RetryWhenOperator.php
@@ -90,8 +90,11 @@ class RetryWhenOperator implements OperatorInterface
                 }
             },
             [$observer, 'onError'],
-            function () use (&$innerCompleted) {
+            function () use (&$innerCompleted, &$sourceError, $observer) {
                 $innerCompleted = true;
+                if ($sourceError) {
+                    $observer->onCompleted();
+                }
             }
         ), $scheduler);
 

--- a/test/Rx/Functional/Operator/RetryWhenTest.php
+++ b/test/Rx/Functional/Operator/RetryWhenTest.php
@@ -204,8 +204,6 @@ class RetryWhenTest extends FunctionalTestCase
      */
     public function retryWhen_Observable_next_complete()
     {
-        $this->markTestSkipped("skip until takeWhile is implemented");
-
         $error = new \Exception();
 
         $xs = $this->createColdObservable([


### PR DESCRIPTION
Removed a skipped test in `retryWhen`. Made correction to behavior of `retryWhen` when the source errors and the notification observable completes. From https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/retrywhen.md: "If the source observable errors and the notifier completes, it will complete the source sequence."
