### PR TITLE
Implement `throttle` operator

### DIFF
--- a/demo/throttle/throttle.php
+++ b/demo/throttle/throttle.php
@@ -1,0 +1,30 @@
+<?php
+
+use React\EventLoop\Factory;
+use Rx\Observable;
+use Rx\Scheduler\EventLoopScheduler;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$loop      = Factory::create();
+$scheduler = new EventLoopScheduler($loop);
+
+$times = [
+    ['value' => 0, 'time' => 100],
+    ['value' => 1, 'time' => 600],
+    ['value' => 2, 'time' => 400],
+    ['value' => 3, 'time' => 900],
+    ['value' => 4, 'time' => 200]
+];
+
+// Delay each item by time and project value;
+$source = Observable::fromArray($times)
+    ->flatMap(function ($item) {
+        return Observable::just($item['value'])
+            ->delay($item['time']);
+    })
+    ->throttle(300 /* ms */);
+
+$subscription = $source->subscribe($stdoutObserver, $scheduler);
+
+$loop->run();

--- a/demo/throttle/throttle.php.expect
+++ b/demo/throttle/throttle.php.expect
@@ -1,0 +1,5 @@
+Next value: 0
+Next value: 2
+Next value: 1
+Next value: 3
+Complete!

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -1783,6 +1783,10 @@ class Observable implements ObservableInterface
      * @param $throttleDuration
      * @param null $scheduler
      * @return AnonymousObservable
+     *
+     * @demo throttle/throttle.php
+     * @operator
+     * @reactivex debounce
      */
     public function throttle($throttleDuration, $scheduler = null)
     {

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -57,6 +57,7 @@ use Rx\Operator\TakeLastOperator;
 use Rx\Operator\TakeOperator;
 use Rx\Operator\TakeUntilOperator;
 use Rx\Operator\TakeWhileOperator;
+use Rx\Operator\ThrottleOperator;
 use Rx\Operator\TimeoutOperator;
 use Rx\Operator\TimestampOperator;
 use Rx\Operator\ToArrayOperator;
@@ -1769,6 +1770,24 @@ class Observable implements ObservableInterface
             }
 
             throw new \Exception('Unable to pluck "' . $property . '"');
+        });
+    }
+
+    /**
+     * Returns an Observable that emits only the first item emitted by the source Observable during
+     * sequential time windows of a specified duration.
+     *
+     * If items are emitted on the source observable prior to the expiration of the time period,
+     * the last item emitted on the source observable will be emitted.
+     *
+     * @param $throttleDuration
+     * @param null $scheduler
+     * @return AnonymousObservable
+     */
+    public function throttle($throttleDuration, $scheduler = null)
+    {
+        return $this->lift(function () use ($throttleDuration, $scheduler) {
+            return new ThrottleOperator($throttleDuration, $scheduler);
         });
     }
 }

