### PR TITLE
Optimized distinct() operator

### DIFF
--- a/lib/Rx/Operator/DistinctOperator.php
+++ b/lib/Rx/Operator/DistinctOperator.php
@@ -18,13 +18,8 @@ class DistinctOperator implements OperatorInterface
 
     public function __construct(callable $keySelector = null, callable $comparer = null)
     {
-
-        $this->comparer = $comparer ?: function ($x, $y) {
-            return $x == $y;
-        };
-
+        $this->comparer = $comparer;
         $this->keySelector = $keySelector;
-
     }
 
     /**
@@ -43,15 +38,22 @@ class DistinctOperator implements OperatorInterface
                 try {
                     $key = $this->keySelector ? call_user_func($this->keySelector, $value) : $value;
 
-                    foreach ($values as $v) {
-                        $comparerEquals = call_user_func($this->comparer, $key, $v);
+                    if ($this->comparer) {
+                        foreach ($values as $v) {
+                            $comparerEquals = call_user_func($this->comparer, $key, $v);
 
-                        if ($comparerEquals) {
+                            if ($comparerEquals) {
+                                return;
+                            }
+                        }
+                        $values[] = $key;
+                    } else {
+                        if (array_key_exists($key, $values)) {
                             return;
                         }
+                        $values[$key] = null;
                     }
 
-                    $values[] = $key;
                     $observer->onNext($value);
 
                 } catch (\Exception $e) {

--- a/test/Rx/Functional/Operator/DistinctTest.php
+++ b/test/Rx/Functional/Operator/DistinctTest.php
@@ -353,6 +353,45 @@ class DistinctTest extends FunctionalTestCase
 
     }
 
+    /**
+     * @test
+     */
+    public function distinct_CustomKey_and_CustomComparer_some_duplicates()
+    {
+
+        $xs = $this->createHotObservable([
+            onNext(280, ['id' => 4]),
+            onNext(300, ['id' => 2]),
+            onNext(350, ['id' => 12]),
+            onNext(380, ['id' => 3]),
+            onNext(400, ['id' => 24]),
+            onCompleted(420)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->distinctKey(
+                function ($x) {
+                    return $x['id'];
+                },
+                $this->modComparer(10)
+            )->map(function ($x) {
+                return $x['id'];
+            });
+        });
+
+        $this->assertMessages([
+            onNext(280, 4),
+            onNext(300, 2),
+            onNext(380, 3),
+            onCompleted(420)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 420)
+        ], $xs->getSubscriptions());
+
+    }
+
 
     public function modComparer($mod)
     {


### PR DESCRIPTION
This is a modified version of `DistinctOperator.php`. When using the default comparer it's much faster to use `array_key_exists()` function to test whether the item is already in the array instead of iterating it. When using a custom comparer the functionality is the same is it was. The tests were passing already I just added one more.

To test the improvement in performance I made a separate branch [with a test runner similar to the one in RxJS 5](https://github.com/martinsik/RxPHP/blob/benchmark-runner/benchmark/run.php).

Results before optimization are following:

```
$ php70 benchmark/run.php benchmark/distinct/distinct.php
Benchmarking 1 file/s (min 5s each)
script_name - total_runs (single_run_mean ±standard_variant)
============================================================
distinct - 37 (135.53ms ±5.60ms)
============================================================
total duration: 5.02s

$ php56 benchmark/run.php benchmark/distinct/distinct.php
Benchmarking 1 file/s (min 5s each)
script_name - total_runs (single_run_mean ±standard_variant)
============================================================
distinct - 16 (321.72ms ±18.15ms)
============================================================
total duration: 5.15s

$ hhvm3.17.0 benchmark/run.php benchmark/distinct/distinct.php
Benchmarking 1 file/s (min 5s each)
script_name - total_runs (single_run_mean ±standard_variant)
============================================================
distinct - 24 (212.56ms ±32.18ms)
============================================================
total duration: 5.74s
```

After optimization:

```
$ git cherry-pick 8a9ac27420d7b1d061885acc0fb5e5274b5cda40
[benchmark-runner 9a85ced] optimized distinct() operator
 Date: Thu Jan 26 07:35:42 2017 +0100
 2 files changed, 51 insertions(+), 10 deletions(-)

$ php70 benchmark/run.php benchmark/distinct/distinct.php
Benchmarking 1 file/s (min 5s each)
script_name - total_runs (single_run_mean ±standard_variant)
============================================================
distinct - 875 (5.72ms ±1.19ms)
============================================================
total duration: 5.02s

$ php56 benchmark/run.php benchmark/distinct/distinct.php
Benchmarking 1 file/s (min 5s each)
script_name - total_runs (single_run_mean ±standard_variant)
============================================================
distinct - 92 (54.88ms ±5.87ms)
============================================================
total duration: 5.06s

$ hhvm3.17.0 benchmark/run.php benchmark/distinct/distinct.php
Benchmarking 1 file/s (min 5s each)
script_name - total_runs (single_run_mean ±standard_variant)
============================================================
distinct - 3425 (1.46ms ±3.32ms)
============================================================
total duration: 5.80s
```