### PR TITLE
Fix order of subscriptions in the takeUntil() operator

### DIFF
--- a/lib/Rx/Operator/TakeUntilOperator.php
+++ b/lib/Rx/Operator/TakeUntilOperator.php
@@ -28,14 +28,14 @@ class TakeUntilOperator implements OperatorInterface
     {
 
         return new CompositeDisposable([
-            $observable->subscribe($observer, $scheduler),
             $this->other->subscribe(
                 new CallbackObserver(
                     [$observer, "onCompleted"],
                     [$observer, "onError"]
                 ),
                 $scheduler
-            )
+            ),
+            $observable->subscribe($observer, $scheduler)
         ]);
     }
 }

--- a/test/Rx/Functional/Operator/TakeUntilTest.php
+++ b/test/Rx/Functional/Operator/TakeUntilTest.php
@@ -5,7 +5,6 @@ namespace Rx\Functional\Operator;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;
 use Rx\Observer\CallbackObserver;
-use Rx\ObserverInterface;
 use Rx\Subject\Subject;
 use Rx\Testing\Subscription;
 

--- a/test/Rx/Functional/Operator/TakeUntilTest.php
+++ b/test/Rx/Functional/Operator/TakeUntilTest.php
@@ -4,6 +4,10 @@ namespace Rx\Functional\Operator;
 
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;
+use Rx\Observer\CallbackObserver;
+use Rx\ObserverInterface;
+use Rx\Subject\Subject;
+use Rx\Testing\Subscription;
 
 class TakeUntilTest extends FunctionalTestCase
 {
@@ -40,6 +44,13 @@ class TakeUntilTest extends FunctionalTestCase
             ],
             $result->getMessages()
         );
+        $this->assertSubscriptions([
+            new Subscription(200, 225)
+        ], $l->getSubscriptions());
+
+        $this->assertSubscriptions([
+            new Subscription(200, 225)
+        ], $r->getSubscriptions());
     }
 
     /**
@@ -340,5 +351,26 @@ class TakeUntilTest extends FunctionalTestCase
         );
 
         $this->assertFalse($sourceNotDisposed);
+    }
+
+    /**
+     * @test
+     */
+    public function takeUntil_should_subscribe_to_the_notifier_first_with_immediate_scheduler()
+    {
+        $emissions = 0;
+        $source = Observable::range(1, 10);
+
+        $notification = new Subject();
+
+        $source->takeUntil($notification)
+            ->subscribe(new CallbackObserver(function($value) use (&$emissions, $notification) {
+                if ($value === 5) {
+                    $notification->onNext(true);
+                }
+                $emissions++;
+            }));
+
+        $this->assertEquals(5, $emissions);
     }
 }


### PR DESCRIPTION
This switches the order of subscriptions in the `takeUntil()` operator. This is relevant only when using the `ImmediateScheduler`.

```
$source = Observable::range(1, 10);
$notification = new Subject();

$source->takeUntil($notification)
    ->subscribe(new CallbackObserver(function($value) use ($notification) {
        echo "$value\n";
        if ($value === 5) {
            $notification->onNext(true);
        }
    }));
```

This will print numbers `1 - 10` even though I called `$notification->onNext(true)` after the first five items because the `takeUntil()` operator first [subscribes to its source](https://github.com/ReactiveX/RxPHP/blob/master/src/Operator/TakeUntilOperator.php#L26) which starts emitting values immediatelly before subscribing to the notifier.

