### PR TITLE
Marble testing

### DIFF
--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -3,10 +3,13 @@
 namespace Rx\Functional;
 
 use PHPUnit_Framework_ExpectationFailedException;
+use Rx\Notification;
+use Rx\Observable;
 use Rx\Scheduler\VirtualTimeScheduler;
 use Rx\TestCase;
 use Rx\Testing\ColdObservable;
 use Rx\Testing\HotObservable;
+use Rx\Testing\Recorded;
 use Rx\Testing\Subscription;
 use Rx\Testing\TestScheduler;
 
@@ -90,6 +93,16 @@ abstract class FunctionalTestCase extends TestCase
         return new ColdObservable($this->scheduler, $events);
     }
 
+    protected function createCold(string $events, array $eventMap = [], \Exception $customError = null)
+    {
+        return new ColdObservable($this->scheduler, $this->convertMarblesToMessages($events, $eventMap, $customError));
+    }
+
+    protected function createHot(string $events, array $eventMap = [], \Exception $customError = null)
+    {
+        return new HotObservable($this->scheduler, $this->convertMarblesToMessages($events, $eventMap, $customError, 200));
+    }
+
     protected function createHotObservable(array $events)
     {
         return new HotObservable($this->scheduler, $events);
@@ -98,5 +111,73 @@ abstract class FunctionalTestCase extends TestCase
     protected function createTestScheduler()
     {
         return new TestScheduler();
+    }
+
+    protected function convertMarblesToMessages(string $marbles, array $eventMap = [], \Exception $customError = null, $subscribePoint = 0)
+    {
+        var_dump($eventMap);
+        /** @var Recorded $events */
+        $events = [];
+        $zero = 0;
+
+        for ($i = 0; $i < strlen($marbles); $i++) {
+            switch ($marbles[$i]) {
+                case '-': // nothing
+                    continue;
+                case '#': // error
+                    $events[] = onError($i * 10, $customError ?? new \Exception());
+                    continue;
+                case '^': // this is the subscribe point
+                    $zero = $i * 10;
+                    continue;
+                case '|': //
+                    $events[] = onCompleted($i * 10);
+                    continue;
+                default:
+                    $events[] = onNext($i * 10, isset($eventMap[$i]) ? $eventMap[$i] : $marbles[$i]);
+                    continue;
+            }
+        }
+
+        if ($subscribePoint != 0) { // zero is cold
+            $oldEvents = $events;
+            $events = [];
+            /** @var Recorded $event */
+            foreach ($oldEvents as $event) {
+                $events[] = new Recorded($event->getTime() + $subscribePoint - $zero, $event->getValue());
+            }
+        }
+
+        return $events;
+    }
+
+    protected function convertMessagesToMarbles($messages)
+    {
+        $output = '';
+        $lastTime = 199;
+
+        /** @var Recorded $message */
+        foreach ($messages as $message) {
+            $time = $message->getTime();
+            /** @var Notification $value */
+            $value = $message->getValue();
+            $output .= str_repeat('-', ($time - $lastTime - 1) / 10);
+
+            $lastTime = $time;
+
+            $value->accept(
+                function ($x) use (&$output) {
+                    $output .= $x;
+                },
+                function (\Exception $e) use (&$output) {
+                    $output .= '#';
+                },
+                function () use (&$output) {
+                    $output .= '|';
+                }
+            );
+        }
+
+        return $output;
     }
 }

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -290,9 +290,8 @@ abstract class FunctionalTestCase extends TestCase
         return $disposeAt;
     }
 
-    public function expectObservable(Observable $observable, string $disposeMarble = null)
+    public function expectObservable(Observable $observable, string $disposeMarble = null): ExpectObservableToBe
     {
-
         if ($disposeMarble) {
             $disposeAt = $this->convertMarblesToDisposeTime($disposeMarble, 200);
 
@@ -307,7 +306,7 @@ abstract class FunctionalTestCase extends TestCase
 
         $messages = $results->getMessages();
 
-        return new class($messages) extends FunctionalTestCase
+        return new class($messages) extends FunctionalTestCase implements ExpectObservableToBe
         {
             private $messages;
 
@@ -329,9 +328,9 @@ abstract class FunctionalTestCase extends TestCase
         };
     }
 
-    public function expectSubscriptions(array $subscriptions)
+    public function expectSubscriptions(array $subscriptions): ExpectSubscriptionsToBe
     {
-        return new class($subscriptions) extends FunctionalTestCase
+        return new class($subscriptions) extends FunctionalTestCase implements ExpectSubscriptionsToBe
         {
             private $subscriptions;
 
@@ -350,4 +349,14 @@ abstract class FunctionalTestCase extends TestCase
             }
         };
     }
