### PR TITLE
Testing higher-order Observables

### DIFF
--- a/lib/Rx/Notification/OnNextObservableNotification.php
+++ b/lib/Rx/Notification/OnNextObservableNotification.php
@@ -11,14 +11,14 @@ class OnNextObservableNotification extends OnNextNotification
     /** @var MockHigherOrderObserver */
     private $observer;
 
-    public function __construct($value, TestScheduler $scheduler = null, $startTime = 0)
+    public function __construct($value, TestScheduler $scheduler = null)
     {
         parent::__construct($value);
         if (!$scheduler) {
             $scheduler = new TestScheduler();
         }
 
-        $this->observer = new MockHigherOrderObserver($scheduler, $startTime);
+        $this->observer = new MockHigherOrderObserver($scheduler, $scheduler->getClock());
 
         /** @var Observable $value */
         $value->subscribe($this->observer, $scheduler);

--- a/lib/Rx/Notification/OnNextObservableNotification.php
+++ b/lib/Rx/Notification/OnNextObservableNotification.php
@@ -3,13 +3,12 @@
 namespace Rx\Notification;
 
 use Rx\Observable;
-use Rx\SchedulerInterface;
-use Rx\Testing\MockObserver;
+use Rx\Testing\MockHigherOrderObserver;
 use Rx\Testing\TestScheduler;
 
 class OnNextObservableNotification extends OnNextNotification
 {
-    /** @var MockObserver */
+    /** @var MockHigherOrderObserver */
     private $observer;
 
     public function __construct($value, TestScheduler $scheduler = null, $startTime = 0)
@@ -19,7 +18,7 @@ class OnNextObservableNotification extends OnNextNotification
             $scheduler = new TestScheduler();
         }
 
-        $this->observer = new MockObserver($scheduler, $startTime);
+        $this->observer = new MockHigherOrderObserver($scheduler, $startTime);
 
         /** @var Observable $value */
         $value->subscribe($this->observer, $scheduler);

--- a/lib/Rx/Notification/OnNextObservableNotification.php
+++ b/lib/Rx/Notification/OnNextObservableNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rx\Notification;
+
+use Rx\Observable;
+use Rx\SchedulerInterface;
+use Rx\Testing\MockObserver;
+use Rx\Testing\TestScheduler;
+
+class OnNextObservableNotification extends OnNextNotification
+{
+    /** @var MockObserver */
+    private $observer;
+
+    public function __construct($value, TestScheduler $scheduler = null, $startTime = 0)
+    {
+        parent::__construct($value);
+        if (!$scheduler) {
+            $scheduler = new TestScheduler();
+        }
+
+        $this->observer = new MockObserver($scheduler, $startTime);
+
+        /** @var Observable $value */
+        $value->subscribe($this->observer, $scheduler);
+
+        $scheduler->start();
+    }
+
+    public function equals($other)
+    {
+        $messages1 = $this->getMessages();
+        /** @var OnNextObservableNotification $other */
+        $messages2 = $other->getMessages();
+
+        if (count($messages1) != count($messages2)) {
+            return false;
+        }
+
+        for ($i = 0; $i < count($messages1); $i++) {
+            if (!$messages1[$i]->equals($messages2[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function getMessages()
+    {
+        return $this->observer->getMessages();
+    }
+
+    public function __toString()
+    {
+        return '[' . join(', ', $this->getMessages()) . ']';
+    }
+}

--- a/lib/Rx/Testing/ColdObservable.php
+++ b/lib/Rx/Testing/ColdObservable.php
@@ -22,12 +22,12 @@ class ColdObservable extends Observable
 
     public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
-        $this->subscriptions[] = new Subscription($this->scheduler->getClock());
+        $scheduler             = $scheduler ?: $this->scheduler;
+        $this->subscriptions[] = new Subscription($scheduler->getClock());
         $index                 = count($this->subscriptions) - 1;
 
         $currentObservable = $this;
         $disposable        = new CompositeDisposable();
-        $scheduler         = $this->scheduler;
         $isDisposed        = false;
 
         foreach ($this->messages as $message) {

--- a/lib/Rx/Testing/ColdObservable.php
+++ b/lib/Rx/Testing/ColdObservable.php
@@ -22,13 +22,16 @@ class ColdObservable extends Observable
 
     public function subscribe(ObserverInterface $observer, $scheduler = null)
     {
-        $scheduler             = $scheduler ?: $this->scheduler;
-        $this->subscriptions[] = new Subscription($scheduler->getClock());
-        $index                 = count($this->subscriptions) - 1;
-
+        $scheduler         = $scheduler ?: $this->scheduler;
         $currentObservable = $this;
         $disposable        = new CompositeDisposable();
         $isDisposed        = false;
+        $index             = null;
+
+        if (!($observer instanceof MockHigherOrderObserver)) {
+            $this->subscriptions[] = new Subscription($scheduler->getClock());
+            $index = count($this->subscriptions) - 1;
+        }
 
         foreach ($this->messages as $message) {
             $notification = $message->getValue();
@@ -50,7 +53,9 @@ class ColdObservable extends Observable
 
         return new CallbackDisposable(function () use (&$currentObservable, $index, $observer, $scheduler, &$subscriptions, &$isDisposed) {
             $isDisposed            = true;
-            $subscriptions[$index] = new Subscription($subscriptions[$index]->getSubscribed(), $scheduler->getClock());
+            if (!($observer instanceof MockHigherOrderObserver)) {
+                $subscriptions[$index] = new Subscription($subscriptions[$index]->getSubscribed(), $scheduler->getClock());
+            }
         });
 
     }

--- a/lib/Rx/Testing/HotObservable.php
+++ b/lib/Rx/Testing/HotObservable.php
@@ -43,17 +43,22 @@ class HotObservable extends Observable
     {
         $currentObservable = $this;
 
-        $this->observers[]     = $observer;
-        $this->subscriptions[] = new Subscription($this->scheduler->getClock());
+        $this->observers[] = $observer;
+        $subscriptions     = &$this->subscriptions;
+        $index             = null;
 
-        $subscriptions = &$this->subscriptions;
+        if (!($observer instanceof MockHigherOrderObserver)) {
+            $this->subscriptions[] = new Subscription($this->scheduler->getClock());
+            $index = count($this->subscriptions) - 1;
+        }
 
-        $index     = count($this->subscriptions) - 1;
         $scheduler = $this->scheduler;
 
         return new CallbackDisposable(function () use (&$currentObservable, $index, $observer, $scheduler, &$subscriptions) {
             $currentObservable->removeObserver($observer);
-            $subscriptions[$index] = new Subscription($subscriptions[$index]->getSubscribed(), $scheduler->getClock());
+            if (!($observer instanceof MockHigherOrderObserver)) {
+                $subscriptions[$index] = new Subscription($subscriptions[$index]->getSubscribed(), $scheduler->getClock());
+            }
         });
     }
 

--- a/lib/Rx/Testing/MockHigherOrderObserver.php
+++ b/lib/Rx/Testing/MockHigherOrderObserver.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx\Testing;
+
+class MockHigherOrderObserver extends MockObserver
+{
+}

--- a/lib/Rx/Testing/MockObserver.php
+++ b/lib/Rx/Testing/MockObserver.php
@@ -32,7 +32,7 @@ class MockObserver implements ObserverInterface
     public function onNext($value)
     {
         if ($value instanceof Observable) {
-            $notification = new OnNextObservableNotification($value, $this->scheduler, $this->scheduler->getClock());
+            $notification = new OnNextObservableNotification($value, $this->scheduler);
         } else {
             $notification = new OnNextNotification($value);
         }

--- a/test/Rx/Testing/RecordedTest.php
+++ b/test/Rx/Testing/RecordedTest.php
@@ -51,6 +51,35 @@ class RecordedTest extends FunctionalTestCase
     /**
      * @test
      */
+    public function automatic_mock_observer_doesnt_create_loggable_subscription()
+    {
+        $inner = $this->createColdObservable([
+            onNext(150, 1),
+            onNext(200, 2),
+            onNext(250, 3),
+            onCompleted(300),
+        ]);
+        // Thanks to OnNextObservableNotification this internally creates
+        // an instance of MockHigherOrderObserver which is not logged
+        // by the ColdObservable::subscribe() method.
+        $records = onNext(100, $inner);
+
+        $expected = onNext(100, $this->createColdObservable([
+            onNext(150, 1),
+            onNext(200, 2),
+            onNext(250, 3),
+            onCompleted(300),
+        ]));
+
+        $this->assertTrue($records->equals($expected));
+        $this->assertMessages([$records], [$expected]);
+
+        $this->assertSubscriptions([], $inner->getSubscriptions());
+    }
+
+    /**
+     * @test
+     */
     public function compare_with_range_cold_observable()
     {
         $records1 = onNext(100, Observable::range(1, 3));

--- a/test/Rx/Testing/RecordedTest.php
+++ b/test/Rx/Testing/RecordedTest.php
@@ -31,13 +31,13 @@ class RecordedTest extends FunctionalTestCase
      */
     public function compare_cold_observables()
     {
-        $records1 = onNextObservable(100, $this->createColdObservable([
+        $records1 = onNext(100, $this->createColdObservable([
             onNext(150, 1),
             onNext(200, 2),
             onNext(250, 3),
             onCompleted(300),
         ]));
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(150, 1),
             onNext(200, 2),
             onNext(250, 3),
@@ -53,8 +53,8 @@ class RecordedTest extends FunctionalTestCase
      */
     public function compare_with_range_cold_observable()
     {
-        $records1 = onNextObservable(100, Observable::range(1, 3));
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records1 = onNext(100, Observable::range(1, 3));
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(1, 1),
             onNext(2, 2),
             onNext(3, 3),
@@ -69,14 +69,14 @@ class RecordedTest extends FunctionalTestCase
      */
     public function compare_with_delayed_range_cold_observable()
     {
-        $records1 = onNextObservable(100, $this->createColdObservable([
+        $records1 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
             onNext(150, 3),
             onCompleted(200)
         ])->delay(100));
 
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(150, 1),
             onNext(200, 2),
             onNext(250, 3),
@@ -91,11 +91,11 @@ class RecordedTest extends FunctionalTestCase
      */
     public function observables_at_different_time_with_same_records_arent_equal()
     {
-        $records1 = onNextObservable(50, $this->createColdObservable([
+        $records1 = onNext(50, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
         ]));
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
         ]));
@@ -109,11 +109,11 @@ class RecordedTest extends FunctionalTestCase
      */
     public function observables_with_inner_records_at_different_time_arent_equal()
     {
-        $records1 = onNextObservable(100, $this->createColdObservable([
+        $records1 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(150, 2),
         ]));
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
         ]));
@@ -127,25 +127,25 @@ class RecordedTest extends FunctionalTestCase
      */
     public function observables_with_more_nested_inner_observables()
     {
-        $records1 = onNextObservable(100, $this->createColdObservable([
+        $records1 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
-            onNextObservable(150, $this->createColdObservable([
+            onNext(150, $this->createColdObservable([
                 onNext(10, 3),
                 onNext(20, 4),
-                onNextObservable(30, $this->createColdObservable([
+                onNext(30, $this->createColdObservable([
                     onNext(10, 5),
                     onNext(20, 6),
                 ])),
             ])->delay(100)),
         ]));
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
-            onNextObservable(150, $this->createColdObservable([
+            onNext(150, $this->createColdObservable([
                 onNext(110, 3),
                 onNext(120, 4),
-                onNextObservable(130, $this->createColdObservable([
+                onNext(130, $this->createColdObservable([
                     onNext(10, 5),
                     onNext(20, 6),
                 ])),
@@ -173,13 +173,13 @@ class RecordedTest extends FunctionalTestCase
                 ])),
             ])->delay(100)),
         ]));
-        $records2 = onNextObservable(100, $this->createColdObservable([
+        $records2 = onNext(100, $this->createColdObservable([
             onNext(50, 1),
             onNext(100, 2),
-            onNextObservable(150, $this->createColdObservable([
+            onNext(150, $this->createColdObservable([
                 onNext(110, 3),
                 onNext(120, 4),
-                onNextObservable(130, $this->createColdObservable([
+                onNext(130, $this->createColdObservable([
                     onNext(10, 5),
                     onNext(20, 42), // this is wrong
                 ])),

--- a/test/Rx/Testing/RecordedTest.php
+++ b/test/Rx/Testing/RecordedTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Rx\Testing;
+
+use Rx\Functional\FunctionalTestCase;
+use Rx\Observable;
+
+class RecordedTest extends FunctionalTestCase
+{
+
+    /**
+     * @test
+     */
+    public function compare_basic_types()
+    {
+        $r1 = new Recorded(100, 42);
+        $r2 = new Recorded(100, 42);
+        $this->assertTrue($r1->equals($r2));
+
+        $r3 = new Recorded(100, 42);
+        $r4 = new Recorded(150, 42);
+        $this->assertFalse($r3->equals($r4));
+
+        $r5 = new Recorded(100, 42);
+        $r6 = new Recorded(100, 24);
+        $this->assertFalse($r5->equals($r6));
+    }
+
+    /**
+     * @test
+     */
+    public function compare_cold_observables()
+    {
+        $records1 = onNextObservable(100, $this->createColdObservable([
+            onNext(150, 1),
+            onNext(200, 2),
+            onNext(250, 3),
+            onCompleted(300),
+        ]));
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(150, 1),
+            onNext(200, 2),
+            onNext(250, 3),
+            onCompleted(300),
+        ]));
+
+        $this->assertTrue($records1->equals($records2));
+        $this->assertMessages([$records1], [$records2]);
+    }
+
+    /**
+     * @test
+     */
+    public function compare_with_range_cold_observable()
+    {
+        $records1 = onNextObservable(100, Observable::range(1, 3));
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(1, 1),
+            onNext(2, 2),
+            onNext(3, 3),
+            onCompleted(4),
+        ]));
+
+        $this->assertMessages([$records1], [$records2]);
+    }
+
+    /**
+     * @test
+     */
+    public function compare_with_delayed_range_cold_observable()
+    {
+        $records1 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+            onNext(150, 3),
+            onCompleted(200)
+        ])->delay(100));
+
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(150, 1),
+            onNext(200, 2),
+            onNext(250, 3),
+            onCompleted(300),
+        ]));
+
+        $this->assertMessages([$records1], [$records2]);
+    }
+
+    /**
+     * @test
+     */
+    public function observables_at_different_time_with_same_records_arent_equal()
+    {
+        $records1 = onNextObservable(50, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+        ]));
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+        ]));
+
+        $this->assertFalse($records1->equals($records2));
+        $this->assertEquals('[OnNext(1)@50, OnNext(2)@100]@50', $records1->__toString());
+    }
+
+    /**
+     * @test
+     */
+    public function observables_with_inner_records_at_different_time_arent_equal()
+    {
+        $records1 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(150, 2),
+        ]));
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+        ]));
+
+        $this->assertFalse($records1->equals($records2));
+        $this->assertEquals('[OnNext(1)@50, OnNext(2)@150]@100', $records1->__toString());
+    }
+
+    /**
+     * @test
+     */
+    public function observables_with_more_nested_inner_observables()
+    {
+        $records1 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+            onNextObservable(150, $this->createColdObservable([
+                onNext(10, 3),
+                onNext(20, 4),
+                onNextObservable(30, $this->createColdObservable([
+                    onNext(10, 5),
+                    onNext(20, 6),
+                ])),
+            ])->delay(100)),
+        ]));
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+            onNextObservable(150, $this->createColdObservable([
+                onNext(110, 3),
+                onNext(120, 4),
+                onNextObservable(130, $this->createColdObservable([
+                    onNext(10, 5),
+                    onNext(20, 6),
+                ])),
+            ])),
+        ]));
+
+        $this->assertTrue($records1->equals($records2));
+        $this->assertMessages([$records1], [$records2]);
+    }
+
+    /**
+     * @test
+     */
+    public function observables_with_difference_in_nested_inner_observables()
+    {
+        $records1 = onNext(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+            onNext(150, $this->createColdObservable([
+                onNext(10, 3),
+                onNext(20, 4),
+                onNext(30, $this->createColdObservable([
+                    onNext(10, 5),
+                    onNext(20, 6),
+                ])),
+            ])->delay(100)),
+        ]));
+        $records2 = onNextObservable(100, $this->createColdObservable([
+            onNext(50, 1),
+            onNext(100, 2),
+            onNextObservable(150, $this->createColdObservable([
+                onNext(110, 3),
+                onNext(120, 4),
+                onNextObservable(130, $this->createColdObservable([
+                    onNext(10, 5),
+                    onNext(20, 42), // this is wrong
+                ])),
+            ])),
+        ]));
+
+        $this->assertFalse($records1->equals($records2));
+    }
+
+}

--- a/test/helper-functions.php
+++ b/test/helper-functions.php
@@ -3,7 +3,6 @@
 use Rx\Observable;
 use Rx\Testing\Recorded;
 use Rx\Testing\Subscription;
-use Rx\Testing\TestScheduler;
 use Rx\Notification\OnCompletedNotification;
 use Rx\Notification\OnErrorNotification;
 use Rx\Notification\OnNextNotification;
@@ -33,4 +32,3 @@ function subscribe($start, $end = null) {
 function RxIdentity($x) {
     return $x;
 }
-

--- a/test/helper-functions.php
+++ b/test/helper-functions.php
@@ -1,10 +1,13 @@
 <?php
 
+use Rx\Observable;
 use Rx\Testing\Recorded;
 use Rx\Testing\Subscription;
+use Rx\Testing\TestScheduler;
 use Rx\Notification\OnCompletedNotification;
 use Rx\Notification\OnErrorNotification;
 use Rx\Notification\OnNextNotification;
+use Rx\Notification\OnNextObservableNotification;
 
 function onError($dueTime, $error, $comparer = null) {
     return new Recorded($dueTime, new OnErrorNotification($error), $comparer);
@@ -12,6 +15,10 @@ function onError($dueTime, $error, $comparer = null) {
 
 function onNext($dueTime, $value, $comparer = null) {
     return new Recorded($dueTime, new OnNextNotification($value), $comparer);
+}
+
+function onNextObservable($dueTime, $value, $comparer = null) {
+    return new Recorded($dueTime, new OnNextObservableNotification($value), $comparer);
 }
 
 function onCompleted($dueTime, $comparer = null) {
@@ -25,3 +32,4 @@ function subscribe($start, $end = null) {
 function RxIdentity($x) {
     return $x;
 }
+

--- a/test/helper-functions.php
+++ b/test/helper-functions.php
@@ -14,11 +14,12 @@ function onError($dueTime, $error, $comparer = null) {
 }
 
 function onNext($dueTime, $value, $comparer = null) {
-    return new Recorded($dueTime, new OnNextNotification($value), $comparer);
-}
-
-function onNextObservable($dueTime, $value, $comparer = null) {
-    return new Recorded($dueTime, new OnNextObservableNotification($value), $comparer);
+    if ($value instanceof Observable) {
+        $notification = new OnNextObservableNotification($value);
+    } else {
+        $notification = new OnNextNotification($value);
+    }
+    return new Recorded($dueTime, $notification, $comparer);
 }
 
 function onCompleted($dueTime, $comparer = null) {


### PR DESCRIPTION
I was implementing the `window()` operator and I realized I've encountered a situation that wasn't tested before. That's higher-order Observables and in particular operators that emit Observables where I need to test that these Observables emit correct items themselves.

This PR lets me write tests for `window()` operator like the following:

```
$xs = $this->createHotObservable([
    onNext(225, 1),
    onNext(250, 2),
    onNext(300, 3),
    ...
]);

$results = $this->scheduler->startWithCreate(function() use ($xs, $window) {
    return $xs->window($window);
});

$window = $this->createHotObservable([
    onNext(325, 1),
   ...
]);

$this->assertMessages([
    onNext(200, $this->createColdObservable([
        onNext(25, 1),
        onNext(50, 2),
        onNext(100, 3),
        onCompleted(125),
    ])),
    ...
```

https://github.com/martinsik/RxPHP/blob/window-operator/test/Rx/Functional/Operator/WindowTest.php

The most important part is this:
```
onNext(200, $this->createColdObservable([
    onNext(25, 1),
    onNext(50, 2),
    onNext(100, 3),
```

There's a new `OnNextObservableNotification` that automatically subscribes to an Observable and all items are recorded with timestamps relative to its parent. Then these automatic subscriptions are ignored by the `ColdObservable`. I've actually spent quite some time scratching my head around how to implement this in the most comfortable and easy to use way. Ideally if I didn't need to think about it at all and use Observables just like any other values.

If I didn't miss anything this should allow fluent porting from RxJS 5 marble tests ([eg. window-spec.ts](https://github.com/ReactiveX/rxjs/blob/master/spec/operators/window-spec.ts)) where they treat Observables like values. For example this should work in RxPHP as well:

```
const expected =     'x------------y------------z------------|    ';
const x = cold(      '---a---b---c-|                              ');
const y = cold(                   '--d---e---f--|                 ');
const z = cold(                                '-g---h---i---|    ');
const expectedValues = { x: x, y: y, z: z };
```

Using this with ReactiveX/RxPHP#133 shouldn't be any problem.

Also, I didn't need to modify any existing tests including those that use higher-order Observables as input such as [`MergeAllTest.php`](https://github.com/ReactiveX/RxPHP/blob/master/test/Rx/Functional/Operator/MergeAllTest.php).