### PR TITLE
Fix `EventLoopScheduler` issue #78

### DIFF
--- a/lib/Rx/Scheduler/EventLoopScheduler.php
+++ b/lib/Rx/Scheduler/EventLoopScheduler.php
@@ -42,22 +42,21 @@ final class EventLoopScheduler extends VirtualTimeScheduler
         return $disp;
     }
 
-
     public function start()
     {
         $this->clock = $this->now();
 
         $this->insideInvoke = true;
         while ($this->queue->count() > 0) {
-            if ($this->queue->peek()->getDueTime() > $this->clock) {
-                $this->nextTimer = $this->queue->peek()->getDueTime();
-                $timerCallable = $this->timerCallable;
-                $timerCallable($this->nextTimer - $this->clock, [$this, "start"]);
-                break;
-            }
-
             $next = $this->getNext();
             if ($next !== null) {
+                if ($next->getDueTime() > $this->clock) {
+                    $this->nextTimer = $next->getDueTime();
+                    $timerCallable   = $this->timerCallable;
+                    $timerCallable($this->nextTimer - $this->clock, [$this, "start"]);
+                    break;
+                }
+
                 $next->inVoke();
             }
         }

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -3,7 +3,6 @@
 namespace Rx\Scheduler;
 
 use React\EventLoop\Factory;
-use React\EventLoop\LoopInterface;
 use Rx\Observable;
 use Rx\TestCase;
 

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -3,6 +3,7 @@
 namespace Rx\Scheduler;
 
 use React\EventLoop\Factory;
+use React\EventLoop\LoopInterface;
 use Rx\Observable;
 use Rx\TestCase;
 
@@ -76,5 +77,37 @@ class EventLoopSchedulerTest extends TestCase
         
         $this->assertEquals(5, $count);
         $this->assertTrue($actionCalled);
+    }
+    
+    public function testDisposedEventDoesNotCauseSkip()
+    {
+        // create a scheduler - timing is not important for this test
+        // so we can just use an empty callable
+        $scheduler = new EventLoopScheduler(function () {
+        });
+        
+        $calls = [];
+        
+        // the way that these are scheduled, if the scheduler runs (by calling start a few times),
+        // calls should be [2] because 0 is disposed and 1 shouldn't be called for 10s
+        $disposable = $scheduler->schedule(function () use (&$calls) {
+            $calls[] = 0;
+        }, 0);
+
+        $scheduler->schedule(function () use (&$calls) {
+            $calls[] = 1;
+        }, 10000);
+
+        $scheduler->schedule(function () use (&$calls) {
+            $calls[] = 2;
+        }, 0);
+        
+        $disposable->dispose();
+        
+        $scheduler->start();
+        $scheduler->start();
+        $scheduler->start();
+        
+        $this->assertEquals([2], $calls);
     }
 }


### PR DESCRIPTION
Fix and test for issue #78.

This PR corrects the `EventLoopScheduler` to use the `getNext` method on the `VirtualTimeScheduler` when it needs to access the next `ScheduledItem`. This prevents accessing a canceled `ScheduledItem`.
