### PR TITLE
Remove cancelled items from PriorityQueue

### DIFF
--- a/src/Scheduler/PriorityQueue.php
+++ b/src/Scheduler/PriorityQueue.php
@@ -22,6 +22,10 @@ class PriorityQueue
 
     public function remove($item)
     {
+        if ($this->count() === 0) {
+            return false;
+        }
+
         if ($this->peek() === $item) {
             $this->dequeue();
             return true;

--- a/src/Scheduler/VirtualTimeScheduler.php
+++ b/src/Scheduler/VirtualTimeScheduler.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Rx\Scheduler;
 
 use Rx\AsyncSchedulerInterface;
+use Rx\Disposable\CallbackDisposable;
 use Rx\Disposable\EmptyDisposable;
 use Rx\Disposable\SerialDisposable;
 use Rx\DisposableInterface;
@@ -87,7 +88,10 @@ class VirtualTimeScheduler implements AsyncSchedulerInterface
 
         $this->queue->enqueue($scheduledItem);
 
-        return $scheduledItem->getDisposable();
+        return new CallbackDisposable(function () use ($scheduledItem) {
+            $scheduledItem->getDisposable()->dispose();
+            $this->queue->remove($scheduledItem);
+        });
     }
 
     public function scheduleRelativeWithState($state, $dueTime, $action): DisposableInterface

--- a/test/Rx/Scheduler/PriorityQueueTest.php
+++ b/test/Rx/Scheduler/PriorityQueueTest.php
@@ -130,4 +130,21 @@ class PriorityQueueTest extends TestCase
         $this->assertSame($scheduledItem, $queue->dequeue());
         $this->assertSame($scheduledItem3, $queue->dequeue());
     }
+
+    /**
+     * @test
+     */
+    public function should_not_remove_nonexistent_item()
+    {
+        $queue = new PriorityQueue();
+        $queue->remove(
+            new ScheduledItem(
+                $this->createMock(ScheduledItem::class),
+                null,
+                function () {
+                },
+                0
+            )
+        );
+    }
 }


### PR DESCRIPTION
In some circumstances, `ScheduledItems` can stay in memory much longer than desired.

Prior to this PR, disposed scheduled items were handled by marking them as canceled. As time went on, the scheduler could just skip any disposed items. This becomes problematic when there are many items that are scheduled out longer than a trivial amount of time as it holds on to all the references of the scheduled callback.