### PR TITLE
Add `sum` operator

### DIFF
--- a/demo/sum/sum.php
+++ b/demo/sum/sum.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$source = Rx\Observable::range(1, 10)
+    ->sum();
+
+$subscription = $source->subscribeCallback(
+    function ($x) {
+        echo 'Next: ' . $x . PHP_EOL;
+    },
+    function ($err) {
+        echo 'Error: ' . $err . PHP_EOL;
+    },
+    function () {
+        echo 'Completed' . PHP_EOL;
+    });
+
+// => Next: 55
+// => Completed

--- a/demo/sum/sum.php.expect
+++ b/demo/sum/sum.php.expect
@@ -1,0 +1,2 @@
+Next: 55
+Completed

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -1652,4 +1652,21 @@ class Observable implements ObservableInterface
             return new RaceOperator();
         });
     }
+
+    /**
+     * Computes the sum of a sequence of values
+     *
+     * @return AnonymousObservable
+     *
+     * @demo sum/sum.php
+     * @operator
+     * @reactivex sum
+     */
+    public function sum()
+    {
+        return $this
+            ->reduce(function ($a, $x) {
+                return $a + $x;
+            }, 0);
+    }
 }

--- a/test/Rx/Functional/Operator/SumTest.php
+++ b/test/Rx/Functional/Operator/SumTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use Rx\Functional\FunctionalTestCase;
+
+class SumTest extends FunctionalTestCase
+{
+    /**
+     * Adapted from RxJS
+     *
+     * @test
+     */
+    public function sum_number_empty()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onCompleted(250)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->sum();
+        });
+
+        $this->assertMessages([
+            onNext(250, 0),
+            onCompleted(250)
+        ], $results->getMessages());
+    }
+
+    /**
+     * Adapted from RxJS
+     *
+     * @test
+     */
+    public function sum_number_return()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onCompleted(250)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->sum();
+        });
+
+        $this->assertMessages([
+            onNext(250, 2),
+            onCompleted(250)
+        ], $results->getMessages());
+    }
+
+    /**
+     * Adapted from RxJS
+     *
+     * @test
+     */
+    public function sum_number_some()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onNext(220, 3),
+            onNext(230, 4),
+            onCompleted(250)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->sum();
+        });
+
+        $this->assertMessages([
+            onNext(250, 2 + 3 + 4),
+            onCompleted(250)
+        ], $results->getMessages());
+    }
+
+    /**
+     * Adapted from RxJS
+     *
+     * @test
+     */
+    public function sum_number_throw()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onError(210, new \Exception())
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->sum();
+        });
+
+        $this->assertMessages([
+            onError(210, new \Exception())
+        ], $results->getMessages());
+    }
+
+    /**
+     * Adapted from RxJS
+     *
+     * @test
+     */
+    public function sum_number_never()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->sum();
+        });
+
+        $this->assertMessages([], $results->getMessages());
+    }
+}


### PR DESCRIPTION
This is an alternative to #66 

This is implemented using `reduce` and relies on the user to map values before this operator if they are interested in casting or catching invalid values.
