### PR TITLE
Fix order of subscriptions in the takeUntil() operator (2.x)

### DIFF
--- a/src/Operator/TakeUntilOperator.php
+++ b/src/Operator/TakeUntilOperator.php
@@ -23,13 +23,13 @@ final class TakeUntilOperator implements OperatorInterface
     {
 
         return new CompositeDisposable([
-            $observable->subscribe($observer),
             $this->other->subscribe(
                 new CallbackObserver(
                     [$observer, 'onCompleted'],
                     [$observer, 'onError']
                 )
-            )
+            ),
+            $observable->subscribe($observer)
         ]);
     }
 }

--- a/test/Rx/Functional/Operator/TakeUntilTest.php
+++ b/test/Rx/Functional/Operator/TakeUntilTest.php
@@ -6,6 +6,9 @@ namespace Rx\Functional\Operator;
 
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observable;
+use Rx\Observer\CallbackObserver;
+use Rx\Subject\Subject;
+use Rx\Testing\Subscription;
 
 class TakeUntilTest extends FunctionalTestCase
 {
@@ -42,6 +45,13 @@ class TakeUntilTest extends FunctionalTestCase
             ],
             $result->getMessages()
         );
+
+        $this->assertSubscriptions([
+            new Subscription(200, 225)
+        ], $l->getSubscriptions());
+        $this->assertSubscriptions([
+            new Subscription(200, 225)
+        ], $r->getSubscriptions());
     }
 
     /**
@@ -342,5 +352,23 @@ class TakeUntilTest extends FunctionalTestCase
         );
 
         $this->assertFalse($sourceNotDisposed);
+    }
+
+    /**
+     * @test
+     */
+    public function takeUntil_should_subscribe_to_the_notifier_first_with_immediate_scheduler()
+    {
+        $emissions = 0;
+        $source = Observable::range(1, 10);
+        $notification = new Subject();
+        $source->takeUntil($notification)
+            ->subscribe(new CallbackObserver(function($value) use (&$emissions, $notification) {
+                if ($value === 5) {
+                    $notification->onNext(true);
+                }
+                $emissions++;
+            }));
+        $this->assertEquals(5, $emissions);
     }
 }


### PR DESCRIPTION
The same as #158.