### PR TITLE
Reroute exceptions in onNext to onError by default

### DIFF
--- a/src/Observable.php
+++ b/src/Observable.php
@@ -97,7 +97,19 @@ abstract class Observable implements ObservableInterface
             throw new \InvalidArgumentException('The first argument needs to be a "callable" or "Observer"');
         }
 
-        $observer = new CallbackObserver($onNextOrObserver, $onError, $onCompleted);
+        $observer = new CallbackObserver(
+            $onNextOrObserver === null
+                ? null
+                : function ($value) use ($onNextOrObserver, &$observer) {
+                try {
+                    $onNextOrObserver($value);
+                } catch (\Throwable $throwable) {
+                    $observer->onError($throwable);
+                }
+            },
+            $onError,
+            $onCompleted
+        );
 
         return $this->_subscribe($observer);
     }

--- a/test/Rx/Functional/ObservableTest.php
+++ b/test/Rx/Functional/ObservableTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rx\Functional;
+
+use Rx\Observer\TestException;
+use Rx\Testing\MockObserver;
+
+class ObservableTest extends FunctionalTestCase
+{
+    public function testExceptionInOnNextByDefaultGoesToErrorAndDisposes()
+    {
+        $xs = $this->createHotObservable(
+            [
+                onNext(150, 1),
+                onNext(210, 2),
+                onNext(220, 3),
+                onNext(230, 4),
+                onCompleted(250)
+            ]);
+
+        $results = new MockObserver($this->scheduler);
+
+        $disposable = null;
+
+        $this->scheduler->scheduleAbsolute(200, function () use ($xs, $results, &$disposable) {
+            $disposable = $xs->subscribe(
+                function ($value) use ($results) {
+                    if ($value === 3) {
+                        throw new TestException();
+                    }
+                    $results->onNext($value);
+                },
+                [$results, 'onError'],
+                [$results, 'onCompleted']
+            );
+        });
+
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$disposable) {
+            $disposable->dispose();
+        });
+
+        $this->scheduler->start();
+
+        $this->assertMessages(
+            [
+                onNext(210, 2),
+                onError(220, new TestException()),
+            ],
+            $results->getMessages());
+
+        $this->assertSubscriptions([subscribe(200, 220)], $xs->getSubscriptions());
+    }
+}

--- a/test/Rx/ObservableTest.php
+++ b/test/Rx/ObservableTest.php
@@ -8,6 +8,7 @@ use Rx\Observable\ConnectableObservable;
 use Rx\Observable\EmptyObservable;
 use Rx\Observable\RefCountObservable;
 use Rx\Observable\ReturnObservable;
+use Rx\Observer\TestException;
 use Rx\Scheduler\ImmediateScheduler;
 use Rx\Testing\TestScheduler;
 
@@ -178,5 +179,27 @@ class ObservableTest extends TestCase
 
 
         $o->switchLatest();
+    }
+
+    /**
+     * @test
+     */
+    public function it_sends_throwables_in_onnext_to_onerror()
+    {
+        $onNext = function ($x) {
+            throw new TestException();
+        };
+
+        $error = null;
+
+        Observable::of(0)
+            ->subscribe(
+                $onNext,
+                function (\Throwable $e) use (&$error) {
+                    $error = $e;
+                }
+            );
+
+        $this->assertInstanceOf(TestException::class, $error);
     }
 }


### PR DESCRIPTION
Fixes #192 

This PR catches exceptions in `onNext` in the default observer that is created when you call `subscribe` using callbacks and sends them to the `onError` handler.

This resolves issues with errors and exceptions happening in a completely silent way.

This may not resolve silent failures if you do not have a handler for the error. This can be dealt with in a separate PR after that warns if you do not pass in an `onError` and an error occurs.

This is specifically only applied to the default observer that is built in `subscribe`. If the user sends in their own `Observer` the library leaves handling these issues up to the user.