### PR TITLE
Create `DoObserver` allowing `do` to be called after error/completion

### DIFF
--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -15,6 +15,7 @@ use Rx\Observable\RangeObservable;
 use Rx\Observable\ReturnObservable;
 use Rx\Observable\TimerObservable;
 use Rx\Observer\CallbackObserver;
+use Rx\Observer\DoObserver;
 use Rx\Operator\AsObservableOperator;
 use Rx\Operator\BufferWithCountOperator;
 use Rx\Operator\CatchErrorOperator;
@@ -805,10 +806,18 @@ class Observable implements ObservableInterface
     }
 
     /**
-     *  Invokes an action for each element in the observable sequence and invokes an action upon graceful
-     *  or exceptional termination of the observable sequence.
-     *  This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to
-     *  run arbitrary actions for messages on the pipeline.
+     * Invokes an action for each element in the observable sequence and invokes an action upon graceful
+     * or exceptional termination of the observable sequence.
+     * This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to
+     * run arbitrary actions for messages on the pipeline.
+     *
+     * When using doOnEach, it is important to note that the Observer may receive additional
+     * events after a stream has completed or errored (such as when useing a repeat or resubscribing).
+     * If you are using an Observable that extends the AbstractObservable, you will not receive these
+     * events. For this special case, use the DoObservable.
+     *
+     * doOnNext, doOnError, and doOnCompleted uses the DoObservable internally and will receive these
+     * additional events.
      *
      * @param ObserverInterface $observer
      *
@@ -836,7 +845,7 @@ class Observable implements ObservableInterface
      */
     public function doOnNext(callable $onNext)
     {
-        return $this->doOnEach(new CallbackObserver(
+        return $this->doOnEach(new DoObserver(
             $onNext
         ));
     }
@@ -851,7 +860,7 @@ class Observable implements ObservableInterface
      */
     public function doOnError(callable $onError)
     {
-        return $this->doOnEach(new CallbackObserver(
+        return $this->doOnEach(new DoObserver(
             null,
             $onError
         ));
@@ -867,7 +876,7 @@ class Observable implements ObservableInterface
      */
     public function doOnCompleted(callable $onCompleted)
     {
-        return $this->doOnEach(new CallbackObserver(
+        return $this->doOnEach(new DoObserver(
             null,
             null,
             $onCompleted

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -814,9 +814,9 @@ class Observable implements ObservableInterface
      * When using doOnEach, it is important to note that the Observer may receive additional
      * events after a stream has completed or errored (such as when useing a repeat or resubscribing).
      * If you are using an Observable that extends the AbstractObservable, you will not receive these
-     * events. For this special case, use the DoObservable.
+     * events. For this special case, use the DoObserver.
      *
-     * doOnNext, doOnError, and doOnCompleted uses the DoObservable internally and will receive these
+     * doOnNext, doOnError, and doOnCompleted uses the DoObserver internally and will receive these
      * additional events.
      *
      * @param ObserverInterface $observer

--- a/lib/Rx/Observer/DoObserver.php
+++ b/lib/Rx/Observer/DoObserver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Rx\Observer;
+
+use Exception;
+use Rx\ObserverInterface;
+
+class DoObserver implements ObserverInterface
+{
+    /** @var callable|null  */
+    private $onNext;
+
+    /** @var callable|null  */
+    private $onError;
+
+    /** @var callable|null  */
+    private $onCompleted;
+
+    public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
+    {
+        $default = function () {
+        };
+
+        $this->onNext = $this->getOrDefault($onNext, $default);
+
+        $this->onError = $this->getOrDefault($onError, function ($e) {
+            throw $e;
+        });
+
+        $this->onCompleted = $this->getOrDefault($onCompleted, $default);
+    }
+    
+    public function onCompleted()
+    {
+        call_user_func($this->onCompleted);
+    }
+
+    public function onError(Exception $error)
+    {
+        call_user_func_array($this->onError, [$error]);
+    }
+
+    public function onNext($value)
+    {
+        call_user_func_array($this->onNext, [$value]);
+    }
+
+    private function getOrDefault(callable $callback = null, $default = null)
+    {
+        if (null === $callback) {
+            return $default;
+        }
+
+        return $callback;
+    }
+}

--- a/test/Rx/Functional/Operator/DoOnCompletedTest.php
+++ b/test/Rx/Functional/Operator/DoOnCompletedTest.php
@@ -28,4 +28,31 @@ class DoOnCompletedTest extends FunctionalTestCase
 
         $this->assertEquals(1, $called);
     }
+
+    /**
+     * @test
+     */
+    public function doOnCompleted_should_call_after_resubscription()
+    {
+        $xs = $this->createColdObservable([
+            onNext(10, 1),
+            onCompleted(20)
+        ]);
+
+        $messages = [];
+
+        $xs
+            ->doOnCompleted(function () use (&$messages) {
+                $messages[] = onCompleted($this->scheduler->getClock());
+            })
+            ->repeat(2)
+            ->subscribeCallback(null, null, null, $this->scheduler);
+
+        $this->scheduler->start();
+
+        $this->assertMessages([
+            onCompleted(20),
+            onCompleted(40)
+        ], $messages);
+    }
 }

--- a/test/Rx/Functional/Operator/DoOnNextTest.php
+++ b/test/Rx/Functional/Operator/DoOnNextTest.php
@@ -34,4 +34,31 @@ class DoOnNextTest extends FunctionalTestCase
         $this->assertEquals(4, $i);
         $this->assertEquals(0, $sum);
     }
+    
+    /**
+     * @test
+     */
+    public function doOnNext_should_call_after_resubscription()
+    {
+        $xs = $this->createColdObservable([
+            onNext(10, 1),
+            onCompleted(20)
+        ]);
+        
+        $messages = [];
+        
+        $xs
+            ->doOnNext(function ($x) use (&$messages) {
+                $messages[] = onNext($this->scheduler->getClock(), $x);
+            })
+            ->repeat(2)
+            ->subscribeCallback(null, null, null, $this->scheduler);
+        
+        $this->scheduler->start();
+        
+        $this->assertMessages([
+            onNext(10, 1),
+            onNext(30, 1)
+        ], $messages);
+    }
 }


### PR DESCRIPTION
This PR addresses #81 by creating a specialized Observer to by used with do.

This is a compromise as there is still some behavior that may not match with what the user expects: If `doOnEach` is used with an Observer that extends `AbstractObserver` such as `CallbackObserver`, they will not receive any events after an error or completion. The other operators (`doOnNext`, `doOnEach`, and `doOnCompleted`) all internally use the DoObserver. This behavior for `doOnEach` has been added to the documentation so that users can hopefully avoid any possible issue.
