### PR TITLE
[WIP] Interop Event-Loop Scheduler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     ],
     "require": {
-        "php": "~5.5|~7.0"
+        "php": "~5.5|~7.0",
+        "wyrihaximus/react-async-interop-loop": "dev-master"
     },
     "require-dev": {
         "react/event-loop": "~0.4.1",


### PR DESCRIPTION
This PR serves as place to discuss using the PHP [Interop Event-Loop](https://github.com/async-interop/event-loop) for the `EventLoopScheduler`, so that RxPHP can be used with [ReactPHP](https://github.com/reactphp/event-loop), [Icicle](https://github.com/icicleio/icicle), [Amphp](https://github.com/amphp/loop), or any project that implements the interop loop.

Usage examples:

With `run` (consistent with the current behavior):

``` PHP
$driver = ReactDriverFactory::createFactoryFromLoop(StreamSelectLoop::class);
Loop::setFactory($driver);

$scheduler = new EventLoopScheduler();
Observable::interval(1000, $scheduler)
    ->take(5)
    ->subscribe($createStdoutObserver());

Loop::get()->run();
```

With `execute`:

``` PHP
$driver = ReactDriverFactory::createFactoryFromLoop(StreamSelectLoop::class);
Loop::setFactory($driver);

Loop::execute(function () use ($createStdoutObserver) {
    $scheduler = new EventLoopScheduler();
    Observable::interval(1000, $scheduler)
        ->take(5)
        ->subscribe($createStdoutObserver());
});
```

Now that we have a static loop, we also need to discuss setting the EventLoopScheduler as the default for operators that require a loop (see https://github.com/ReactiveX/RxPHP/pull/25).  Currently, they default to Immediate and the user needs to manually set it to a supported scheduler, which isn't ideal.

The above example could then be further simplified to:

``` PHP
$driver = ReactDriverFactory::createFactoryFromLoop(StreamSelectLoop::class);
Loop::setFactory($driver);

Observable::interval(1000)
    ->take(5)
    ->subscribe($createStdoutObserver());

Loop::get()->run();
```
