### PR TITLE
Take operator doesn't dispose upstream observable

### DIFF
--- a/src/Operator/TakeOperator.php
+++ b/src/Operator/TakeOperator.php
@@ -27,12 +27,15 @@ final class TakeOperator implements OperatorInterface
         $remaining = $this->count;
 
         $callbackObserver = new CallbackObserver(
-            function ($nextValue) use ($observer, &$remaining) {
+            function ($nextValue) use ($observer, &$remaining, &$disposable) {
                 if ($remaining > 0) {
                     $remaining--;
                     $observer->onNext($nextValue);
                     if ($remaining === 0) {
                         $observer->onCompleted();
+                        if ($disposable instanceof DisposableInterface) {
+                            $disposable->dispose();
+                        }
                     }
                 }
             },
@@ -40,6 +43,7 @@ final class TakeOperator implements OperatorInterface
             [$observer, 'onCompleted']
         );
 
-        return $observable->subscribe($callbackObserver);
+        $disposable = $observable->subscribe($callbackObserver);
+        return $disposable;
     }
 }


### PR DESCRIPTION
If there is an active polling observable upstream it will keep polling as long as it isn't disposed. By disposing when we reach the desired amount of items, the possible upstream polling is also stopped.