+}
+
+interface ExpectSubscriptionsToBe
+{
+    public function toBe(string $subscriptionsMarbles);
+}
+
+interface ExpectObservableToBe
+{
+    public function toBe(string $expected, array $values = [], string $errorMessage = null);
 }

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -185,7 +185,7 @@ abstract class FunctionalTestCase extends TestCase
             $time = $message->getTime();
             /** @var Notification $value */
             $value = $message->getValue();
-            $output .= str_repeat('-', ($time - $lastTime - 1) / 10);
+            $output .= str_repeat('-', floor(($time - $lastTime - 1) / 10));
 
             $lastTime = $time;
 

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -153,7 +153,7 @@ abstract class FunctionalTestCase extends TestCase
         }
 
         for ($i = 0; $i < strlen($marbles); $i++) {
-            $now = $groupTime === -1 ? $timeOffset + $i * self::TIME_FACTOR : $groupTime++;
+            $now = $groupTime === -1 ? $timeOffset + $i * self::TIME_FACTOR : $groupTime;
 
             switch ($marbles[$i]) {
                 case ' ':

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -268,7 +268,7 @@ abstract class FunctionalTestCase extends TestCase
     }
 
 
-    public function expectObservable(Observable $observable): FunctionalTestCase
+    public function expectObservable(Observable $observable)
     {
         $results = $this->scheduler->startWithCreate(function () use ($observable) {
             return $observable;
@@ -286,17 +286,19 @@ abstract class FunctionalTestCase extends TestCase
                 $this->messages = $messages;
             }
 
-            public function toBe(string $expected, array $values = [])
+            public function toBe(string $expected, array $values = [], string $errorMessage = null)
             {
+                $error = $errorMessage ? new \Exception($errorMessage) : null;
+
                 $this->assertEquals(
-                    $this->convertMarblesToMessages($expected, $values, null, 200),
+                    $this->convertMarblesToMessages($expected, $values, $error, 200),
                     $this->messages
                 );
             }
         };
     }
 
-    public function expectSubscriptions(array $subscriptions): FunctionalTestCase
+    public function expectSubscriptions(array $subscriptions)
     {
         return new class($subscriptions) extends FunctionalTestCase
         {

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -159,29 +159,29 @@ abstract class FunctionalTestCase extends TestCase
                 case ' ':
                 case '^':
                 case '-': // nothing
-                    continue;
+                    continue 2;
                 case '#': // error
                     $events[] = onError($now, $customError ?? new \Exception());
-                    continue;
+                    continue 2;
                 case '|':
                     $events[] = onCompleted($now);
-                    continue;
+                    continue 2;
                 case '(':
                     if ($groupTime !== -1) {
                         throw new MarbleDiagramException('We\'re already inside a group');
                     }
                     $groupTime = $now;
-                    continue;
+                    continue 2;
                 case ')':
                     if ($groupTime === -1) {
                         throw new MarbleDiagramException('We\'re already outside of a group');
                     }
                     $groupTime = -1;
-                    continue;
+                    continue 2;
                 default:
                     $eventKey = $marbles[$i];
                     $events[] = onNext($now, isset($eventMap[$eventKey]) ? $eventMap[$eventKey] : $marbles[$i]);
-                    continue;
+                    continue 2;
             }
         }
 
@@ -230,25 +230,25 @@ abstract class FunctionalTestCase extends TestCase
             switch ($marbles[$i]) {
                 case ' ':
                 case '-':
-                    continue;
+                    continue 2;
                 case '(':
                     if ($groupTime !== -1) {
                         throw new MarbleDiagramException('We\'re already inside a group');
                     }
                     $groupTime = $now;
-                    continue;
+                    continue 2;
                 case ')':
                     if ($groupTime === -1) {
                         throw new MarbleDiagramException('We\'re already outside of a group');
                     }
                     $groupTime = -1;
-                    continue;
+                    continue 2;
                 case '^': // subscribe
                     if ($latestSubscription) {
                         throw new MarbleDiagramException('Trying to subscribe before unsubscribing the previous subscription.');
                     }
                     $latestSubscription = $now;
-                    continue;
+                    continue 2;
                 case '!': // unsubscribe
                     if (!$latestSubscription) {
                         throw new MarbleDiagramException('Trying to unsubscribe before subscribing.');
@@ -258,7 +258,6 @@ abstract class FunctionalTestCase extends TestCase
                     break;
                 default:
                     throw new MarbleDiagramException('Only "^" and "!" markers are allowed in this diagram.');
-                    continue;
             }
         }
         if ($latestSubscription) {
@@ -277,13 +276,12 @@ abstract class FunctionalTestCase extends TestCase
 
             switch ($marbles[$i]) {
                 case ' ':
-                    continue;
+                    continue 2;
                 case '!': // unsubscribe
                     $disposeAt = $now;
                     break;
                 default:
                     throw new MarbleDiagramException('Only " " and "!" markers are allowed in this diagram.');
-                    continue;
             }
         }
 

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -5,7 +5,7 @@ namespace Rx\Functional;
 use Rx\Notification;
 use Rx\Observable;
 use Rx\TestCase;
-use Rx\MarbleDiagramError;
+use Rx\MarbleDiagramException;
 use Rx\Testing\ColdObservable;
 use Rx\Testing\HotObservable;
 use Rx\Testing\Recorded;
@@ -168,13 +168,13 @@ abstract class FunctionalTestCase extends TestCase
                     continue;
                 case '(':
                     if ($groupTime !== -1) {
-                        throw new MarbleDiagramError('We\'re already inside a group');
+                        throw new MarbleDiagramException('We\'re already inside a group');
                     }
                     $groupTime = $now;
                     continue;
                 case ')':
                     if ($groupTime === -1) {
-                        throw new MarbleDiagramError('We\'re already outside of a group');
+                        throw new MarbleDiagramException('We\'re already outside of a group');
                     }
                     $groupTime = -1;
                     continue;
@@ -233,31 +233,31 @@ abstract class FunctionalTestCase extends TestCase
                     continue;
                 case '(':
                     if ($groupTime !== -1) {
-                        throw new MarbleDiagramError('We\'re already inside a group');
+                        throw new MarbleDiagramException('We\'re already inside a group');
                     }
                     $groupTime = $now;
                     continue;
                 case ')':
                     if ($groupTime === -1) {
-                        throw new MarbleDiagramError('We\'re already outside of a group');
+                        throw new MarbleDiagramException('We\'re already outside of a group');
                     }
                     $groupTime = -1;
                     continue;
                 case '^': // subscribe
                     if ($latestSubscription) {
-                        throw new MarbleDiagramError('Trying to subscribe before unsubscribing the previous subscription.');
+                        throw new MarbleDiagramException('Trying to subscribe before unsubscribing the previous subscription.');
                     }
                     $latestSubscription = $now;
                     continue;
                 case '!': // unsubscribe
                     if (!$latestSubscription) {
-                        throw new MarbleDiagramError('Trying to unsubscribe before subscribing.');
+                        throw new MarbleDiagramException('Trying to unsubscribe before subscribing.');
                     }
                     $events[] = new Subscription($latestSubscription, $now);
                     $latestSubscription = null;
                     break;
                 default:
-                    throw new MarbleDiagramError('Only "^" and "!" markers are allowed in this diagram.');
+                    throw new MarbleDiagramException('Only "^" and "!" markers are allowed in this diagram.');
                     continue;
             }
         }
