### PR TITLE
Added 'pluck' operator

### DIFF
--- a/demo/pluck/pluck.php
+++ b/demo/pluck/pluck.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$source = Rx\Observable::fromArray([
+    (object)['value' => 0],
+    (object)['value' => 1],
+    (object)['value' => 2]
+])
+    ->pluck('value');
+
+$subscription = $source->subscribeCallback(
+    function ($x) {
+        echo 'Next: ' . $x . PHP_EOL;
+    },
+    function ($err) {
+        echo 'Error: ' . $err . PHP_EOL;
+    },
+    function () {
+        echo 'Completed' . PHP_EOL;
+    }
+);
+
+// => Next: 0
+// => Next: 1
+// => Next: 2
+// => Completed

--- a/demo/pluck/pluck.php.expect
+++ b/demo/pluck/pluck.php.expect
@@ -1,0 +1,4 @@
+Next: 0
+Next: 1
+Next: 2
+Completed

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -1693,4 +1693,29 @@ class Observable implements ObservableInterface
                 return $total / $count;
             }, 0);
     }
+
+    /**
+     * Returns an Observable containing the value of a specified array index (if array) or property (if object) from
+     * all elements in the Observable sequence. If a property can't be resolved the observable will error.
+     *
+     * @param mixed $property
+     * @return Observable
+     *
+     * @demo pluck/pluck.php
+     * @operator
+     * @reactivex pluck
+     */
+    public function pluck($property)
+    {
+        return $this->map(function ($x) use ($property) {
+            if (is_array($x) && isset($x[$property])) {
+                return $x[$property];
+            }
+            if (is_object($x) && isset($x->$property)) {
+                return $x->$property;
+            }
+
+            throw new \Exception('Unable to pluck "' . $property . '"');
+        });
+    }
 }

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -1703,7 +1703,7 @@ class Observable implements ObservableInterface
      *
      * @demo pluck/pluck.php
      * @operator
-     * @reactivex pluck
+     * @reactivex map
      */
     public function pluck($property)
     {

--- a/test/Rx/Functional/Operator/PluckTest.php
+++ b/test/Rx/Functional/Operator/PluckTest.php
@@ -159,4 +159,35 @@ class PluckTest extends FunctionalTestCase
             subscribe(200, 290)
         ], $xs->getSubscriptions());
     }
+
+    /**
+     * @test
+     */
+    public function pluck_array_numeric_index()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, [-1,-1,-1,-1]),
+            onNext(210, [4,3,2,1]),
+            onNext(240, [4,3,20,10]),
+            onNext(290, [4,3,200,100]),
+            onNext(350, [4,3,2000,1000]),
+            onCompleted(400)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck(2);
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 20),
+            onNext(290, 200),
+            onNext(350, 2000),
+            onCompleted(400)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 400)
+        ], $xs->getSubscriptions());
+    }
 }

--- a/test/Rx/Functional/Operator/PluckTest.php
+++ b/test/Rx/Functional/Operator/PluckTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use Rx\Functional\FunctionalTestCase;
+
+class PluckTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function pluck_completed()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, (object)['prop' => 1]),
+            onNext(210, (object)['prop' => 2]),
+            onNext(240, (object)['prop' => 3]),
+            onNext(290, (object)['prop' => 4]),
+            onNext(350, (object)['prop' => 5]),
+            onCompleted(400),
+            onNext(410, (object)['prop' => -1]),
+            onCompleted(420),
+            onError(430, new \Exception())
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck('prop');
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 3),
+            onNext(290, 4),
+            onNext(350, 5),
+            onCompleted(400)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 400)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function pluck_error()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, ['prop' => 1]),
+            onNext(210, ['prop' => 2]),
+            onNext(240, ['prop' => 3]),
+            onNext(290, ['prop' => 4]),
+            onNext(350, ['prop' => 5]),
+            onError(400, new \Exception())
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck('prop');
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 3),
+            onNext(290, 4),
+            onNext(350, 5),
+            onError(400, new \Exception())
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 400)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function pluck_completed_array()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, ['prop' => 1]),
+            onNext(210, ['prop' => 2]),
+            onNext(240, ['prop' => 3]),
+            onNext(290, ['prop' => 4]),
+            onNext(350, ['prop' => 5]),
+            onCompleted(400)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck('prop');
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 3),
+            onNext(290, 4),
+            onNext(350, 5),
+            onCompleted(400)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 400)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function pluck_array_index_missing()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, ['prop' => 1]),
+            onNext(210, ['prop' => 2]),
+            onNext(240, ['prop' => 3]),
+            onNext(290, []),
+            onNext(350, ['prop' => 5]),
+            onError(400, new \Exception())
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck('prop');
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 3),
+            onError(290, new \Exception())
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 290)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function pluck_object_property_missing()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, (object)['prop' => 1]),
+            onNext(210, (object)['prop' => 2]),
+            onNext(240, (object)['prop' => 3]),
+            onNext(290, new \stdClass()),
+            onNext(350, (object)['prop' => 5]),
+            onError(400, new \Exception())
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck('prop');
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 3),
+            onError(290, new \Exception())
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 290)
+        ], $xs->getSubscriptions());
+    }
+}


### PR DESCRIPTION
This PR adds the `pluck` operator.

There is a difference in the way this version handles objects and arrays without the property or index to be plucked. In RxJS, the operator returns `undefined`, this implementation causes the sequence to error. This is better for PHP as returning any value should be supported and there is not a way to distinguish between a missing property and if it was the value of the property. An additional `map` or `filter` prior to the pluck can give the user control over this circumstance if needed.

Because PHP supports string-indexed arrays, this operator also supports arrays and could be used to pluck specific indexes whether numeric or a string.
