### PR TITLE
Dispose of event loop timers and never create more than one

### DIFF
--- a/src/Scheduler/EventLoopScheduler.php
+++ b/src/Scheduler/EventLoopScheduler.php
@@ -5,6 +5,8 @@ declare(strict_types = 1);
 namespace Rx\Scheduler;
 
 use React\EventLoop\LoopInterface;
+use Rx\Disposable\CallbackDisposable;
+use Rx\Disposable\EmptyDisposable;
 use Rx\DisposableInterface;
 
 final class EventLoopScheduler extends VirtualTimeScheduler
@@ -15,6 +17,8 @@ final class EventLoopScheduler extends VirtualTimeScheduler
 
     private $delayCallback;
 
+    private $currentTimer;
+
     /**
      * EventLoopScheduler constructor.
      * @param callable|LoopInterface $timerCallableOrLoop
@@ -23,9 +27,14 @@ final class EventLoopScheduler extends VirtualTimeScheduler
     {
         $this->delayCallback = $timerCallableOrLoop instanceof LoopInterface ?
             function ($ms, $callable) use ($timerCallableOrLoop) {
-                $timerCallableOrLoop->addTimer($ms / 1000, $callable);
+                $timer = $timerCallableOrLoop->addTimer($ms / 1000, $callable);
+                return new CallbackDisposable(function () use ($timer) {
+                    $timer->cancel();
+                });
             } :
             $timerCallableOrLoop;
+
+        $this->currentTimer = new EmptyDisposable();
 
         parent::__construct($this->now(), function ($a, $b) {
             return $a - $b;
@@ -36,9 +45,18 @@ final class EventLoopScheduler extends VirtualTimeScheduler
     {
         $disp = parent::scheduleAbsoluteWithState($state, $dueTime, $action);
 
-        if (!$this->insideInvoke) {
-            call_user_func($this->delayCallback, 0, [$this, 'start']);
+        if ($this->insideInvoke) {
+            return $disp;
         }
+
+        if ($this->nextTimer <= $dueTime) {
+            return $disp;
+        }
+
+        $this->nextTimer = $this->getClock();
+
+        $this->currentTimer->dispose();
+        $this->currentTimer = call_user_func($this->delayCallback, 0, [$this, 'start']);
 
         return $disp;
     }
@@ -48,12 +66,13 @@ final class EventLoopScheduler extends VirtualTimeScheduler
         $this->clock = $this->now();
 
         $this->insideInvoke = true;
+        $this->nextTimer    = PHP_INT_MAX;
         while ($this->queue->count() > 0) {
             $next = $this->getNext();
             if ($next !== null) {
                 if ($next->getDueTime() > $this->clock) {
                     $this->nextTimer = $next->getDueTime();
-                    call_user_func($this->delayCallback, $this->nextTimer - $this->clock, [$this, "start"]);
+                    $this->currentTimer = call_user_func($this->delayCallback, $this->nextTimer - $this->clock, [$this, "start"]);
                     break;
                 }
 

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Rx\Scheduler;
 
 use React\EventLoop\Factory;
+use Rx\Disposable\CallbackDisposable;
 use Rx\TestCase;
 
 class EventLoopSchedulerTest extends TestCase
@@ -131,5 +132,96 @@ class EventLoopSchedulerTest extends TestCase
         $loop->run();
 
         $this->assertNotNull($called);
+    }
+
+    public function testScheduledItemsFromOutsideOfSchedulerDontCreateExtraTimers()
+    {
+        $timersCreated   = 0;
+        $timersExecuted = 0;
+        $loop           = Factory::create();
+        $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
+            $timersCreated++;
+            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted) {
+                $timersExecuted++;
+                $action();
+            });
+            return new CallbackDisposable(function () use ($timer) {
+                $timer->cancel();
+            });
+        });
+
+        $scheduler->schedule(function () {}, 20);
+
+        $scheduler->schedule(function () {}, 15)->dispose();
+        $scheduler->schedule(function () {}, 14)->dispose();
+        $scheduler->schedule(function () {}, 13)->dispose();
+        $scheduler->schedule(function () {}, 12)->dispose();
+
+        $scheduler->schedule(function () {}, 10);
+
+        $loop->run();
+
+        $this->assertEquals($timersCreated, 3);
+        $this->assertEquals($timersExecuted, 3);
+    }
+
+    public function testMultipleSchedulersFromOutsideInSameTickDontCreateExtraTimers()
+    {
+        $timersCreated   = 0;
+        $timersExecuted = 0;
+        $loop           = Factory::create();
+        $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
+            $timersCreated++;
+            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted) {
+                $timersExecuted++;
+                $action();
+            });
+            return new CallbackDisposable(function () use ($timer) {
+                $timer->cancel();
+            });
+        });
+
+        $scheduler->schedule(function () {}, 20);
+        $loop->addTimer(0.01, function () use ($scheduler) {
+            $scheduler->schedule(function () {}, 30);
+
+            $scheduler->schedule(function () {}, 25)->dispose();
+            $scheduler->schedule(function () {}, 24)->dispose();
+            $scheduler->schedule(function () {}, 23)->dispose();
+            $scheduler->schedule(function () {}, 22)->dispose();
+        });
+
+        $loop->run();
+
+        $this->assertEquals($timersCreated, 3);
+        $this->assertEquals($timersExecuted, 3);
+    }
+
+    public function testThatStuffScheduledWayInTheFutureDoesntKeepTheLoopRunningIfDisposed()
+    {
+        $loop           = Factory::create();
+        $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
+            $timersCreated++;
+            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted) {
+                $timersExecuted++;
+                $action();
+            });
+            return new CallbackDisposable(function () use ($timer) {
+                $timer->cancel();
+            });
+        });
+
+        $disp = $scheduler->schedule(function () {}, 3000);
+        $loop->addTimer(0.01, function () use ($scheduler, $disp) {
+            $scheduler->schedule(function () use ($disp) {
+                $disp->dispose();
+            });
+        });
+
+        $beforeLoopStart = microtime(true);
+        $loop->run();
+        $loopTime = microtime(true) - $beforeLoopStart;
+
+        $this->assertLessThan(2, $loopTime);
     }
 }


### PR DESCRIPTION
Fixes #165 .

Fixes `EventLoopScheduler` to only ever schedule 1 timer with the underlying loop. Also disposes of unneeded timers.

This has a small API change with the EventLoopScheduler now requiring the delay callback (if a callback is used) to return a `DisposableInterface` that can cancel the actual timer.