### PR TITLE
Make CallbackDisposable guarantee dispose callback only gets called once

### DIFF
--- a/src/Disposable/CallbackDisposable.php
+++ b/src/Disposable/CallbackDisposable.php
@@ -9,6 +9,7 @@ use Rx\DisposableInterface;
 class CallbackDisposable implements DisposableInterface
 {
     private $action;
+    private $disposed = false;
 
     public function __construct(callable $action)
     {
@@ -17,6 +18,10 @@ class CallbackDisposable implements DisposableInterface
 
     public function dispose()
     {
+        if ($this->disposed) {
+            return;
+        }
+        $this->disposed = true;
         $call = $this->action;
         $call();
     }

--- a/src/Observable/ConnectableObservable.php
+++ b/src/Observable/ConnectableObservable.php
@@ -54,13 +54,7 @@ class ConnectableObservable extends Observable
 
         $this->hasSubscription = true;
 
-        $isDisposed = false;
-
-        $connectableDisposable = new CallbackDisposable(function () use (&$isDisposed) {
-            if ($isDisposed) {
-                return;
-            }
-            $isDisposed            = true;
+        $connectableDisposable = new CallbackDisposable(function () {
             $this->hasSubscription = false;
         });
 

--- a/src/Observable/RefCountObservable.php
+++ b/src/Observable/RefCountObservable.php
@@ -41,15 +41,7 @@ class RefCountObservable extends Observable
             $this->connectableSubscription = $this->source->connect();
         }
 
-        $isDisposed = false;
-
-        return new CallbackDisposable(function () use ($subscription, &$isDisposed) {
-            if ($isDisposed) {
-                return;
-            }
-
-            $isDisposed = true;
-
+        return new CallbackDisposable(function () use ($subscription) {
             $subscription->dispose();
 
             $this->count--;

--- a/test/Rx/Disposable/CallbackDisposableTest.php
+++ b/test/Rx/Disposable/CallbackDisposableTest.php
@@ -23,4 +23,29 @@ class CallbackDisposableTest extends TestCase
         $this->assertTrue($disposed);
     }
 
+    /**
+     * @test
+     */
+    public function it_only_disposes_once()
+    {
+        $disposed    = false;
+        $invocations = 0;
+        $disposable  = new CallbackDisposable(function () use (&$disposed, &$invocations) {
+            $invocations++;
+            $disposed = true;
+        });
+
+        $this->assertFalse($disposed);
+
+        $disposable->dispose();
+
+        $this->assertTrue($disposed);
+        $this->assertEquals(1, $invocations);
+
+        $disposable->dispose();
+
+        $this->assertTrue($disposed);
+        $this->assertEquals(1, $invocations);
+    }
+
 }

--- a/test/Rx/Testing/HotObservableTest.php
+++ b/test/Rx/Testing/HotObservableTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Rx\Testing;
+
+use Rx\TestCase;
+
+class HotObservableTest extends TestCase
+{
+    public function testRemovingObserverThatNeverSubscribed()
+    {
+        $scheduler = new TestScheduler();
+
+        $hotObservable = new HotObservable($scheduler, []);
+
+        $observer = new MockObserver($scheduler);
+
+        $this->assertFalse($hotObservable->removeObserver($observer));
+    }
+}


### PR DESCRIPTION
The `CallbackDisposable` should guarantee that the disposal callback is only called once.

This PR removes some unreachable code caused by the change and also adds some testing to bring code coverage back to 100%.