### PR TITLE
Allow plucking of multiple items at once

### DIFF
--- a/src/Observable.php
+++ b/src/Observable.php
@@ -1892,6 +1892,11 @@ abstract class Observable implements ObservableInterface
      */
     public function pluck($property): Observable
     {
+        $args = func_get_args();
+        if (count($args) > 1) {
+            return call_user_func_array([$this->pluck(array_shift($args)), 'pluck'], $args);
+        }
+
         return $this->map(function ($x) use ($property) {
             if (is_array($x) && isset($x[$property])) {
                 return $x[$property];

--- a/test/Rx/Functional/Operator/PluckTest.php
+++ b/test/Rx/Functional/Operator/PluckTest.php
@@ -192,4 +192,66 @@ class PluckTest extends FunctionalTestCase
             subscribe(200, 400)
         ], $xs->getSubscriptions());
     }
+
+    /**
+     * @test
+     */
+    public function pluck_nested()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, [-1,-1,-1,-1]),
+            onNext(210, [[1],[2],[3]]),
+            onNext(240, [[4],[5],[6]]),
+            onNext(290, [[7],[8],[9]]),
+            onNext(350, [[10],[11],[12]]),
+            onCompleted(400)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck(1, 0);
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 5),
+            onNext(290, 8),
+            onNext(350, 11),
+            onCompleted(400)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 400)
+        ], $xs->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
+    public function pluck_nested_numeric_key_with_object_properties()
+    {
+        $xs = $this->createHotObservable([
+            onNext(180, [-1,-1,-1,-1]),
+            onNext(210, [[1],(object)['prop' => 2],[3]]),
+            onNext(240, [[4],(object)['prop' => 5],[6]]),
+            onNext(290, [[7],(object)['prop' => 8],[9]]),
+            onNext(350, [[10],(object)['prop' => 11],[12]]),
+            onCompleted(400)
+        ]);
+
+        $results = $this->scheduler->startWithCreate(function () use ($xs) {
+            return $xs->pluck(1, 'prop');
+        });
+
+        $this->assertMessages([
+            onNext(210, 2),
+            onNext(240, 5),
+            onNext(290, 8),
+            onNext(350, 11),
+            onCompleted(400)
+        ], $results->getMessages());
+
+        $this->assertSubscriptions([
+            subscribe(200, 400)
+        ], $xs->getSubscriptions());
+    }
 }


### PR DESCRIPTION
This PR allows you to use pluck to pluck multiple levels deep:

```php
$x = [
    [
        [
            (object)[
                "something" => "Hello"
            ]
        ]
    ]
];

Rx\Observable::fromArray($x)->pluck(0, 0, 'something')->subscribe(function ($x) {
    echo $x;
});
```