@@ -282,7 +282,7 @@ abstract class FunctionalTestCase extends TestCase
                     $disposeAt = $now;
                     break;
                 default:
-                    throw new MarbleDiagramError('Only " " and "!" markers are allowed in this diagram.');
+                    throw new MarbleDiagramException('Only " " and "!" markers are allowed in this diagram.');
                     continue;
             }
         }

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -225,7 +225,7 @@ abstract class FunctionalTestCase extends TestCase
         $groupTime = -1;
 
         for ($i = 0; $i < strlen($marbles); $i++) {
-            $now = $groupTime === -1 ? $startTime + $i * self::TIME_FACTOR : $groupTime++;
+            $now = $groupTime === -1 ? $startTime + $i * self::TIME_FACTOR : $groupTime;
 
             switch ($marbles[$i]) {
                 case ' ':

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rx\Functional;
+
+class MarbleTest extends FunctionalTestCase
+{
+    public function testColdMarble()
+    {
+        $c = $this->createCold('----1----3---|');
+        $h = $this->createHot('--^--a--b---|');
+
+        $result = $this->scheduler->startWithCreate(function () use ($c) {
+            return $c;
+        });
+
+        $this->assertMessages([
+            onNext(240, '1'),
+            onNext(290, '3'),
+            onCompleted(330)
+        ], $result->getMessages());
+
+        var_dump($result->getMessages());
+    }
+
+    public function testHotMarble()
+    {
+        $h = $this->createHot('-1-^--a--b---|');
+
+        $result = $this->scheduler->startWithCreate(function () use ($h) {
+            return $h;
+        });
+
+        $this->assertMessages([
+            onNext(230, 'a'),
+            onNext(260, 'b'),
+            onCompleted(300)
+        ], $result->getMessages());
+
+        var_dump($result->getMessages());
+    }
+
+    public function testMessageConversion()
+    {
+        $messages = [
+            onNext(230, 'a'),
+            onNext(260, 'b'),
+            onCompleted(300)
+        ];
+
+        $this->assertEquals('--a--b---|', $this->convertMessagesToMarbles($messages));
+    }
+
+    public function testSomethingElse()
+    {
+        $cold     = '--1--2--|';
+        $expected = '--2--3--|';
+
+        $results = $this->scheduler->startWithCreate(function () use ($cold) {
+            return $this->createCold($cold)->map(function ($x) { return $x + 1; });
+        });
+
+        $this->assertEquals($expected, $this->convertMessagesToMarbles($results->getMessages()));
+    }
+}

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -263,4 +263,20 @@ class MarbleTest extends FunctionalTestCase
         $this->expectObservable($r)->toBe($expected, ['x' => 2, 'y' => 3]);
         $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
     }
+
+    public function testMapErrorMarble()
+    {
+        $cold     = '--x--|';
+        $subs     = '^ !   ';
+        $expected = '--#   ';
+
+        $e1 = $this->createCold($cold, ['x' => 42]);
+
+        $r = $e1->map(function ($x) {
+            throw new \Exception('too bad');
+        });
+
+        $this->expectObservable($r)->toBe($expected, [], 'too bad');
+        $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
+    }
 }

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -247,4 +247,20 @@ class MarbleTest extends FunctionalTestCase
         $marbles = '--^---!-!-';
         $this->convertMarblesToSubscriptions($marbles);
     }
