### PR TITLE
Removed ReplaySubject::subscribe second argument type hint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
   - 5.6
   - 7
   - hhvm
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script: composer install
 

--- a/lib/Rx/Observable/ArrayObservable.php
+++ b/lib/Rx/Observable/ArrayObservable.php
@@ -16,7 +16,7 @@ class ArrayObservable extends Observable
         $this->data = $data;
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $values    = &$this->data;
         $max       = count($values);

--- a/lib/Rx/Observable/EmptyObservable.php
+++ b/lib/Rx/Observable/EmptyObservable.php
@@ -11,7 +11,7 @@ use Rx\SchedulerInterface;
 class EmptyObservable extends Observable
 {
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $scheduler = $scheduler?: new ImmediateScheduler();
 

--- a/lib/Rx/Observable/ErrorObservable.php
+++ b/lib/Rx/Observable/ErrorObservable.php
@@ -18,7 +18,7 @@ class ErrorObservable extends Observable
         $this->error = $error;
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
 
         $scheduler = $scheduler?: new ImmediateScheduler();

--- a/lib/Rx/Observable/ForkJoinObservable.php
+++ b/lib/Rx/Observable/ForkJoinObservable.php
@@ -28,7 +28,7 @@ class ForkJoinObservable extends Observable {
         $this->resultSelector = $resultSelector;
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $disposable = new CompositeDisposable();
 

--- a/lib/Rx/Observable/IntervalObservable.php
+++ b/lib/Rx/Observable/IntervalObservable.php
@@ -23,7 +23,7 @@ class IntervalObservable extends Observable
     }
 
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         if ($this->scheduler !== null) {
             $scheduler = $this->scheduler;

--- a/lib/Rx/Observable/IteratorObservable.php
+++ b/lib/Rx/Observable/IteratorObservable.php
@@ -22,7 +22,7 @@ class IteratorObservable extends Observable
      * @param SchedulerInterface|null $scheduler
      * @return \Rx\Disposable\CompositeDisposable|\Rx\DisposableInterface
      */
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $scheduler = $scheduler ?: new ImmediateScheduler();
         

--- a/lib/Rx/Observable/NeverObservable.php
+++ b/lib/Rx/Observable/NeverObservable.php
@@ -10,7 +10,7 @@ use Rx\SchedulerInterface;
 class NeverObservable extends Observable
 {
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         return new EmptyDisposable();
     }

--- a/lib/Rx/Observable/RangeObservable.php
+++ b/lib/Rx/Observable/RangeObservable.php
@@ -36,7 +36,7 @@ class RangeObservable extends Observable
 
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
 
         if ($this->scheduler !== null) {

--- a/lib/Rx/Observable/ReturnObservable.php
+++ b/lib/Rx/Observable/ReturnObservable.php
@@ -20,7 +20,7 @@ class ReturnObservable extends Observable
         $this->value = $value;
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $value     = $this->value;
 

--- a/lib/Rx/Observable/TimerObservable.php
+++ b/lib/Rx/Observable/TimerObservable.php
@@ -25,7 +25,7 @@ class TimerObservable extends Observable
         $this->scheduler = $scheduler;
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         if ($this->scheduler !== null) {
             $scheduler = $this->scheduler;

--- a/lib/Rx/Subject/ReplaySubject.php
+++ b/lib/Rx/Subject/ReplaySubject.php
@@ -61,7 +61,7 @@ class ReplaySubject extends Subject
         $this->scheduler = $scheduler;
     }
 
-    public function subscribe(ObserverInterface $observer, SchedulerInterface $scheduler = null)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $this->assertNotDisposed();
 

--- a/lib/Rx/Testing/ColdObservable.php
+++ b/lib/Rx/Testing/ColdObservable.php
@@ -20,7 +20,7 @@ class ColdObservable extends Observable
         $this->messages  = $messages;
     }
 
-    public function subscribe(ObserverInterface $observer)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $this->subscriptions[] = new Subscription($this->scheduler->getClock());
         $index                 = count($this->subscriptions) - 1;

--- a/lib/Rx/Testing/HotObservable.php
+++ b/lib/Rx/Testing/HotObservable.php
@@ -39,7 +39,7 @@ class HotObservable extends Observable
         }
     }
 
-    public function subscribe(ObserverInterface $observer)
+    public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
         $currentObservable = $this;
 


### PR DESCRIPTION
This pulls it in line with the other subjects. Ran into issues while testing nightly on Travis for a project that uses RX: https://travis-ci.org/php-api-clients/pusher/jobs/199114221#L330 

It is to be noted that this changes shouldn't be on nightly but I'd still consider this a bug: https://twitter.com/kelunik/status/828869548652818432