### PR TITLE
Fix phpdoc on observable scan operator

### DIFF
--- a/src/Observable.php
+++ b/src/Observable.php
@@ -1001,7 +1001,7 @@ abstract class Observable implements ObservableInterface
      * The optional seed value is used as the initial accumulator value.
      *
      * @param $accumulator
-     * @param null $seed
+     * @param mixed $seed
      * @return Observable
      *
      * @demo scan/scan.php


### PR DESCRIPTION
Prevent false positive on PHPStan

```
Parameter #2 $seed of method Rx\Observable::scan() expects null, false given.
```