+
+    public function testMapMarble()
+    {
+        $cold     = '--1--2--|';
+        $subs     = '^       !';
+        $expected = '--x--y--|';
+
+        $e1 = $this->createCold($cold);
+
+        $r = $e1->map(function ($x) {
+            return $x + 1;
+        });
+
+        $this->expectObservable($r)->toBe($expected, ['x' => 2, 'y' => 3]);
+        $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
+    }
 }

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -2,12 +2,13 @@
 
 namespace Rx\Functional;
 
+use Rx\Testing\Subscription;
+
 class MarbleTest extends FunctionalTestCase
 {
     public function testColdMarble()
     {
         $c = $this->createCold('----1----3---|');
-        $h = $this->createHot('--^--a--b---|');
 
         $result = $this->scheduler->startWithCreate(function () use ($c) {
             return $c;
@@ -18,8 +19,6 @@ class MarbleTest extends FunctionalTestCase
             onNext(290, '3'),
             onCompleted(330)
         ], $result->getMessages());
-
-        var_dump($result->getMessages());
     }
 
     public function testHotMarble()
@@ -35,8 +34,17 @@ class MarbleTest extends FunctionalTestCase
             onNext(260, 'b'),
             onCompleted(300)
         ], $result->getMessages());
+    }
 
-        var_dump($result->getMessages());
+    public function testColdMarbleWithEqualMessages()
+    {
+        $marbles1 = '----1-^--a--b---|   ';
+        $marbles2 = '    1-^--a--b---|---';
+
+        $this->assertMessages(
+            $this->convertMarblesToMessages($marbles1),
+            $this->convertMarblesToMessages($marbles2)
+        );
     }
 
     public function testMessageConversion()