--- a/lib/Rx/Operator/ThrottleOperator.php
+++ b/lib/Rx/Operator/ThrottleOperator.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Rx\Operator;
+
+use Rx\Disposable\CallbackDisposable;
+use Rx\Disposable\CompositeDisposable;
+use Rx\Disposable\EmptyDisposable;
+use Rx\Disposable\SerialDisposable;
+use Rx\Observable;
+use Rx\ObservableInterface;
+use Rx\Observer\CallbackObserver;
+use Rx\ObserverInterface;
+use Rx\SchedulerInterface;
+
+class ThrottleOperator implements OperatorInterface
+{
+    private $nextSend = 0;
+    
+    private $throttleTime = 0;
+    
+    private $completed = false;
+    
+    /** @var SchedulerInterface */
+    private $scheduler;
+
+    /**
+     * DebounceOperator constructor.
+     * @param int $debounceTime
+     * @param SchedulerInterface $scheduler
+     */
+    public function __construct($debounceTime, SchedulerInterface $scheduler = null)
+    {
+        $this->throttleTime = $debounceTime;
+        $this->scheduler    = $scheduler;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(
+        ObservableInterface $observable,
+        ObserverInterface $observer,
+        SchedulerInterface $scheduler = null
+    ) {
+        if ($this->scheduler !== null) {
+            $scheduler = $this->scheduler;
+        }
+        if ($scheduler === null) {
+            throw new \Exception("You must use a scheduler that support non-zero delay.");
+        }
+
+        $innerDisp = new SerialDisposable();
+        
+        $disp = $observable->subscribe(new CallbackObserver(
+            function ($x) use ($innerDisp, $observer, $scheduler) {
+                $now = $scheduler->now();
+                if ($this->nextSend <= $now) {
+                    $innerDisp->setDisposable(new EmptyDisposable());
+                    $observer->onNext($x);
+                    $this->nextSend = $now + $this->throttleTime - 1;
+                    return;
+                }
+                
+                $newDisp = Observable::just($x)
+                    ->delay($this->nextSend - $now)
+                    ->subscribe(new CallbackObserver(
+                        function ($x) use ($observer, $scheduler) {
+                            $observer->onNext($x);
+                            $this->nextSend = $scheduler->now() + $this->throttleTime - 1;
+                            if ($this->completed) {
+                                $observer->onCompleted();
+                            }
+                        },
+                        [$observer, 'onError']
+                    ), $scheduler);
+                
+                $innerDisp->setDisposable($newDisp);
+            },
+            function (\Exception $e) use ($observer, $innerDisp) {
+                $innerDisp->dispose();
+                $observer->onError($e);
+            },
+            function () use ($observer) {
+                $this->completed = true;
+                if ($this->nextSend === 0) {
+                    $observer->onCompleted();
+                }
+            }
+        ), $scheduler);
+
+        return new CompositeDisposable([$disp, $innerDisp]);
+    }
+}

--- a/lib/Rx/Operator/ThrottleOperator.php
+++ b/lib/Rx/Operator/ThrottleOperator.php
@@ -45,9 +45,6 @@ class ThrottleOperator implements OperatorInterface
         if ($this->scheduler !== null) {
             $scheduler = $this->scheduler;
         }
-        if ($scheduler === null) {
-            throw new \Exception("You must use a scheduler that support non-zero delay.");
-        }
 
         $innerDisp = new SerialDisposable();
         

--- a/test/Rx/Functional/Operator/ThrottleTest.php
+++ b/test/Rx/Functional/Operator/ThrottleTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use Rx\Functional\FunctionalTestCase;
+use Rx\Observable;
+
+class ThrottleTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function throttle_completed()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onNext(250, 3),
+            onNext(310, 4),
+            onNext(350, 5),
+            onNext(410, 6),
+            onNext(450, 7),
+            onCompleted(500)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(410, 6),
+            onNext(610, 7),
+            onCompleted(610)
+        ], $results->getMessages());
+        
+        $this->assertSubscriptions([
+            subscribe(200, 610)
+        ], $xs->getSubscriptions());
+    }
+    
+    /**
+     * @test
+     */
+    public function throttle_never()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 1000)
+        ], $xs->getSubscriptions());
+    }
+    
+    /**
+     * @test
+     */
+    public function throttle_empty()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onCompleted(500)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([
+            onCompleted(500)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 500)
+        ], $xs->getSubscriptions());
+    }
+    
+    /**
+     * @test
+     */
+    public function throttle_error()
+    {
+        $error = new \Exception();
+
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onNext(250, 3),
+            onNext(310, 4),
+            onNext(350, 5),
+            onError(410, $error),
+            onNext(450, 7),
+            onCompleted(500)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onError(410, $error)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 410)
+        ], $xs->getSubscriptions());
+    }
+    
+    /**
+     * @test
+     */
+    public function throttle_no_end()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onNext(250, 3),
+            onNext(310, 4),
+            onNext(350, 5),
+            onNext(410, 6),
+            onNext(450, 7)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(410, 6),
+            onNext(610, 7)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 1000)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function throttle_dispose()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onNext(250, 3),
+            onNext(310, 4),
+            onNext(350, 5),
+            onNext(410, 6),
+            onNext(450, 7)
+        ]);
+
+        $results = $this->scheduler->startWithDispose(function () use ($xs) {
+            return $xs->throttle(200);
+        }, 420);
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(410, 6)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 420)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function throttle_dispose_with_value_waiting()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(210, 2),
+            onNext(250, 3),
+            onNext(310, 4),
+            onNext(350, 5),
+            onNext(410, 6),
+            onNext(450, 7)
+        ]);
+
+        $results = $this->scheduler->startWithDispose(function () use ($xs) {
+            return $xs->throttle(200);
+        }, 460);
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(410, 6)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 460)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function throttle_quiet_observable_emits_immediately()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(250, 2),
+            onNext(550, 7)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([
+            onNext(250, 2),
+            onNext(550, 7)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 1000)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function throttle_noisy_observable_drops_items()
+    {
+        $xs = $this->createHotObservable([
+            onNext(150, 1),
+            onNext(250, 2),
+            onNext(251, 3),
+            onNext(252, 4),
+            onNext(253, 5),
+            onNext(254, 6),
+            onNext(255, 7),
+            onNext(256, 8),
+            onNext(257, 9),
+            onNext(550, 10),
+            onNext(850, 11)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->throttle(200);
+        });
+
+        $this->assertMessages([
+            onNext(250, 2),
+            onNext(450, 9),
+            onNext(650, 10),
+            onNext(850, 11)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 1000)
+        ], $xs->getSubscriptions());
+    }
+}

--- a/test/Rx/Functional/Operator/ThrottleTest.php
+++ b/test/Rx/Functional/Operator/ThrottleTest.php
@@ -2,8 +2,11 @@
 
 namespace Rx\Functional\Operator;
 
+use Rx\Disposable\EmptyDisposable;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;
+use Rx\Scheduler\ImmediateScheduler;
+use Rx\SchedulerInterface;
 
 class ThrottleTest extends FunctionalTestCase
 {
@@ -260,5 +263,20 @@ class ThrottleTest extends FunctionalTestCase
         $this->assertSubscriptions([
             subscribe(200, 1000)
         ], $xs->getSubscriptions());
+    }
+    
+    /**
+     * @test
+     */
+    public function throttle_scheduler_overrides_subscribe_scheduler()
+    {
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects($this->any())
+            ->method('schedule')
+            ->willReturn(new EmptyDisposable());
+        
+        Observable::just(1)
+            ->throttle(100, $scheduler)
+            ->subscribeCallback(null, null, null, new ImmediateScheduler());
     }
 }


### PR DESCRIPTION
In implementing this operator, I changed the behavior from the rxjs4 version.

This operator returns an `Observable` that emits only the first item emitted by the source `Observable` during sequential time windows of a specified duration.

The difference in this implementation is that if items are emitted on the source observable prior to the expiration of the throttle time period, the last item emitted on the source observable will be emitted at the expiration of that period. This guarantees that the most recent item will eventually be emitted.
