### PR TITLE
Add support for react/promise v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "react/promise": "~2.2"
+        "react/promise": "^3 || ~2.2"
     },
     "require-dev": {
         "satooshi/php-coveralls": "~1.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+parameters:
+    level: max
+
+    paths:
+        - test/types/
+
+    fileExtensions:
+        - php

--- a/src/React/Promise.php
+++ b/src/React/Promise.php
@@ -2,7 +2,6 @@
 
 namespace Rx\React;
 
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\Promise as ReactPromise;
 use React\Promise\PromiseInterface;
 use Rx\Disposable\CallbackDisposable;
@@ -11,6 +10,7 @@ use Rx\Observable;
 use Rx\Observable\AnonymousObservable;
 use Rx\Subject\AsyncSubject;
 use React\Promise\Deferred;
+use Throwable;
 
 final class Promise
 {
@@ -32,7 +32,7 @@ final class Promise
     public static function rejected($exception): ReactPromise
     {
         $d = new Deferred();
-        $d->reject($exception);
+        $d->reject($exception instanceof Throwable ? $exception : new RejectedPromiseException($exception));
         return $d->promise();
     }
 
@@ -94,7 +94,7 @@ final class Promise
             $disp = $subject->subscribe($observer);
             return new CallbackDisposable(function () use ($p, $disp) {
                 $disp->dispose();
-                if ($p instanceof CancellablePromiseInterface) {
+                if (\method_exists($p, 'cancel')) {
                     $p->cancel();
                 }
             });

--- a/test/Rx/Functional/Promise/FromPromiseTest.php
+++ b/test/Rx/Functional/Promise/FromPromiseTest.php
@@ -40,7 +40,7 @@ class FromPromiseTest extends FunctionalTestCase
      */
     public function from_promise_failure()
     {
-        $p = \React\Promise\reject('error');
+        $p = \React\Promise\reject(new RejectedPromiseException('error'));
 
         $source = Observable::fromPromise($p);
 


### PR DESCRIPTION
With v3 come a whole list of [changes](https://github.com/reactphp/promise/releases/tag/v3.0.0) including end of promise chain detection, the removal of the `CancellablePromiseInterface` interface, and type templating.