### PR TITLE
PriorityQueue speed improvement

### DIFF
--- a/lib/Rx/Scheduler/PriorityQueue.php
+++ b/lib/Rx/Scheduler/PriorityQueue.php
@@ -20,6 +20,10 @@ class PriorityQueue
 
     public function remove($item)
     {
+        if ($this->peek() === $item) {
+            $this->dequeue();
+            return true;
+        }
         $newQueue = new InternalPriorityQueue();
         $removed  = false;
 


### PR DESCRIPTION
This small fix makes the priority queue much faster if there is a non-trivial amount of work being queued.

It may be possible to remove the remaining part of the function in a future update also.