@@ -47,7 +55,7 @@ class MarbleTest extends FunctionalTestCase
             onCompleted(300)
         ];
 
-        $this->assertEquals('--a--b---|', $this->convertMessagesToMarbles($messages));
+        $this->assertEquals('---a--b---|', $this->convertMessagesToMarbles($messages));
     }
 
     public function testSomethingElse()
@@ -60,5 +68,108 @@ class MarbleTest extends FunctionalTestCase
         });
 
         $this->assertEquals($expected, $this->convertMessagesToMarbles($results->getMessages()));
+    }
+
+    public function testMarbleValues()
+    {
+        $marbles = '--a--b--c--|';
+        $values = [
+            'a' => 42,
+            'b' => 'xyz',
+            'c' => [1, 2, 3],
+        ];
+
+        $messages = $this->convertMarblesToMessages($marbles, $values);
+
+        $this->assertMessages([
+            onNext(20, 42),
+            onNext(50, 'xyz'),
+            onNext(80, [1, 2, 3]),
+            onCompleted(110)
+        ], $messages);
+    }
+
+    public function testMarbleValuesDontMatch()
+    {
+        $marbles = '--a--b--c--|';
+        $values = [
+            'a' => 42,
+            'b' => 'xyz',
+            'c' => [1, 2, 3],
+        ];
+
+        $messages = $this->convertMarblesToMessages($marbles, $values);
+
+        $this->assertMessagesNotEqual([
+            onNext(20, 42),
+            onNext(50, 'xyz'),
+            onNext(80, [1, 5, 3]), // wrong
+            onCompleted(110)
+        ], $messages);
+    }
+
+    public function testMarbleWithMissingValues()
+    {
+        $marbles = '--a--b--c--|';
+        $values = [
+            'a' => 42,
+        ];
+
+        $messages = $this->convertMarblesToMessages($marbles, $values);
+
+        $this->assertMessages([
+            onNext(20, 42),
+            onNext(50, 'b'),
+            onNext(80, 'c'),
+            onCompleted(110)
+        ], $messages);
+    }
+
+    public function testSubscriptions()
+    {
+        $marbles = '--^-----!---^!--';
+
+        $subscriptions = $this->convertMarblesToSubscriptions($marbles, 200);
+        $this->assertSubscriptions([
+            new Subscription(220, 280),
+            new Subscription(320, 330),
+        ], $subscriptions);
+    }
+
+    public function testSubscriptionsMissingUnsubscribeMarker()
+    {
+        $marbles = '--^--';
+
+        $subscriptions = $this->convertMarblesToSubscriptions($marbles);
+        $this->assertSubscriptions([
+            new Subscription(20),
+        ], $subscriptions);
+    }
+
+    /**
+     * @expectedException \Rx\MarbleDiagramError
+     */
+    public function testSubscriptionsInvalidMarkers()
+    {
+        $marbles = '--^--a--!-';
+        $this->convertMarblesToSubscriptions($marbles);
+    }
+
+    /**
+     * @expectedException \Rx\MarbleDiagramError
+     */
+    public function testSubscriptionsMultipleSubscribeMarkers()
+    {
+        $marbles = '--^-^---!-';
+        $this->convertMarblesToSubscriptions($marbles);
+    }
+
+    /**
+     * @expectedException \Rx\MarbleDiagramError
+     */
+    public function testSubscriptionsMultipleUnsubscribeMarkers()
+    {
+        $marbles = '--^---!-!-';
+        $this->convertMarblesToSubscriptions($marbles);
     }
 }

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -134,8 +134,8 @@ class MarbleTest extends FunctionalTestCase
 
         $this->assertMessages([
             onNext(30, 'a'),
-            onNext(31, 'b'),
-            onNext(32, 'c'),
+            onNext(30, 'b'),
+            onNext(30, 'c'),
             onCompleted(100)
         ], $messages);
     }
@@ -151,11 +151,11 @@ class MarbleTest extends FunctionalTestCase
 
         $this->assertMessages([
             onNext(20, 42),
-            onNext(21, 'b'),
-            onNext(22, 'c'),
+            onNext(20, 'b'),
+            onNext(20, 'c'),
             onNext(100, 'd'),
-            onNext(101, 'f'),
-            onNext(102, 42),
+            onNext(100, 'f'),
+            onNext(100, 42),
             onCompleted(170)
         ], $messages);
     }
