### PR TITLE
Allow subscribe with no arguments

### DIFF
--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -72,8 +72,9 @@ class Observable implements ObservableInterface
     protected $observers = [];
     protected $started = false;
 
-    public function subscribe(ObserverInterface $observer, $scheduler = null)
+    public function subscribe(ObserverInterface $observer = null, $scheduler = null)
     {
+        $observer          = $observer ? $observer : new CallbackObserver();
         $this->observers[] = $observer;
         $this->started     = true;
 


### PR DESCRIPTION
This PR allows calling `subscribe` on Observables without any arguments.

It is common to start observable sequences without any observer. This allows you to completely leave out arguments.
