### PR TITLE
Create specific exception for `timeout`

### DIFF
--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx\Exception;
+
+class Exception extends \Exception
+{
+}

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx\Exception;
+
+class TimeoutException extends Exception
+{
+}

--- a/src/Observable.php
+++ b/src/Observable.php
@@ -1552,6 +1552,9 @@ abstract class Observable implements ObservableInterface
     }
 
     /**
+     * Errors the observable sequence if no item is emitted in the specified time.
+     * When a timeout occurs, this operator errors with an instance of Rx\Exception\TimeoutException
+     *
      * @param $timeout
      * @param ObservableInterface $timeoutObservable
      * @param SchedulerInterface $scheduler

--- a/src/Operator/TimeoutOperator.php
+++ b/src/Operator/TimeoutOperator.php
@@ -10,6 +10,7 @@ use Rx\ObservableInterface;
 use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
 use Rx\SchedulerInterface;
+use Rx\TimeoutException;
 
 final class TimeoutOperator implements OperatorInterface
 {
@@ -26,7 +27,7 @@ final class TimeoutOperator implements OperatorInterface
         $this->timeoutObservable = $timeoutObservable;
 
         if ($this->timeoutObservable === null) {
-            $this->timeoutObservable = new ErrorObservable(new \Exception('timeout'), $scheduler);
+            $this->timeoutObservable = new ErrorObservable(new TimeoutException('timeout'), $scheduler);
         }
     }
 

--- a/src/Operator/TimeoutOperator.php
+++ b/src/Operator/TimeoutOperator.php
@@ -10,7 +10,7 @@ use Rx\ObservableInterface;
 use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
 use Rx\SchedulerInterface;
-use Rx\TimeoutException;
+use Rx\Exception\TimeoutException;
 
 final class TimeoutOperator implements OperatorInterface
 {

--- a/src/TimeoutException.php
+++ b/src/TimeoutException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx;
+
+class TimeoutException extends \Exception
+{
+}

--- a/src/TimeoutException.php
+++ b/src/TimeoutException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Rx;
-
-class TimeoutException extends \Exception
-{
-}

--- a/test/Rx/Functional/Operator/TimeoutTest.php
+++ b/test/Rx/Functional/Operator/TimeoutTest.php
@@ -4,7 +4,7 @@ namespace Rx\Functional\Operator;
 
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable\ErrorObservable;
-use Rx\TimeoutException;
+use Rx\Exception\TimeoutException;
 
 class TimeoutTest extends FunctionalTestCase
 {

--- a/test/Rx/Functional/Operator/TimeoutTest.php
+++ b/test/Rx/Functional/Operator/TimeoutTest.php
@@ -4,6 +4,7 @@ namespace Rx\Functional\Operator;
 
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable\ErrorObservable;
+use Rx\TimeoutException;
 
 class TimeoutTest extends FunctionalTestCase
 {
@@ -54,7 +55,7 @@ class TimeoutTest extends FunctionalTestCase
 
         $this->assertMessages(
             [
-                onError(401, new \Exception())
+                onError(401, new TimeoutException())
             ],
             $results->getMessages()
         );


### PR DESCRIPTION
This PR creates the `TimeoutException` so that a timeout can be identified downstream.

Fixes #113 