@@ -170,7 +170,7 @@ class MarbleTest extends FunctionalTestCase
             onNext(20, 'a'),
             onNext(60, 'b'),
             onNext(90, 'c'),
-            onCompleted(91)
+            onCompleted(90)
         ], $messages);
     }
 
@@ -183,7 +183,7 @@ class MarbleTest extends FunctionalTestCase
         $this->assertMessages([
             onNext(20, 'a'),
             onNext(60, 'b'),
-            onError(61, new \Exception()),
+            onError(60, new \Exception()),
             onNext(120, 'c'),
             onCompleted(150),
         ], $messages);
@@ -217,7 +217,7 @@ class MarbleTest extends FunctionalTestCase
         $subscriptions = $this->convertMarblesToSubscriptions($marbles);
 
         $this->assertSubscriptions([
-            new Subscription(20, 21),
+            new Subscription(20, 20),
         ], $subscriptions);
     }
 
@@ -294,6 +294,18 @@ class MarbleTest extends FunctionalTestCase
         });
 
         $this->expectObservable($r, $unsub)->toBe($expected, ['x' => '1!', 'y' => '2!']);
+        $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
+    }
+
+    public function testCountMarble()
+    {
+        $cold     = '--a--b--c--|';
+        $subs     = '^          !';
+        $expected = '-----------(x|)';
+
+        $e1 = $this->createCold($cold);
+
+        $this->expectObservable($e1->count())->toBe($expected, ['x' => 3]);
         $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
     }
 }

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -222,7 +222,7 @@ class MarbleTest extends FunctionalTestCase
     }
 
     /**
-     * @expectedException \Rx\MarbleDiagramError
+     * @expectedException \Rx\MarbleDiagramException
      */
     public function testSubscriptionsInvalidMarkers()
     {
@@ -231,7 +231,7 @@ class MarbleTest extends FunctionalTestCase
     }
 
     /**
-     * @expectedException \Rx\MarbleDiagramError
+     * @expectedException \Rx\MarbleDiagramException
      */
     public function testSubscriptionsMultipleSubscribeMarkers()
     {
@@ -240,7 +240,7 @@ class MarbleTest extends FunctionalTestCase
     }
 
     /**
-     * @expectedException \Rx\MarbleDiagramError
+     * @expectedException \Rx\MarbleDiagramException
      */
     public function testSubscriptionsMultipleUnsubscribeMarkers()
     {

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -279,4 +279,21 @@ class MarbleTest extends FunctionalTestCase
         $this->expectObservable($r)->toBe($expected, [], 'too bad');
         $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
     }
+
+    public function testMapDisposeMarble()
+    {
+        $cold     = '--1--2--3--|';
+        $unsub    = '      !     ';
+        $subs     = '^     !     ';
+        $expected = '--x--y-     ';
+
+        $e1 = $this->createCold($cold);
+
+        $r = $e1->map(function ($x) {
+            return $x . '!';
+        });
+
+        $this->expectObservable($r, $unsub)->toBe($expected, ['x' => '1!', 'y' => '2!']);
+        $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
+    }
 }

--- a/test/Rx/MarbleDiagramError.php
+++ b/test/Rx/MarbleDiagramError.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx;
+
+class MarbleDiagramError extends \Exception
+{
+}

--- a/test/Rx/MarbleDiagramError.php
+++ b/test/Rx/MarbleDiagramError.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Rx;
-
-class MarbleDiagramError extends \Exception
-{
-}

--- a/test/Rx/MarbleDiagramException.php
+++ b/test/Rx/MarbleDiagramException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx;
+
+class MarbleDiagramException extends \Exception
+{
+}


### PR DESCRIPTION
This PR is a preliminary implementation of marble testing as requested at SunshinePHP at the talk by @luijar see: https://github.com/ReactiveX/rxjs/blob/master/doc/writing-marble-tests.md

Example:

```php
    public function testMapAddOne()
    {
        $cold     = '--1--2--|';
        $expected = '--2--3--|';

        $results = $this->scheduler->startWithCreate(function () use ($cold) {
            return $this->createCold($cold)->map(function ($x) { return $x + 1; });
        });

        $this->assertEquals($expected, $this->convertMessagesToMarbles($results->getMessages()));
    }
```