### PR TITLE
use now() method in VirtualTimeScheduler::schedule

### DIFF
--- a/lib/Rx/Scheduler/VirtualTimeScheduler.php
+++ b/lib/Rx/Scheduler/VirtualTimeScheduler.php
@@ -32,7 +32,7 @@ class VirtualTimeScheduler implements SchedulerInterface
             return new EmptyDisposable();
         };
 
-        return $this->scheduleAbsoluteWithState($action, $this->clock + $delay, $invokeAction);
+        return $this->scheduleAbsoluteWithState($action, $this->now() + $delay, $invokeAction);
     }
 
     public function scheduleRecursive(callable $action)

--- a/lib/Rx/Scheduler/VirtualTimeScheduler.php
+++ b/lib/Rx/Scheduler/VirtualTimeScheduler.php
@@ -93,7 +93,7 @@ class VirtualTimeScheduler implements SchedulerInterface
 
     public function scheduleRelativeWithState($state, $dueTime, $action)
     {
-        $runAt = $this->clock + $dueTime;
+        $runAt = $this->now() + $dueTime;
 
         return $this->scheduleAbsoluteWithState($state, $runAt, $action);
     }

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -109,4 +109,24 @@ class EventLoopSchedulerTest extends TestCase
         
         $this->assertEquals([2], $calls);
     }
+
+    public function testSchedulerWorkedWithScheduledEventOutsideItself()
+    {
+        $loop         = Factory::create();
+        $scheduler    = new EventLoopScheduler($loop);
+
+        $scheduler->start();
+        $start = microtime(true);
+        $called = null;
+
+        $loop->addTimer(0.1, function () use ($scheduler, &$called) {
+            $scheduler->schedule(function () use (&$called) {
+                $called = microtime(true);
+            }, 100);
+        });
+
+        $loop->run();
+
+        $this->assertEquals(0.2, $called-$start, '', 0.02);
+    }
 }


### PR DESCRIPTION
Will change nothing for VirtualTimeScheduler itself but will fix clock offset issue in EventLoopScheduler

Clock is often out of sync when I use EventLoopScheduler, this patch seems to fix all my troubles.
