### PR TITLE
[WIP] Rework Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,13 @@ $ php demo/interval/interval.php
 
 Have fun running the demos in `/demo`.
 
-note:  The demos are automatically run within `Loop::execute`.  When using RxPHP within your own project, you'll need to install a [loop implementation](https://packagist.org/providers/async-interop/event-loop-implementation).  
+note:  When running the demos, the scheduler is automatically bootstrapped.  When using RxPHP within your own project, you'll need to set the default scheduler; 
 
 ## Installation
-1. Install one [async-interop event loop](https://packagist.org/providers/async-interop/event-loop-implementation) implementation.
+1. Install an event loop.  Any event loop should work, but the ReactPHP event loop is recommended.
 
-With ReactPHP:
 ```bash
-$ composer require wyrihaximus/react-async-interop-loop
-```
-With amphp:
-```bash
-$ composer require amphp/loop:dev-master
-```
-With KoolKode:
-```bash
-$ composer require koolkode/async
+$ composer require react/event-loop
 ```
 
 2. Install RxPHP using [composer](https://getcomposer.org).
@@ -70,7 +61,7 @@ $ composer require koolkode/async
 $ composer require reactivex/rxphp:2.x-dev
 ```
 
-3. Write some code
+3. Write some code.
 
 ```PHP
 <?php
@@ -78,20 +69,26 @@ $ composer require reactivex/rxphp:2.x-dev
 require_once __DIR__ . '/vendor/autoload.php';
 
 use Rx\Observable;
-use Interop\Async\Loop;
+use React\EventLoop\Factory;
+use Rx\Scheduler;
 
-Loop::execute(function () {
+$loop      = Factory::create();
+$scheduler = new Scheduler\EventLoopScheduler($loop);
 
-    Observable::interval(1000)
-        ->take(5)
-        ->flatMap(function ($i) {
-            return Observable::of($i + 1);
-        })
-        ->subscribe(function ($e) {
-            echo $e, PHP_EOL;
-        });
+//You only need to set the default scheduler once
+Scheduler::setDefault($scheduler);
 
-});
+Observable::interval(1000)
+    ->take(5)
+    ->flatMap(function ($i) {
+        return Observable::of($i + 1);
+    })
+    ->subscribe(function ($e) {
+        echo $e, PHP_EOL;
+    });
+
+$loop->run();
+
 ```
 ## Working with Promises
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "phpunit/phpunit": "^5.5",
         "react/event-loop": "^0.4.2"
     },
+    "suggest": {
+        "react/event-loop": "Used for scheduling async operations"
+    },
     "autoload": {
         "psr-4": { "Rx\\": "src" }
     },

--- a/composer.json
+++ b/composer.json
@@ -21,22 +21,19 @@
     ],
     "require": {
         "php": "~7.0",
-        "async-interop/promise": "^0.3",
-        "async-interop/event-loop": "^0.4",
-        "async-interop/event-loop-implementation": "^0.4"
+        "async-interop/promise": "^0.3"
     },
     "require-dev": {
-        "wyrihaximus/react-async-interop-loop": "^0.2.1",
         "satooshi/php-coveralls": "~1.0",
         "phpunit/phpcov": "^3.1",
-        "phpunit/phpunit": "^5.5"
+        "phpunit/phpunit": "^5.5",
+        "react/event-loop": "^0.4.2"
     },
     "autoload": {
         "psr-4": { "Rx\\": "src" }
     },
     "autoload-dev": {
         "files": [
-            "test/loop-auto-start.php",
             "test/helper-functions.php"
         ],
         "psr-4": {

--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -9,6 +9,9 @@
  * file that was distributed with this source code.
  */
 
+use React\EventLoop\Factory;
+use Rx\Scheduler;
+
 if (file_exists($file = __DIR__.'/../vendor/autoload.php')) {
     $autoload = require_once $file;
     $autoload->addPsr4('Vendor\\Rx\\Operator\\', __DIR__ . '/custom-operator');
@@ -33,5 +36,10 @@ $createStdoutObserver = function ($prefix = '') {
     );
 };
 
-
 $stdoutObserver = $createStdoutObserver();
+
+$loop = Factory::create();
+Scheduler::setDefault(new Scheduler\EventLoopScheduler($loop));
+register_shutdown_function(function () use ($loop) {
+    $loop->run();
+});

--- a/demo/recursive-scheduler/recursive-scheduler.php
+++ b/demo/recursive-scheduler/recursive-scheduler.php
@@ -2,7 +2,6 @@
 
 require_once __DIR__ . '/../bootstrap.php';
 
-use Interop\Async\Loop;
 use Rx\Observable;
 
 class RecursiveReturnObservable extends Observable

--- a/src/AsyncSchedulerInterface.php
+++ b/src/AsyncSchedulerInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Rx;
+
+interface AsyncSchedulerInterface extends SchedulerInterface
+{
+}

--- a/src/Observable.php
+++ b/src/Observable.php
@@ -1070,14 +1070,14 @@ abstract class Observable implements ObservableInterface
      * Returns an observable sequence that produces a value after dueTime has elapsed.
      *
      * @param integer $dueTime - milliseconds
-     * @param SchedulerInterface $scheduler
+     * @param AsyncSchedulerInterface $scheduler
      * @return TimerObservable
      *
      * @demo timer/timer.php
      * @operator
      * @reactivex timer
      */
-    public static function timer(int $dueTime, SchedulerInterface $scheduler = null): TimerObservable
+    public static function timer(int $dueTime, AsyncSchedulerInterface $scheduler = null): TimerObservable
     {
         return new TimerObservable($dueTime, $scheduler ?: Scheduler::getAsync());
     }
@@ -1561,14 +1561,14 @@ abstract class Observable implements ObservableInterface
      *
      * @param $timeout
      * @param ObservableInterface $timeoutObservable
-     * @param SchedulerInterface $scheduler
+     * @param AsyncSchedulerInterface $scheduler
      * @return Observable
      *
      * @demo timeout/timeout.php
      * @operator
      * @reactivex timeout
      */
-    public function timeout(int $timeout, ObservableInterface $timeoutObservable = null, SchedulerInterface $scheduler = null): Observable
+    public function timeout(int $timeout, ObservableInterface $timeoutObservable = null, AsyncSchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($timeout, $timeoutObservable, $scheduler) {
             return new TimeoutOperator($timeout, $timeoutObservable, $scheduler ?: Scheduler::getAsync());

--- a/src/Observable.php
+++ b/src/Observable.php
@@ -141,14 +141,14 @@ abstract class Observable implements ObservableInterface
      * Returns an Observable that emits an infinite sequence of ascending integers starting at 0, with a constant interval of time of your choosing between emissions.
      *
      * @param $interval int Period for producing the values in the resulting sequence (specified as an integer denoting milliseconds).
-     * @param SchedulerInterface|null $scheduler
+     * @param null|AsyncSchedulerInterface|SchedulerInterface $scheduler
      * @return IntervalObservable An observable sequence that produces a value after each period.
      *
      * @demo interval/interval.php
      * @operator
      * @reactivex interval
      */
-    public static function interval(int $interval, $scheduler = null): IntervalObservable
+    public static function interval(int $interval, AsyncSchedulerInterface $scheduler = null): IntervalObservable
     {
         return new IntervalObservable($interval, $scheduler ?: Scheduler::getAsync());
     }
@@ -1541,14 +1541,14 @@ abstract class Observable implements ObservableInterface
      * Time shifts the observable sequence by dueTime. The relative time intervals between the values are preserved.
      *
      * @param $delay
-     * @param SchedulerInterface|null $scheduler
+     * @param AsyncSchedulerInterface|null $scheduler
      * @return Observable
      *
      * @demo delay/delay.php
      * @operator
      * @reactivex delay
      */
-    public function delay(int $delay, SchedulerInterface $scheduler = null): Observable
+    public function delay(int $delay, AsyncSchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($delay, $scheduler) {
             return new DelayOperator($delay, $scheduler ?: Scheduler::getAsync());

--- a/src/Observable/IntervalObservable.php
+++ b/src/Observable/IntervalObservable.php
@@ -7,21 +7,21 @@ namespace Rx\Observable;
 use Rx\DisposableInterface;
 use Rx\Observable;
 use Rx\ObserverInterface;
-use Rx\SchedulerInterface;
+use Rx\AsyncSchedulerInterface;
 
 class IntervalObservable extends Observable
 {
     private $interval;
 
-    /** @var SchedulerInterface */
+    /** @var AsyncSchedulerInterface */
     private $scheduler;
 
     /**
      * IntervalObservable constructor.
      * @param $interval
-     * @param SchedulerInterface $scheduler
+     * @param AsyncSchedulerInterface $scheduler
      */
-    public function __construct(int $interval, SchedulerInterface $scheduler)
+    public function __construct(int $interval, AsyncSchedulerInterface $scheduler)
     {
         $this->interval  = $interval;
         $this->scheduler = $scheduler;

--- a/src/Observable/TimerObservable.php
+++ b/src/Observable/TimerObservable.php
@@ -7,7 +7,7 @@ namespace Rx\Observable;
 use Rx\DisposableInterface;
 use Rx\Observable;
 use Rx\ObserverInterface;
-use Rx\SchedulerInterface;
+use Rx\AsyncSchedulerInterface;
 
 class TimerObservable extends Observable
 {
@@ -15,7 +15,7 @@ class TimerObservable extends Observable
 
     private $scheduler;
 
-    public function __construct(int $dueTime, SchedulerInterface $scheduler)
+    public function __construct(int $dueTime, AsyncSchedulerInterface $scheduler)
     {
         $this->dueTime   = $dueTime;
         $this->scheduler = $scheduler;

--- a/src/Operator/DelayOperator.php
+++ b/src/Operator/DelayOperator.php
@@ -11,7 +11,7 @@ use Rx\Observable\AnonymousObservable;
 use Rx\ObservableInterface;
 use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
-use Rx\SchedulerInterface;
+use Rx\AsyncSchedulerInterface;
 use Rx\Timestamped;
 
 final class DelayOperator implements OperatorInterface
@@ -25,10 +25,10 @@ final class DelayOperator implements OperatorInterface
     /** @var DisposableInterface */
     private $schedulerDisposable;
 
-    /** @var SchedulerInterface */
+    /** @var AsyncSchedulerInterface */
     private $scheduler;
 
-    public function __construct(int $delayTime, SchedulerInterface $scheduler)
+    public function __construct(int $delayTime, AsyncSchedulerInterface $scheduler)
     {
         $this->delayTime = $delayTime;
         $this->queue     = new \SplQueue();

--- a/src/Operator/TimeoutOperator.php
+++ b/src/Operator/TimeoutOperator.php
@@ -11,7 +11,7 @@ use Rx\Observable\ErrorObservable;
 use Rx\ObservableInterface;
 use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
-use Rx\SchedulerInterface;
+use Rx\AsyncSchedulerInterface;
 use Rx\Exception\TimeoutException;
 
 final class TimeoutOperator implements OperatorInterface
@@ -22,7 +22,7 @@ final class TimeoutOperator implements OperatorInterface
 
     private $timeoutObservable;
 
-    public function __construct(int $timeout, ObservableInterface $timeoutObservable = null, SchedulerInterface $scheduler)
+    public function __construct(int $timeout, ObservableInterface $timeoutObservable = null, AsyncSchedulerInterface $scheduler)
     {
         $this->timeout           = $timeout;
         $this->scheduler         = $scheduler;

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Rx;
 
-use Rx\Scheduler\EventLoopScheduler;
 use Rx\Scheduler\ImmediateScheduler;
 
 class Scheduler

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -15,27 +15,39 @@ class Scheduler
 
     public static function getDefault(): SchedulerInterface
     {
-        if (!static::$default) {
-            static::$default = new EventLoopScheduler();
+        if (static::$default) {
+            return static::$default;
         }
 
-        return static::$default;
+        throw new \Exception(
+            "Please set a default scheduler (for react: Scheduler::setDefault(new EventLoopScheduler(\$loop));"
+        );
     }
 
     public static function setDefault(SchedulerInterface $scheduler)
     {
         if (static::$default !== null) {
-            throw new \Exception("Scheduler can only be set once. (Are you calling set after get?)");
+            throw new \Exception("Scheduler can only be set once.");
         }
+
         static::$default = $scheduler;
     }
 
-    public static function getAsync(): SchedulerInterface
+    public static function getAsync(): AsyncSchedulerInterface
     {
-        if (!static::$async) {
-            static::$async = new EventLoopScheduler();
+        if (static::$async) {
+            return static::$async;
         }
-        return self::$async;
+
+        if (static::$default instanceof AsyncSchedulerInterface) {
+            static::$async = static::$default;
+
+            return static::$async;
+        }
+
+        throw new \Exception(
+            "Please set an async scheduler (for react: Scheduler::setAsync(new EventLoopScheduler(\$loop));"
+        );
     }
 
     public static function getImmediate(): ImmediateScheduler
@@ -46,18 +58,18 @@ class Scheduler
         return self::$immediate;
     }
 
-    public static function setAsync($async)
+    public static function setAsync(AsyncSchedulerInterface $async)
     {
         if (static::$async !== null) {
-            throw new \Exception("Scheduler can only be set once. (Are you calling set after get?)");
+            throw new \Exception("Scheduler can only be set once.");
         }
         self::$async = $async;
     }
 
-    public static function setImmediate($immediate)
+    public static function setImmediate(SchedulerInterface $immediate)
     {
         if (static::$immediate !== null) {
-            throw new \Exception("Scheduler can only be set once. (Are you calling set after get?)");
+            throw new \Exception("Scheduler can only be set once.");
         }
         self::$immediate = $immediate;
     }

--- a/src/Scheduler/VirtualTimeScheduler.php
+++ b/src/Scheduler/VirtualTimeScheduler.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 
 namespace Rx\Scheduler;
 
+use Rx\AsyncSchedulerInterface;
 use Rx\Disposable\EmptyDisposable;
 use Rx\Disposable\SerialDisposable;
 use Rx\DisposableInterface;
-use Rx\SchedulerInterface;
 
-class VirtualTimeScheduler implements SchedulerInterface
+class VirtualTimeScheduler implements AsyncSchedulerInterface
 {
     protected $clock;
     protected $comparer;

--- a/test/Rx/Functional/Operator/AsObservableTest.php
+++ b/test/Rx/Functional/Operator/AsObservableTest.php
@@ -134,22 +134,4 @@ class AsObservableTest extends FunctionalTestCase
 
         $this->assertTrue($subscribed);
     }
-
-    public function testAsObservablePassThroughScheduler()
-    {
-        $gotValue = false;
-        Observable::interval(10)
-            ->asObservable()
-            ->take(1)
-            ->subscribe(new CallbackObserver(
-                function ($x) use (&$gotValue) {
-                    $this->assertEquals(0, $x);
-                    $gotValue = true;
-                }
-            ));
-
-        Loop::get()->run();
-
-        $this->assertTrue($gotValue);
-    }
 }

--- a/test/Rx/Functional/Operator/AsObservableTest.php
+++ b/test/Rx/Functional/Operator/AsObservableTest.php
@@ -6,13 +6,11 @@ declare(strict_types = 1);
 namespace Rx\Functional\Operator;
 
 use Exception;
-use Interop\Async\Loop;
 use Rx\Disposable\CallbackDisposable;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable\AnonymousObservable;
 use Rx\Observable;
 use Rx\Observable\EmptyObservable;
-use Rx\Observer\CallbackObserver;
 
 class AsObservableTest extends FunctionalTestCase
 {

--- a/test/Rx/Functional/Operator/CombineLatestTest.php
+++ b/test/Rx/Functional/Operator/CombineLatestTest.php
@@ -5,12 +5,9 @@ declare(strict_types = 1);
 
 namespace Rx\Functional\Operator;
 
-use Interop\Async\Loop;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;
 use Rx\Observable\NeverObservable;
-use Rx\Observer\CallbackObserver;
-use Rx\Scheduler\EventLoopScheduler;
 
 class CombineLatestTest extends FunctionalTestCase
 {

--- a/test/Rx/Functional/Operator/CombineLatestTest.php
+++ b/test/Rx/Functional/Operator/CombineLatestTest.php
@@ -901,33 +901,20 @@ class CombineLatestTest extends FunctionalTestCase
      */
     public function combineLatest_delay()
     {
-        $loop      = Loop::get();
-        $scheduler = new EventLoopScheduler($loop);
-
-        $source1 = Observable::timer(100);
-        $source2 = Observable::timer(120);
-        $source3 = Observable::timer(140);
+        $source1 = Observable::timer(100, $this->scheduler);
+        $source2 = Observable::timer(120, $this->scheduler);
+        $source3 = Observable::timer(140, $this->scheduler);
 
         $source = $source1->combineLatest([$source2, $source3]);
 
-        $result    = null;
-        $completed = false;
+        $result = $this->scheduler->startWithCreate(function () use ($source) {
+            return $source;
+        });
 
-        $source->subscribe(new CallbackObserver(
-            function ($x) use (&$result) {
-                $result = $x;
-            },
-            null,
-            function () use (&$completed) {
-                $completed = true;
-            }
-
-        ));
-
-        $loop->run();
-
-        $this->assertEquals([0, 0, 0], $result);
-        $this->assertTrue($completed);
+        $this->assertMessages([
+            onNext(340, [0, 0, 0]),
+            onCompleted(340)
+        ], $result->getMessages());
     }
 
     /**

--- a/test/Rx/Functional/Promise/ToPromiseTest.php
+++ b/test/Rx/Functional/Promise/ToPromiseTest.php
@@ -5,7 +5,6 @@ declare(strict_types = 1);
 namespace Rx\Functional\Promise;
 
 use Exception;
-use Interop\Async\Loop;
 use Interop\Async\Promise\ErrorHandler;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;

--- a/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Rx\Functional\Scheduler;
 
-use Interop\Async\Loop;
 use React\EventLoop\Factory;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;

--- a/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
@@ -5,9 +5,11 @@ declare(strict_types = 1);
 namespace Rx\Functional\Scheduler;
 
 use Interop\Async\Loop;
+use React\EventLoop\Factory;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;
 use Rx\Observer\CallbackObserver;
+use Rx\Scheduler\EventLoopScheduler;
 
 class EventLoopSchedulerTest extends FunctionalTestCase
 {
@@ -16,7 +18,9 @@ class EventLoopSchedulerTest extends FunctionalTestCase
         $completed = false;
         $nextCount = 0;
 
-        Observable::interval(50)
+        $loop = Factory::create();
+
+        Observable::interval(50, new EventLoopScheduler($loop))
             ->take(1)
             ->subscribe(new CallbackObserver(
                 function ($x) use (&$nextCount) {
@@ -30,7 +34,7 @@ class EventLoopSchedulerTest extends FunctionalTestCase
                 }
             ));
 
-        Loop::get()->run();
+        $loop->run();
 
         $this->assertTrue($completed);
         $this->assertEquals(1, $nextCount);

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Rx\Scheduler;
 
 use Interop\Async\Loop;
+use React\EventLoop\Factory;
 use Rx\TestCase;
 
 class EventLoopSchedulerTest extends TestCase
@@ -14,7 +15,7 @@ class EventLoopSchedulerTest extends TestCase
      */
     public function now_returns_time_since_epoch_in_ms()
     {
-        $scheduler = new EventLoopScheduler();
+        $scheduler = new EventLoopScheduler(function () {});
 
         $this->assertTrue(abs(time() * 1000 - $scheduler->now()) < 1000, 'time difference is less than or equal to 1');
     }
@@ -24,9 +25,9 @@ class EventLoopSchedulerTest extends TestCase
      */
     public function eventloop_schedule()
     {
-        $loop = Loop::get();
+        $loop = Factory::create();
 
-        $scheduler    = new EventLoopScheduler();
+        $scheduler    = new EventLoopScheduler($loop);
         $actionCalled = false;
 
         $action = function () use (&$actionCalled) {
@@ -39,7 +40,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertInstanceOf('Rx\DisposableInterface', $disposable);
         $this->assertFalse($actionCalled);
 
-        $loop->defer(function () use ($loop) {
+        $loop->futureTick(function () use ($loop) {
             $loop->stop();
         });
 
@@ -55,8 +56,8 @@ class EventLoopSchedulerTest extends TestCase
     public function eventloop_schedule_recursive()
     {
 
-        $loop = Loop::get();
-        $scheduler    = new EventLoopScheduler();
+        $loop = Factory::create();
+        $scheduler    = new EventLoopScheduler($loop);
         $actionCalled = false;
         $count        = 0;
 
@@ -116,14 +117,13 @@ class EventLoopSchedulerTest extends TestCase
 
     public function testSchedulerWorkedWithScheduledEventOutsideItself()
     {
-        $loop      = Loop::get();
-        $scheduler = new EventLoopScheduler();
+        $loop      = Factory::create();
+        $scheduler = new EventLoopScheduler($loop);
 
         $scheduler->start();
-        $start  = microtime(true);
         $called = null;
 
-        $loop->delay(100, function () use ($scheduler, &$called) {
+        $loop->addTimer(0.100, function () use ($scheduler, &$called) {
             $scheduler->schedule(function () use (&$called) {
                 $called = microtime(true);
             }, 100);

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Rx\Scheduler;
 
-use Interop\Async\Loop;
 use React\EventLoop\Factory;
 use Rx\TestCase;
 

--- a/test/Rx/SchedulerTest.php
+++ b/test/Rx/SchedulerTest.php
@@ -26,7 +26,11 @@ class SchedulerTest extends TestCase
         $this->resetStaticScheduler();
     }
 
-    public function testGetDefaultConstructsEventLoopScheduler()
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Please set a default scheduler (for react: Scheduler::setDefault(new EventLoopScheduler($loop));
+     */
+    public function testGetDefaultThrowsIfNotSet()
     {
         $scheduler = Scheduler::getDefault();
 
@@ -63,11 +67,13 @@ class SchedulerTest extends TestCase
     /**
      * @expectedException \Exception
      */
-    public function testSetDefaultTwiceThrowsException()
+    public function testSetDefaultAfterDefaultStartThrowsException()
     {
         $scheduler = new TestScheduler();
 
         Scheduler::setDefault($scheduler);
+
+        $scheduler->start();
 
         $scheduler2 = new TestScheduler();
         
@@ -100,5 +106,23 @@ class SchedulerTest extends TestCase
         $scheduler2 = new ImmediateScheduler();
 
         Scheduler::setImmediate($scheduler2);
+    }
+
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Please set an async scheduler (for react: Scheduler::setAsync(new EventLoopScheduler($loop));
+     */
+    public function testGetAsyncBeforeSet()
+    {
+        Scheduler::getAsync();
+    }
+
+    public function testGetAsyncAfterSettingDefaultToAsync()
+    {
+        $asyncScheduler = new EventLoopScheduler(function () {});
+
+        Scheduler::setDefault($asyncScheduler);
+
+        $this->assertSame($asyncScheduler, Scheduler::getAsync());
     }
 }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -22,3 +22,5 @@ if (file_exists($file = __DIR__ . '/../vendor/autoload.php')) {
  * For testing we need to block at `subscribe`, so we need to switch the default to the ImmediateScheduler.
  */
 \Rx\Scheduler::setDefault(new \Rx\Scheduler\ImmediateScheduler());
+
+require 'loop-auto-start.php';

--- a/test/loop-auto-start.php
+++ b/test/loop-auto-start.php
@@ -2,8 +2,13 @@
 
 declare(strict_types = 1);
 
-use Interop\Async\Loop;
+use React\EventLoop\Factory;
+use Rx\Scheduler;
 
-register_shutdown_function(function () {
-    Loop::execute(function () {}, Loop::get());
+$loop      = Factory::create();
+$scheduler = new Scheduler\EventLoopScheduler($loop);
+Scheduler::setAsync($scheduler);
+
+register_shutdown_function(function () use ($loop) {
+    $loop->run();
 });


### PR DESCRIPTION
This PR returns the `EventLoopScheduler` to the v1 style construction.

This also adds `AsyncSchedulerInterface` for operators and observables that require async schedulers.

The README.md still needs to be updated.