### PR TITLE
Added docblocks

### DIFF
--- a/lib/Rx/Disposable/BinaryDisposable.php
+++ b/lib/Rx/Disposable/BinaryDisposable.php
@@ -10,10 +10,10 @@ use Rx\DisposableInterface;
  */
 class BinaryDisposable implements DisposableInterface
 {
-    /** @var \Rx\DisposableInterface */
+    /** @var DisposableInterface */
     private $first;
 
-    /** @var \Rx\DisposableInterface */
+    /** @var DisposableInterface */
     private $second;
 
     /** @var bool */
@@ -21,8 +21,8 @@ class BinaryDisposable implements DisposableInterface
 
     /**
      * BinaryDisposable constructor.
-     * @param $first
-     * @param $second
+     * @param DisposableInterface $first
+     * @param DisposableInterface $second
      */
     public function __construct(DisposableInterface $first, DisposableInterface $second)
     {
@@ -31,7 +31,7 @@ class BinaryDisposable implements DisposableInterface
     }
 
     /**
-     *
+     * @inheritdoc
      */
     public function dispose()
     {

--- a/lib/Rx/Disposable/CallbackDisposable.php
+++ b/lib/Rx/Disposable/CallbackDisposable.php
@@ -6,13 +6,20 @@ use Rx\DisposableInterface;
 
 class CallbackDisposable implements DisposableInterface
 {
+    /** @var callable */
     private $action;
 
+    /**
+     * @param callable $action
+     */
     public function __construct(callable $action)
     {
         $this->action = $action;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         $call = $this->action;

--- a/lib/Rx/Disposable/CompositeDisposable.php
+++ b/lib/Rx/Disposable/CompositeDisposable.php
@@ -6,14 +6,23 @@ use Rx\DisposableInterface;
 
 class CompositeDisposable implements DisposableInterface
 {
+    /** @var DisposableInterface[]  */
     private $disposables;
+
+    /** @var bool */
     private $isDisposed = false;
 
+    /**
+     * @param DisposableInterface[] $disposables
+     */
     public function __construct(array $disposables = [])
     {
         $this->disposables = $disposables;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         if ($this->isDisposed) {
@@ -30,6 +39,10 @@ class CompositeDisposable implements DisposableInterface
         }
     }
 
+    /**
+     * @param DisposableInterface $disposable
+     * @return void
+     */
     public function add(DisposableInterface $disposable)
     {
         if ($this->isDisposed) {
@@ -39,6 +52,10 @@ class CompositeDisposable implements DisposableInterface
         }
     }
 
+    /**
+     * @param DisposableInterface $disposable
+     * @return bool
+     */
     public function remove(DisposableInterface $disposable)
     {
         if ($this->isDisposed) {
@@ -58,16 +75,26 @@ class CompositeDisposable implements DisposableInterface
         return true;
     }
 
+    /**
+     * @param DisposableInterface $disposable
+     * @return bool
+     */
     public function contains(DisposableInterface $disposable)
     {
         return in_array($disposable, $this->disposables, true);
     }
 
+    /**
+     * @return int
+     */
     public function count()
     {
         return count($this->disposables);
     }
 
+    /**
+     * @return void
+     */
     public function clear()
     {
         $disposables       = $this->disposables;

--- a/lib/Rx/Disposable/EmptyDisposable.php
+++ b/lib/Rx/Disposable/EmptyDisposable.php
@@ -6,6 +6,9 @@ use Rx\DisposableInterface;
 
 class EmptyDisposable implements DisposableInterface
 {
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         // do nothing \o/

--- a/lib/Rx/Disposable/RefCountDisposable.php
+++ b/lib/Rx/Disposable/RefCountDisposable.php
@@ -6,16 +6,29 @@ use Rx\DisposableInterface;
 
 class RefCountDisposable implements DisposableInterface
 {
+    /** @var int */
     private $count = 0;
+
+    /** @var DisposableInterface */
     private $disposable;
+
+    /** @var bool */
     private $isDisposed = false;
+
+    /** @var bool */
     private $isPrimaryDisposed = false;
 
+    /**
+     * @param DisposableInterface $disposable
+     */
     public function __construct(DisposableInterface $disposable)
     {
         $this->disposable = $disposable;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         if ($this->isDisposed) {
@@ -30,6 +43,9 @@ class RefCountDisposable implements DisposableInterface
         }
     }
 
+    /**
+     * @return CallbackDisposable
+     */
     public function getDisposable()
     {
         if (!$this->isDisposed) {
@@ -40,16 +56,25 @@ class RefCountDisposable implements DisposableInterface
         }); // no op
     }
 
+    /**
+     * @return bool
+     */
     public function isDisposed()
     {
         return $this->isDisposed;
     }
 
+    /**
+     * @return bool
+     */
     public function isPrimaryDisposed()
     {
         return $this->isPrimaryDisposed;
     }
 
+    /**
+     * @return CallbackDisposable
+     */
     private function createInnerDisposable()
     {
         $count = &$this->count;

--- a/lib/Rx/Disposable/ScheduledDisposable.php
+++ b/lib/Rx/Disposable/ScheduledDisposable.php
@@ -16,12 +16,19 @@ class ScheduledDisposable implements DisposableInterface
     /** @var bool */
     protected $isDisposed = false;
 
+    /**
+     * @param SchedulerInterface $scheduler
+     * @param DisposableInterface $disposable
+     */
     public function __construct(SchedulerInterface $scheduler, DisposableInterface $disposable)
     {
         $this->scheduler  = $scheduler;
         $this->disposable = $disposable;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         if ($this->isDisposed) {

--- a/lib/Rx/Disposable/SerialDisposable.php
+++ b/lib/Rx/Disposable/SerialDisposable.php
@@ -13,9 +13,12 @@ class SerialDisposable implements DisposableInterface
     /** @var bool */
     private $isDisposed = false;
 
-    /** @var DisposableInterface */
+    /** @var null|DisposableInterface */
     private $disposable = null;
 
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         if ($this->isDisposed) {
@@ -32,7 +35,7 @@ class SerialDisposable implements DisposableInterface
     }
 
     /**
-     * @return DisposableInterface
+     * @return null|DisposableInterface
      */
     public function getDisposable()
     {

--- a/lib/Rx/Disposable/SingleAssignmentDisposable.php
+++ b/lib/Rx/Disposable/SingleAssignmentDisposable.php
@@ -7,9 +7,15 @@ use Rx\DisposableInterface;
 
 class SingleAssignmentDisposable implements DisposableInterface
 {
+    /** @var DisposableInterface|null */
     private $current;
+
+    /** @var bool */
     private $isDisposed = false;
 
+    /**
+     * @inheritdoc
+     */
     public function dispose()
     {
         $old = null;
@@ -25,6 +31,10 @@ class SingleAssignmentDisposable implements DisposableInterface
         }
     }
 
+    /**
+     * @param DisposableInterface|null $disposable
+     * @return void
+     */
     public function setDisposable(DisposableInterface $disposable = null)
     {
         if ($this->current) {
@@ -40,11 +50,17 @@ class SingleAssignmentDisposable implements DisposableInterface
         }
     }
 
+    /**
+     * @return null|DisposableInterface
+     */
     public function getDisposable()
     {
         return $this->current;
     }
 
+    /**
+     * @return bool
+     */
     public function isDisposed()
     {
         return $this->isDisposed;

--- a/lib/Rx/DisposableInterface.php
+++ b/lib/Rx/DisposableInterface.php
@@ -4,5 +4,8 @@ namespace Rx;
 
 interface DisposableInterface
 {
+    /**
+     * @return void
+     */
     public function dispose();
 }

--- a/lib/Rx/Observable.php
+++ b/lib/Rx/Observable.php
@@ -74,10 +74,18 @@ use Rx\Disposable\CallbackDisposable;
 
 class Observable implements ObservableInterface
 {
+    /** @var ObserverInterface[] */
     protected $observers = [];
+
+    /** @var bool */
     protected $started = false;
 
-    public function subscribe(ObserverInterface $observer, $scheduler = null)
+    /**
+     * @param ObserverInterface $observer
+     * @param SchedulerInterface|null $scheduler
+     * @return DisposableInterface
+     */
+    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         $this->observers[] = $observer;
         $this->started     = true;
@@ -89,6 +97,7 @@ class Observable implements ObservableInterface
 
     /**
      * @internal
+     * @return bool
      */
     public function removeObserver(ObserverInterface $observer)
     {
@@ -103,6 +112,13 @@ class Observable implements ObservableInterface
         return true;
     }
 
+    /**
+     * @param callable|null $onNext
+     * @param callable|null $onError
+     * @param callable|null $onCompleted
+     * @param SchedulerInterface|null $scheduler
+     * @return DisposableInterface
+     */
     public function subscribeCallback(callable $onNext = null, callable  $onError = null, callable $onCompleted = null, SchedulerInterface $scheduler = null)
     {
         $observer = new CallbackObserver($onNext, $onError, $onCompleted);
@@ -128,7 +144,7 @@ class Observable implements ObservableInterface
     /**
      * Returns an Observable that emits an infinite sequence of ascending integers starting at 0, with a constant interval of time of your choosing between emissions.
      *
-     * @param $interval int Period for producing the values in the resulting sequence (specified as an integer denoting milliseconds).
+     * @param int $interval Period for producing the values in the resulting sequence (specified as an integer denoting milliseconds).
      * @param SchedulerInterface|null $scheduler
      * @return IntervalObservable An observable sequence that produces a value after each period.
      *
@@ -187,7 +203,7 @@ class Observable implements ObservableInterface
     /**
      * Returns an observable sequence that terminates with an exception.
      *
-     * @param $error
+     * @param \Exception $error
      * @return ErrorObservable The observable sequence that terminates exceptionally with the specified exception object.
      *
      * @demo error-observable/error-observable.php
@@ -312,8 +328,8 @@ class Observable implements ObservableInterface
      * Generates an observable sequence of integral numbers within a specified range, using the specified scheduler to
      * send out observer messages.
      *
-     * @param $start
-     * @param $count
+     * @param int $start
+     * @param int $count
      * @return RangeObservable
      *
      * @demo range/range.php
@@ -395,7 +411,7 @@ class Observable implements ObservableInterface
     /**
      * Maps every value to the same value every time
      *
-     * @param $value
+     * @param mixed $value
      * @return AnonymousObservable
      *
      * @demo map/mapTo.php
@@ -492,13 +508,13 @@ class Observable implements ObservableInterface
     /**
      * Alias for flatMap
      *
-     * @param $selector
+     * @param callable $selector
      * @return AnonymousObservable
      *
      * @operator
      * @reactivex flatMap
      */
-    public function selectMany($selector)
+    public function selectMany(callable $selector)
     {
         return $this->flatMap($selector);
     }
@@ -667,7 +683,7 @@ class Observable implements ObservableInterface
     /**
      * Returns a specified number of contiguous elements from the end of an observable sequence.
      *
-     * @param $count
+     * @param int $count
      * @return AnonymousObservable
      *
      * @demo take/takeLast.php
@@ -747,8 +763,8 @@ class Observable implements ObservableInterface
      * namespace format:
      * CustomNamespace\Rx\Operator\OperatorNameOperator
      *
-     * @param $name
-     * @param $arguments
+     * @param string $name
+     * @param array $arguments
      * @return Observable
      * 
      * @demo custom-operator/rot13.php
@@ -945,8 +961,8 @@ class Observable implements ObservableInterface
      * Applies an accumulator function over an observable sequence and returns each intermediate result.
      * The optional seed value is used as the initial accumulator value.
      *
-     * @param $accumulator
-     * @param null $seed
+     * @param callable $accumulator
+     * @param mixed|null $seed
      * @return AnonymousObservable
      *
      * @demo scan/scan.php
@@ -1283,7 +1299,7 @@ class Observable implements ObservableInterface
      * from zero to one, then shares that subscription with all subsequent observers until the number of observers
      * returns to zero, at which point the subscription is disposed.
      *
-     * @param $initialValue
+     * @param int $initialValue
      * @return \Rx\Observable\RefCountObservable
      *
      * @demo share/shareValue.php
@@ -1327,7 +1343,7 @@ class Observable implements ObservableInterface
      *
      * @param integer $bufferSize
      * @param integer $windowSize
-     * @param $scheduler
+     * @param SchedulerInterface|null $scheduler
      * @return \Rx\Observable\RefCountObservable
      *
      * @demo share/shareReplay.php
@@ -1493,7 +1509,7 @@ class Observable implements ObservableInterface
     /**
      * Time shifts the observable sequence by dueTime. The relative time intervals between the values are preserved.
      *
-     * @param $delay
+     * @param int $delay
      * @param SchedulerInterface|null $scheduler
      * @return AnonymousObservable
      *
@@ -1509,7 +1525,7 @@ class Observable implements ObservableInterface
     }
 
     /**
-     * @param $timeout
+     * @param int $timeout
      * @param ObservableInterface $timeoutObservable
      * @param SchedulerInterface $scheduler
      * @return AnonymousObservable
@@ -1529,7 +1545,7 @@ class Observable implements ObservableInterface
      * Projects each element of an observable sequence into zero or more buffers which are produced based on
      * element count information.
      *
-     * @param $count
+     * @param int $count
      * @param int $skip
      * @return AnonymousObservable
      *
@@ -1836,15 +1852,15 @@ class Observable implements ObservableInterface
      * If items are emitted on the source observable prior to the expiration of the time period,
      * the last item emitted on the source observable will be emitted.
      *
-     * @param $throttleDuration
-     * @param null $scheduler
+     * @param int $throttleDuration
+     * @param SchedulerInterface|null $scheduler
      * @return AnonymousObservable
      *
      * @demo throttle/throttle.php
      * @operator
      * @reactivex debounce
      */
-    public function throttle($throttleDuration, $scheduler = null)
+    public function throttle($throttleDuration, SchedulerInterface $scheduler = null)
     {
         return $this->lift(function () use ($throttleDuration, $scheduler) {
             return new ThrottleOperator($throttleDuration, $scheduler);

--- a/lib/Rx/Observable/AnonymousObservable.php
+++ b/lib/Rx/Observable/AnonymousObservable.php
@@ -10,15 +10,19 @@ use Rx\Scheduler\ImmediateScheduler;
 
 class AnonymousObservable extends Observable
 {
+    /** @var callable */
     private $subscribeAction;
 
+    /**
+     * @param callable $subscribeAction
+     */
     public function __construct(callable $subscribeAction)
     {
         $this->subscribeAction = $subscribeAction;
     }
 
     /**
-     * @override
+     * @inheritdoc
      */
     public function subscribe(ObserverInterface $observer, $scheduler = null)
     {

--- a/lib/Rx/Observable/ArrayObservable.php
+++ b/lib/Rx/Observable/ArrayObservable.php
@@ -9,13 +9,20 @@ use Rx\SchedulerInterface;
 
 class ArrayObservable extends Observable
 {
+    /** @var array */
     private $data;
 
+    /**
+     * @param array $data
+     */
     public function __construct(array $data)
     {
         $this->data = $data;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         $values    = &$this->data;

--- a/lib/Rx/Observable/EmptyObservable.php
+++ b/lib/Rx/Observable/EmptyObservable.php
@@ -10,7 +10,9 @@ use Rx\SchedulerInterface;
 
 class EmptyObservable extends Observable
 {
-
+    /**
+     * @inheritdoc
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         $scheduler = $scheduler?: new ImmediateScheduler();

--- a/lib/Rx/Observable/ErrorObservable.php
+++ b/lib/Rx/Observable/ErrorObservable.php
@@ -11,13 +11,20 @@ use Rx\SchedulerInterface;
 
 class ErrorObservable extends Observable
 {
+    /** @var \Exception */
     private $error;
 
+    /**
+     * @param \Exception $error
+     */
     public function __construct(Exception $error)
     {
         $this->error = $error;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
 

--- a/lib/Rx/Observable/ForkJoinObservable.php
+++ b/lib/Rx/Observable/ForkJoinObservable.php
@@ -17,6 +17,9 @@ class ForkJoinObservable extends Observable {
      */
     private $observables;
 
+    /**
+     * @var array
+     */
     private $values = [];
 
     private $completed = 0;

--- a/lib/Rx/Observable/GroupedObservable.php
+++ b/lib/Rx/Observable/GroupedObservable.php
@@ -11,9 +11,17 @@ use Rx\DisposableInterface;
 
 class GroupedObservable extends Observable
 {
+    /** @var string|int */
     private $key;
+
+    /** @var ObservableInterface  */
     private $underlyingObservable;
 
+    /**
+     * @param string|int $key
+     * @param ObservableInterface $underlyingObservable
+     * @param DisposableInterface|null $mergedDisposable
+     */
     public function __construct($key, ObservableInterface $underlyingObservable, DisposableInterface $mergedDisposable = null)
     {
         $this->key = $key;
@@ -33,11 +41,17 @@ class GroupedObservable extends Observable
         }
     }
 
+    /**
+     * @return int|string
+     */
     public function getKey()
     {
         return $this->key;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         return $this->underlyingObservable->subscribe($observer, $scheduler);

--- a/lib/Rx/Observable/IntervalObservable.php
+++ b/lib/Rx/Observable/IntervalObservable.php
@@ -8,13 +8,15 @@ use Rx\SchedulerInterface;
 
 class IntervalObservable extends Observable
 {
+    /** @var int */
     private $interval;
 
     /** @var SchedulerInterface */
     private $scheduler;
 
     /**
-     * IntervalObservable constructor.
+     * @param int $interval
+     * @param SchedulerInterface|null $scheduler
      */
     public function __construct($interval, SchedulerInterface $scheduler = null)
     {
@@ -22,7 +24,9 @@ class IntervalObservable extends Observable
         $this->scheduler = $scheduler;
     }
 
-
+    /**
+     * @inheritdoc
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         if ($this->scheduler !== null) {

--- a/lib/Rx/Observable/IteratorObservable.php
+++ b/lib/Rx/Observable/IteratorObservable.php
@@ -12,6 +12,9 @@ class IteratorObservable extends Observable
     /** @var \Iterator */
     private $items;
 
+    /**
+     * @param \Iterator $items
+     */
     public function __construct(\Iterator $items)
     {
         $this->items = $items;

--- a/lib/Rx/Observable/NeverObservable.php
+++ b/lib/Rx/Observable/NeverObservable.php
@@ -9,7 +9,11 @@ use Rx\SchedulerInterface;
 
 class NeverObservable extends Observable
 {
-
+    /**
+     * @param ObserverInterface $observer
+     * @param SchedulerInterface|null $scheduler
+     * @return EmptyDisposable
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         return new EmptyDisposable();

--- a/lib/Rx/Observable/RangeObservable.php
+++ b/lib/Rx/Observable/RangeObservable.php
@@ -15,14 +15,14 @@ class RangeObservable extends Observable
     /** @var integer */
     private $count;
 
-    /** @var SchedulerInterface */
+    /** @var SchedulerInterface|null */
     private $scheduler;
 
     /**
      * SkipLastOperator constructor.
-     * @param $start
-     * @param $count
-     * @param SchedulerInterface $scheduler
+     * @param int $start
+     * @param int $count
+     * @param SchedulerInterface|null $scheduler
      */
     public function __construct($start, $count, SchedulerInterface $scheduler = null)
     {
@@ -36,6 +36,9 @@ class RangeObservable extends Observable
 
     }
 
+    /**
+     * @inheritdoc
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
 

--- a/lib/Rx/Observable/ReturnObservable.php
+++ b/lib/Rx/Observable/ReturnObservable.php
@@ -10,6 +10,7 @@ use Rx\SchedulerInterface;
 
 class ReturnObservable extends Observable
 {
+    /** @var mixed */
     private $value;
 
     /**
@@ -20,6 +21,11 @@ class ReturnObservable extends Observable
         $this->value = $value;
     }
 
+    /**
+     * @param ObserverInterface $observer
+     * @param SchedulerInterface|null $scheduler
+     * @return CompositeDisposable
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         $value     = $this->value;

--- a/lib/Rx/Observable/TimerObservable.php
+++ b/lib/Rx/Observable/TimerObservable.php
@@ -25,6 +25,12 @@ class TimerObservable extends Observable
         $this->scheduler = $scheduler;
     }
 
+    /**
+     * @param ObserverInterface $observer
+     * @param SchedulerInterface|null $scheduler
+     * @return \Rx\DisposableInterface
+     * @throws \Exception
+     */
     public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
     {
         if ($this->scheduler !== null) {

--- a/lib/Rx/Observer/AbstractObserver.php
+++ b/lib/Rx/Observer/AbstractObserver.php
@@ -11,7 +11,7 @@ abstract class AbstractObserver implements ObserverInterface
     private $isStopped = false;
 
     /**
-     * @return void
+     * @inheritdoc
      */
     public function onCompleted()
     {
@@ -24,7 +24,7 @@ abstract class AbstractObserver implements ObserverInterface
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     public function onError(Exception $error)
     {
@@ -37,7 +37,7 @@ abstract class AbstractObserver implements ObserverInterface
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     public function onNext($value)
     {
@@ -54,11 +54,13 @@ abstract class AbstractObserver implements ObserverInterface
     abstract protected function completed();
 
     /**
+     * @param mixed $value
      * @return void
      */
     abstract protected function next($value);
 
     /**
+     * @param \Exception $error
      * @return void
      */
     abstract protected function error(Exception $error);

--- a/lib/Rx/Observer/AbstractObserver.php
+++ b/lib/Rx/Observer/AbstractObserver.php
@@ -7,8 +7,12 @@ use Rx\ObserverInterface;
 
 abstract class AbstractObserver implements ObserverInterface
 {
+    /** @var bool */
     private $isStopped = false;
 
+    /**
+     * @return void
+     */
     public function onCompleted()
     {
         if ($this->isStopped) {
@@ -19,6 +23,9 @@ abstract class AbstractObserver implements ObserverInterface
         $this->completed();
     }
 
+    /**
+     * @return void
+     */
     public function onError(Exception $error)
     {
         if ($this->isStopped) {
@@ -29,6 +36,9 @@ abstract class AbstractObserver implements ObserverInterface
         $this->error($error);
     }
 
+    /**
+     * @return void
+     */
     public function onNext($value)
     {
         if ($this->isStopped) {
@@ -38,9 +48,18 @@ abstract class AbstractObserver implements ObserverInterface
         $this->next($value);
     }
 
+    /**
+     * @return void
+     */
     abstract protected function completed();
 
+    /**
+     * @return void
+     */
     abstract protected function next($value);
 
+    /**
+     * @return void
+     */
     abstract protected function error(Exception $error);
 }

--- a/lib/Rx/Observer/AutoDetachObserver.php
+++ b/lib/Rx/Observer/AutoDetachObserver.php
@@ -10,14 +10,22 @@ use Rx\Disposable\SingleAssignmentDisposable;
 
 class AutoDetachObserver extends AbstractObserver
 {
+    /** @var ObserverInterface */
     private $observer;
 
+    /**
+     * @param ObserverInterface $observer
+     */
     public function __construct(ObserverInterface $observer)
     {
         $this->observer   = $observer;
         $this->disposable = new SingleAssignmentDisposable();
     }
 
+    /**
+     * @param DisposableInterface|null $disposable
+     * @return void
+     */
     public function setDisposable(DisposableInterface $disposable = null)
     {
         $disposable = $disposable ?: new EmptyDisposable();
@@ -25,6 +33,10 @@ class AutoDetachObserver extends AbstractObserver
         $this->disposable->setDisposable($disposable);
     }
 
+    /**
+     * @return void
+     * @throws Exception
+     */
     protected function completed()
     {
         try {
@@ -36,6 +48,10 @@ class AutoDetachObserver extends AbstractObserver
         }
     }
 
+    /**
+     * @return void
+     * @throws Exception
+     */
     protected function error(Exception $exception)
     {
         try {
@@ -47,6 +63,10 @@ class AutoDetachObserver extends AbstractObserver
         }
     }
 
+    /**
+     * @return void
+     * @throws Exception
+     */
     protected function next($value)
     {
         try {
@@ -57,6 +77,9 @@ class AutoDetachObserver extends AbstractObserver
         }
     }
 
+    /**
+     * @return void
+     */
     public function dispose()
     {
         $this->disposable->dispose();

--- a/lib/Rx/Observer/AutoDetachObserver.php
+++ b/lib/Rx/Observer/AutoDetachObserver.php
@@ -13,6 +13,9 @@ class AutoDetachObserver extends AbstractObserver
     /** @var ObserverInterface */
     private $observer;
 
+    /** @var SingleAssignmentDisposable */
+    private $disposable;
+
     /**
      * @param ObserverInterface $observer
      */
@@ -34,7 +37,7 @@ class AutoDetachObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      * @throws Exception
      */
     protected function completed()
@@ -49,7 +52,7 @@ class AutoDetachObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      * @throws Exception
      */
     protected function error(Exception $exception)
@@ -64,7 +67,7 @@ class AutoDetachObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      * @throws Exception
      */
     protected function next($value)

--- a/lib/Rx/Observer/CallbackObserver.php
+++ b/lib/Rx/Observer/CallbackObserver.php
@@ -6,13 +6,13 @@ use Exception;
 
 class CallbackObserver extends AbstractObserver
 {
-    /** @var callable|null  */
+    /** @var callable  */
     private $onNext;
 
-    /** @var callable|null  */
+    /** @var callable  */
     private $onError;
 
-    /** @var callable|null  */
+    /** @var callable  */
     private $onCompleted;
 
     /**
@@ -35,7 +35,7 @@ class CallbackObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function completed()
     {
@@ -44,7 +44,7 @@ class CallbackObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function error(Exception $error)
     {
@@ -52,7 +52,7 @@ class CallbackObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function next($value)
     {

--- a/lib/Rx/Observer/CallbackObserver.php
+++ b/lib/Rx/Observer/CallbackObserver.php
@@ -15,6 +15,11 @@ class CallbackObserver extends AbstractObserver
     /** @var callable|null  */
     private $onCompleted;
 
+    /**
+     * @param callable|null $onNext
+     * @param callable|null $onError
+     * @param callable|null $onCompleted
+     */
     public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
     {
         $default = function () {
@@ -29,22 +34,36 @@ class CallbackObserver extends AbstractObserver
         $this->onCompleted = $this->getOrDefault($onCompleted, $default);
     }
 
+    /**
+     * @return void
+     */
     protected function completed()
     {
         // Cannot use $foo() here, see: https://bugs.php.net/bug.php?id=47160
         call_user_func($this->onCompleted);
     }
 
+    /**
+     * @return void
+     */
     protected function error(Exception $error)
     {
         call_user_func_array($this->onError, [$error]);
     }
 
+    /**
+     * @return void
+     */
     protected function next($value)
     {
         call_user_func_array($this->onNext, [$value]);
     }
 
+    /**
+     * @param callable|null $callback
+     * @param null $default
+     * @return callable|null
+     */
     private function getOrDefault(callable $callback = null, $default = null)
     {
         if (null === $callback) {

--- a/lib/Rx/Observer/DoObserver.php
+++ b/lib/Rx/Observer/DoObserver.php
@@ -16,6 +16,11 @@ class DoObserver implements ObserverInterface
     /** @var callable|null  */
     private $onCompleted;
 
+    /**
+     * @param callable|null $onNext
+     * @param callable|null $onError
+     * @param callable|null $onCompleted
+     */
     public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
     {
         $default = function () {
@@ -29,22 +34,36 @@ class DoObserver implements ObserverInterface
 
         $this->onCompleted = $this->getOrDefault($onCompleted, $default);
     }
-    
+
+    /**
+     * @return void
+     */
     public function onCompleted()
     {
         call_user_func($this->onCompleted);
     }
 
+    /**
+     * @return void
+     */
     public function onError(Exception $error)
     {
         call_user_func_array($this->onError, [$error]);
     }
 
+    /**
+     * @return void
+     */
     public function onNext($value)
     {
         call_user_func_array($this->onNext, [$value]);
     }
 
+    /**
+     * @param callable|null $callback
+     * @param null $default
+     * @return callable|null
+     */
     private function getOrDefault(callable $callback = null, $default = null)
     {
         if (null === $callback) {

--- a/lib/Rx/Observer/DoObserver.php
+++ b/lib/Rx/Observer/DoObserver.php
@@ -7,13 +7,13 @@ use Rx\ObserverInterface;
 
 class DoObserver implements ObserverInterface
 {
-    /** @var callable|null  */
+    /** @var callable  */
     private $onNext;
 
-    /** @var callable|null  */
+    /** @var callable  */
     private $onError;
 
-    /** @var callable|null  */
+    /** @var callable  */
     private $onCompleted;
 
     /**
@@ -36,7 +36,7 @@ class DoObserver implements ObserverInterface
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     public function onCompleted()
     {
@@ -44,7 +44,7 @@ class DoObserver implements ObserverInterface
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     public function onError(Exception $error)
     {
@@ -52,7 +52,7 @@ class DoObserver implements ObserverInterface
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     public function onNext($value)
     {

--- a/lib/Rx/Observer/ScheduledObserver.php
+++ b/lib/Rx/Observer/ScheduledObserver.php
@@ -40,7 +40,7 @@ class ScheduledObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function completed()
     {
@@ -50,7 +50,7 @@ class ScheduledObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function next($value)
     {
@@ -60,7 +60,7 @@ class ScheduledObserver extends AbstractObserver
     }
 
     /**
-     * @return void
+     * @inheritdoc
      */
     protected function error(Exception $error)
     {

--- a/lib/Rx/Observer/ScheduledObserver.php
+++ b/lib/Rx/Observer/ScheduledObserver.php
@@ -39,7 +39,9 @@ class ScheduledObserver extends AbstractObserver
         $this->disposable = new SerialDisposable();
     }
 
-
+    /**
+     * @return void
+     */
     protected function completed()
     {
         $this->queue[] = function () {
@@ -47,6 +49,9 @@ class ScheduledObserver extends AbstractObserver
         };
     }
 
+    /**
+     * @return void
+     */
     protected function next($value)
     {
         $this->queue[] = function () use ($value) {
@@ -54,6 +59,9 @@ class ScheduledObserver extends AbstractObserver
         };
     }
 
+    /**
+     * @return void
+     */
     protected function error(Exception $error)
     {
         $this->queue[] = function () use ($error) {
@@ -61,6 +69,9 @@ class ScheduledObserver extends AbstractObserver
         };
     }
 
+    /**
+     * @return void
+     */
     public function ensureActive()
     {
         $isOwner = false;
@@ -103,6 +114,9 @@ class ScheduledObserver extends AbstractObserver
         );
     }
 
+    /**
+     * @return void
+     */
     public function dispose()
     {
         $this->disposable->dispose();

--- a/lib/Rx/ObserverInterface.php
+++ b/lib/Rx/ObserverInterface.php
@@ -12,11 +12,13 @@ interface ObserverInterface
     public function onCompleted();
 
     /**
+     * @param \Exception $error
      * @return void
      */
     public function onError(Exception $error);
 
     /**
+     * @param mixed $value
      * @return void
      */
     public function onNext($value);

--- a/lib/Rx/ObserverInterface.php
+++ b/lib/Rx/ObserverInterface.php
@@ -6,9 +6,18 @@ use Exception;
 
 interface ObserverInterface
 {
+    /**
+     * @return void
+     */
     public function onCompleted();
 
+    /**
+     * @return void
+     */
     public function onError(Exception $error);
 
+    /**
+     * @return void
+     */
     public function onNext($value);
 }


### PR DESCRIPTION
I went through some classes and tried to add docblocks where missing. I checked the correct syntax for [`@param` and it always has to have proper type specified](https://www.phpdoc.org/docs/latest/references/phpdoc/tags/param.html#description). I've also seen `@override` which doesn't seem to be supported by phpdoc (isn't this from Java?).

This mostly applies to 2.x branch as well.