### PR TITLE
PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,23 @@ jobs:
     name: PHPUnit (PHP ${{ matrix.php }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os:
-          - ubuntu-20.04
-          - windows-2019
+          - ubuntu-latest
+          - windows-latest
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
-          - 8.0
-          - 7.4
-          - 7.3
-          - 7.2
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-      - run: composer install
+          tools: composer
+          cache: composer
+      - run: composer install --prefer-dist --no-interaction --no-progress
       - run: vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1.0",
         "react/promise": "^3 || ~2.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "require-dev": {
         "satooshi/php-coveralls": "~1.0",
         "phpunit/phpunit": "^8.5 || ^9",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4.2"
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4.2",
+        "rector/rector": "^2.0"
     },
     "suggest": {
         "react/event-loop": "Used for scheduling async operations"

--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -30,9 +30,9 @@ function asString($value) {
 
 $createStdoutObserver = function ($prefix = '') {
     return new Rx\Observer\CallbackObserver(
-        function ($value) use ($prefix) { echo $prefix . "Next value: " . asString($value) . "\n"; },
-        function ($error) use ($prefix) { echo $prefix . "Exception: " . $error->getMessage() . "\n"; },
-        function ()       use ($prefix) { echo $prefix . "Complete!\n"; }
+        function ($value) use ($prefix): void { echo $prefix . "Next value: " . asString($value) . "\n"; },
+        function ($error) use ($prefix): void { echo $prefix . "Exception: " . $error->getMessage() . "\n"; },
+        function ()       use ($prefix): void { echo $prefix . "Complete!\n"; }
     );
 };
 
@@ -42,6 +42,6 @@ $loop = Factory::create();
 Scheduler::setDefaultFactory(function () use ($loop) {
     return new Scheduler\EventLoopScheduler($loop);
 });
-register_shutdown_function(function () use ($loop) {
+register_shutdown_function(function () use ($loop): void {
     $loop->run();
 });

--- a/demo/create/create.php
+++ b/demo/create/create.php
@@ -9,7 +9,7 @@ $source = \Rx\Observable::create(function (\Rx\ObserverInterface $observer) {
     $observer->onNext(42);
     $observer->onCompleted();
 
-    return new CallbackDisposable(function () {
+    return new CallbackDisposable(function (): void {
         echo "Disposed\n";
     });
 });

--- a/demo/create/createObservable.php
+++ b/demo/create/createObservable.php
@@ -9,7 +9,7 @@ $source = new \Rx\Observable\AnonymousObservable(function (\Rx\ObserverInterface
     $observer->onNext(42);
     $observer->onCompleted();
 
-    return new CallbackDisposable(function () {
+    return new CallbackDisposable(function (): void {
         echo "Disposed\n";
     });
 });

--- a/demo/custom-operator/Rot13Operator.php
+++ b/demo/custom-operator/Rot13Operator.php
@@ -15,7 +15,7 @@ class Rot13Operator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         return $observable->subscribe(
-            function ($json) use ($observer) {
+            function ($json) use ($observer): void {
                 $observer->onNext(str_rot13($json));
             },
             [$observer, 'onError'],

--- a/demo/delay/delay.php
+++ b/demo/delay/delay.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 \Rx\Observable::interval(1000)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo 'Side effect: ' . $x . "\n";
     })
     ->delay(500)

--- a/demo/do/do.php
+++ b/demo/do/do.php
@@ -4,13 +4,13 @@ require_once __DIR__ . '/../bootstrap.php';
 
 $source = \Rx\Observable::range(0, 3)
     ->do(
-        function ($x) {
+        function ($x): void {
             echo 'Do Next:', $x, PHP_EOL;
         },
-        function (Throwable $err) {
+        function (Throwable $err): void {
             echo 'Do Error:', $err->getMessage(), PHP_EOL;
         },
-        function () {
+        function (): void {
             echo 'Do Completed', PHP_EOL;
         }
     );

--- a/demo/do/doOnCompleted.php
+++ b/demo/do/doOnCompleted.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 $source = \Rx\Observable::empty()
-    ->doOnCompleted(function () {
+    ->doOnCompleted(function (): void {
         echo 'Do Completed', PHP_EOL;
     });
 

--- a/demo/do/doOnError.php
+++ b/demo/do/doOnError.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 $source = \Rx\Observable::error(new Exception('Oops'))
-    ->doOnError(function (Throwable $err) {
+    ->doOnError(function (Throwable $err): void {
         echo 'Do Error:', $err->getMessage(), PHP_EOL;
     });
 

--- a/demo/do/doOnNext.php
+++ b/demo/do/doOnNext.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 $source = \Rx\Observable::range(0, 3)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo 'Do Next:', $x, PHP_EOL;
     });
 

--- a/demo/finally/finally-error.php
+++ b/demo/finally/finally-error.php
@@ -9,7 +9,7 @@ Rx\Observable::range(1, 3)
         }
         return $value;
     })
-    ->finally(function() {
+    ->finally(function(): void {
         echo "Finally\n";
     })
     ->subscribe($stdoutObserver);

--- a/demo/finally/finally.php
+++ b/demo/finally/finally.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 Rx\Observable::range(1, 3)
-    ->finally(function() {
+    ->finally(function(): void {
         echo "Finally\n";
     })
     ->subscribe($stdoutObserver);

--- a/demo/groupBy/groupBy.php
+++ b/demo/groupBy/groupBy.php
@@ -17,6 +17,6 @@ $observable
             return $key;
         }
     )
-    ->subscribe(function ($groupedObserver) use ($createStdoutObserver) {
+    ->subscribe(function ($groupedObserver) use ($createStdoutObserver): void {
         $groupedObserver->subscribe($createStdoutObserver($groupedObserver->getKey() . ": "));
     });

--- a/demo/groupBy/groupByUntil.php
+++ b/demo/groupBy/groupByUntil.php
@@ -34,17 +34,17 @@ $source = Rx\Observable
         });
 
 $subscription = $source->subscribe(new CallbackObserver(
-    function (\Rx\Observable $obs) {
+    function (\Rx\Observable $obs): void {
         // Print the count
         $obs->count()->subscribe(new CallbackObserver(
-            function ($x) {
+            function ($x): void {
                 echo 'Count: ', $x, PHP_EOL;
             }));
     },
-    function (Throwable $err) {
+    function (Throwable $err): void {
         echo 'Error', $err->getMessage(), PHP_EOL;
     },
-    function () {
+    function (): void {
         echo 'Completed', PHP_EOL;
     }));
 

--- a/demo/promise/toPromise.php
+++ b/demo/promise/toPromise.php
@@ -5,6 +5,6 @@ require_once __DIR__ . '/../bootstrap.php';
 $promise = \Rx\Observable::of(42)
     ->toPromise();
 
-$promise->then(function ($value) {
+$promise->then(function ($value): void {
     echo "Value: {$value}\n";
 });

--- a/demo/publish/publish.php
+++ b/demo/publish/publish.php
@@ -7,7 +7,7 @@ $interval = \Rx\Observable::range(0, 10);
 
 $source = $interval
     ->take(2)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo "Side effect\n";
     });
 

--- a/demo/publish/publishLast.php
+++ b/demo/publish/publishLast.php
@@ -6,7 +6,7 @@ $range = \Rx\Observable::fromArray(range(0, 1000));
 
 $source = $range
     ->take(2)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo "Side effect\n";
     });
 

--- a/demo/publish/publishValue.php
+++ b/demo/publish/publishValue.php
@@ -6,7 +6,7 @@ $range = \Rx\Observable::fromArray(range(0, 1000));
 
 $source = $range
     ->take(2)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo "Side effect\n";
     });
 

--- a/demo/recursive-scheduler/recursive-scheduler.php
+++ b/demo/recursive-scheduler/recursive-scheduler.php
@@ -18,7 +18,7 @@ class RecursiveReturnObservable extends Observable
 
     public function _subscribe(\Rx\ObserverInterface $observer): \Rx\DisposableInterface
     {
-        return \Rx\Scheduler::getDefault()->scheduleRecursive(function ($reschedule) use ($observer) {
+        return \Rx\Scheduler::getDefault()->scheduleRecursive(function ($reschedule) use ($observer): void {
             $observer->onNext($this->value);
             $reschedule();
         });
@@ -31,14 +31,14 @@ $observable->subscribe($stdoutObserver);
 $observable = new RecursiveReturnObservable(21);
 $disposable = $observable->subscribe($stdoutObserver);
 
-Loop::repeat(100, function () {
+Loop::repeat(100, function (): void {
     $memory    = memory_get_usage() / 1024;
     $formatted = number_format($memory, 3) . 'K';
     echo "Current memory usage: {$formatted}\n";
 });
 
 // after a second we'll dispose the 21 observable
-Loop::delay(1000, function () use ($disposable) {
+Loop::delay(1000, function () use ($disposable): void {
     echo "Disposing 21 observable.\n";
     $disposable->dispose();
 });

--- a/demo/repeat/repeatWhen.php
+++ b/demo/repeat/repeatWhen.php
@@ -9,7 +9,7 @@ $source = Rx\Observable::of(42)
                 return $acc + $x;
             }, 0)
             ->delay(1000)
-            ->doOnNext(function () {
+            ->doOnNext(function (): void {
                 echo "1 second delay", PHP_EOL;
             })
             ->takeWhile(function ($count) {

--- a/demo/replay/replay.php
+++ b/demo/replay/replay.php
@@ -6,7 +6,7 @@ $interval = \Rx\Observable::interval(1000);
 
 $source = $interval
     ->take(2)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo $x, ' something', PHP_EOL;
         echo 'Side effect', PHP_EOL;
     });

--- a/demo/share/share.php
+++ b/demo/share/share.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/../bootstrap.php';
 //With Share
 $source = \Rx\Observable::interval(1000)
     ->take(2)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo "Side effect\n";
     });
 

--- a/demo/share/shareReplay.php
+++ b/demo/share/shareReplay.php
@@ -6,7 +6,7 @@ $interval = Rx\Observable::interval(1000);
 
 $source = $interval
     ->take(4)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo 'Side effect', PHP_EOL;
     });
 

--- a/demo/share/shareValue.php
+++ b/demo/share/shareValue.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 $source = \Rx\Observable::interval(1000)
     ->take(2)
-    ->doOnNext(function ($x) {
+    ->doOnNext(function ($x): void {
         echo "Side effect\n";
     });
 

--- a/demo/share/singleInstance.php
+++ b/demo/share/singleInstance.php
@@ -6,7 +6,7 @@ $interval = Rx\Observable::interval(1000);
 
 $source = $interval
     ->take(2)
-    ->do(function () {
+    ->do(function (): void {
         echo 'Side effect', PHP_EOL;
     });
 
@@ -16,7 +16,7 @@ $single = $source->singleInstance();
 $single->subscribe($createStdoutObserver('SourceA '));
 $single->subscribe($createStdoutObserver('SourceB '));
 
-\Rx\Observable::timer(5000)->subscribe(function () use ($single, &$createStdoutObserver) {
+\Rx\Observable::timer(5000)->subscribe(function () use ($single, &$createStdoutObserver): void {
     // resubscribe two times again, more than 5 seconds later,
     // long after the original two subscriptions have ended
     $single->subscribe($createStdoutObserver('SourceC '));

--- a/demo/subscribeOn/subscribeOn.php
+++ b/demo/subscribeOn/subscribeOn.php
@@ -10,7 +10,7 @@ use Rx\Scheduler\EventLoopScheduler;
 $loop = Factory::create();
 
 $observable = Rx\Observable::create(function (ObserverInterface $observer) use ($loop) {
-    $handler = function () use ($observer) {
+    $handler = function () use ($observer): void {
         $observer->onNext(42);
         $observer->onCompleted();
     };
@@ -18,7 +18,7 @@ $observable = Rx\Observable::create(function (ObserverInterface $observer) use (
     // Change scheduler for here
     $timer = $loop->addTimer(0.001, $handler);
 
-    return new CallbackDisposable(function () use ($loop, $timer) {
+    return new CallbackDisposable(function () use ($loop, $timer): void {
         // And change scheduler for here
         if ($timer) {
             $loop->cancelTimer($timer);

--- a/demo/test.php
+++ b/demo/test.php
@@ -8,7 +8,7 @@ function run_cmd($file) {
         $output,
         $exit_code
     );
-    return array($exit_code, implode("\n", $output));
+    return [$exit_code, implode("\n", $output)];
 }
 
 function run_demo($file) {
@@ -38,7 +38,7 @@ function has_expect($file) {
 }
 
 function strip_cwd($cwd, $absolute_path) {
-    $is_prefix = 0 === strpos($absolute_path, $cwd);
+    $is_prefix = str_starts_with($absolute_path, $cwd);
     if (!$is_prefix) {
         return $absolute_path;
     }

--- a/demo/toArray/toArray.php
+++ b/demo/toArray/toArray.php
@@ -10,7 +10,7 @@ $observer = $createStdoutObserver();
 
 $subscription = $source->toArray()
     ->subscribe(new CallbackObserver(
-        function ($array) use ($observer) {
+        function ($array) use ($observer): void {
             $observer->onNext(json_encode($array));
         },
         [$observer, "onError"],

--- a/demo/zip/zip.php
+++ b/demo/zip/zip.php
@@ -17,7 +17,7 @@ $observer = $createStdoutObserver();
 
 $subscription = $source
     ->subscribe(new CallbackObserver(
-        function ($array) use ($observer) {
+        function ($array) use ($observer): void {
             $observer->onNext(json_encode($array));
         },
         [$observer, 'onError'],

--- a/docs/build-docs.php
+++ b/docs/build-docs.php
@@ -10,12 +10,12 @@ require_once __DIR__ . '/doc-loader.php';
 require_once __DIR__ . '/doc-writer.php';
 require_once __DIR__ . '/utils.php';
 
-function println($line) {
+function println($line): void {
     $args = func_get_args();
     echo call_user_func_array('sprintf', $args) . "\n";
 }
 
-function run_lint() {
+function run_lint(): void {
     $docs = load_all_docs();
     println("Successfully loaded documentation for %d observables/operators\n",
         count($docs)
@@ -33,7 +33,7 @@ function run_lint() {
     exit(0);
 }
 
-function run_reactivex() {
+function run_reactivex(): void {
     $allDocs = load_all_docs();
 
     $docs = array_filter($allDocs, function ($doc) {
@@ -74,14 +74,14 @@ function run_reactivex() {
     exit(0);
 }
 
-function run_usage() {
+function run_usage(): void {
     println("Usage: $argv[0] <command>");
     println("  lint      Verifies that documentation can be loaded");
     println("  reactivex Updates the reactivex documentation");
     exit(1);
 }
 
-function main($argv) {
+function main($argv): void {
     if (count($argv) !== 2) {
         run_usage();
     }

--- a/docs/doc-loader.php
+++ b/docs/doc-loader.php
@@ -132,7 +132,7 @@ function has_documentation_tag(\ReflectionMethod $method) {
 }
 
 function load_all_docs() {
-    $observable = new \ReflectionClass('Rx\Observable');
+    $observable = new \ReflectionClass(\Rx\Observable::class);
 
     $possibleMethods = $observable
         ->getMethods(ReflectionMethod::IS_STATIC|ReflectionMethod::IS_PUBLIC);

--- a/docs/doc-writer.php
+++ b/docs/doc-writer.php
@@ -12,7 +12,7 @@ function load_all_reactivex_docs($docsPath) {
     return $docsPerId;
 }
 
-function update_documentation($path, $docs) {
+function update_documentation($path, $docs): void {
     $htmlDocs = build_documentation($docs);
     $currentDocumentation = file_get_contents($path);
     $currentLines = explode("\n", $currentDocumentation);

--- a/docs/doc-writer.php
+++ b/docs/doc-writer.php
@@ -67,7 +67,7 @@ function get_replace_position($lines) {
             break;
         }
     }
-    return array($start, $end - $start + 1);
+    return [$start, $end - $start + 1];
 }
 
 function build_documentation($docs) {

--- a/docs/utils.php
+++ b/docs/utils.php
@@ -2,7 +2,7 @@
 
 abstract class Str {
     public static function contains($haystack, $needle) {
-        return false !== strpos($haystack, $needle);
+        return str_contains($haystack, $needle);
     }
 
     public static function containsAny($haystack, $needles) {
@@ -20,7 +20,7 @@ abstract class Str {
     }
 
     public static function startsWith($haystack, $needle) {
-        return 0 === strpos($haystack, $needle);
+        return str_starts_with($haystack, $needle);
     }
 
     public static function substringAfter($haystack, $needle) {
@@ -62,5 +62,5 @@ function run_cmd($cmd) {
     $output = [];
     $exitCode = 0;
     exec($cmd, $output, $exitCode);
-    return array($exitCode, $output);
+    return [$exitCode, $output];
 }

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ])
     ->withPhpVersion(80400)
     ->withPhpSets()
-    ->withTypeCoverageLevel(1)
+    ->withTypeCoverageLevel(2)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0)
     ->withRules([

--- a/rector.php
+++ b/rector.php
@@ -14,7 +14,7 @@ return RectorConfig::configure()
     ])
     ->withPhpVersion(80400)
     ->withPhpSets()
-    ->withTypeCoverageLevel(0)
+    ->withTypeCoverageLevel(1)
     ->withDeadCodeLevel(0)
     ->withCodeQualityLevel(0)
     ->withRules([

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -15,4 +16,7 @@ return RectorConfig::configure()
     ->withPhpSets()
     ->withTypeCoverageLevel(0)
     ->withDeadCodeLevel(0)
-    ->withCodeQualityLevel(0);
+    ->withCodeQualityLevel(0)
+    ->withRules([
+        ExplicitNullableParamTypeRector::class,
+    ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/demo',
+        __DIR__ . '/docs',
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+    ])
+    ->withPhpVersion(80400)
+    ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/src/Disposable/RefCountDisposable.php
+++ b/src/Disposable/RefCountDisposable.php
@@ -38,7 +38,7 @@ class RefCountDisposable implements DisposableInterface
             return $this->createInnerDisposable();
         }
 
-        return new CallbackDisposable(function () {
+        return new CallbackDisposable(function (): void {
         }); // no op
     }
 
@@ -57,7 +57,7 @@ class RefCountDisposable implements DisposableInterface
         $this->count++;
         $isInnerDisposed = false;
 
-        return new CallbackDisposable(function () use (&$isInnerDisposed) {
+        return new CallbackDisposable(function () use (&$isInnerDisposed): void {
             if ($this->isDisposed()) {
                 return;
             }

--- a/src/Disposable/ScheduledDisposable.php
+++ b/src/Disposable/ScheduledDisposable.php
@@ -32,7 +32,7 @@ class ScheduledDisposable implements DisposableInterface
 
         $this->isDisposed = true;
 
-        $this->scheduler->schedule(function () {
+        $this->scheduler->schedule(function (): void {
             $this->disposable->dispose();
         });
     }

--- a/src/Disposable/SingleAssignmentDisposable.php
+++ b/src/Disposable/SingleAssignmentDisposable.php
@@ -27,7 +27,7 @@ class SingleAssignmentDisposable implements DisposableInterface
         }
     }
 
-    public function setDisposable(DisposableInterface $disposable = null)
+    public function setDisposable(?DisposableInterface $disposable = null)
     {
         if ($this->current) {
             throw new RuntimeException('Disposable has already been assigned.');

--- a/src/Observable.php
+++ b/src/Observable.php
@@ -103,7 +103,7 @@ abstract class Observable implements ObservableInterface
         $observer = new CallbackObserver(
             $onNextOrObserver === null
                 ? null
-                : function ($value) use ($onNextOrObserver, &$observer, &$disposable) {
+                : function ($value) use ($onNextOrObserver, &$observer, &$disposable): void {
                     try {
                         $onNextOrObserver($value);
                     } catch (\Throwable $throwable) {
@@ -270,7 +270,7 @@ abstract class Observable implements ObservableInterface
      */
     public function merge(ObservableInterface $otherObservable): Observable
     {
-        return (new AnonymousObservable(function (ObserverInterface $observer) use ($otherObservable) {
+        return (new AnonymousObservable(function (ObserverInterface $observer) use ($otherObservable): void {
             $observer->onNext($this);
             $observer->onNext($otherObservable);
             $observer->onCompleted();
@@ -380,7 +380,7 @@ abstract class Observable implements ObservableInterface
         $scheduler = $scheduler ?? Scheduler::getDefault();
         $subject   = new AsyncSubject();
 
-        $scheduler->schedule(function () use ($subject, $action) {
+        $scheduler->schedule(function () use ($subject, $action): void {
             $result = null;
             try {
                 $result = $action();
@@ -1352,7 +1352,7 @@ abstract class Observable implements ObservableInterface
             if (!$hasObservable) {
                 $hasObservable = true;
                 $observable = $source
-                    ->finally(function () use (&$hasObservable) {
+                    ->finally(function () use (&$hasObservable): void {
                         $hasObservable = false;
                     })
                     ->publish()

--- a/src/Observable.php
+++ b/src/Observable.php
@@ -90,7 +90,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex subscribe
      */
-    public function subscribe($onNextOrObserver = null, callable $onError = null, callable $onCompleted = null): DisposableInterface
+    public function subscribe($onNextOrObserver = null, ?callable $onError = null, ?callable $onCompleted = null): DisposableInterface
     {
         if ($onNextOrObserver instanceof ObserverInterface) {
             return $this->_subscribe($onNextOrObserver);
@@ -134,7 +134,7 @@ abstract class Observable implements ObservableInterface
      * @param callable|null $onCompleted
      * @return DisposableInterface
      */
-    public function subscribeCallback(callable $onNext = null, callable $onError = null, callable $onCompleted = null): DisposableInterface
+    public function subscribeCallback(?callable $onNext = null, ?callable $onError = null, ?callable $onCompleted = null): DisposableInterface
     {
         $observer = new CallbackObserver($onNext, $onError, $onCompleted);
 
@@ -167,7 +167,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex interval
      */
-    public static function interval(int $interval, AsyncSchedulerInterface $scheduler = null): IntervalObservable
+    public static function interval(int $interval, ?AsyncSchedulerInterface $scheduler = null): IntervalObservable
     {
         return new IntervalObservable($interval, $scheduler ?: Scheduler::getAsync());
     }
@@ -183,7 +183,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex just
      */
-    public static function of($value, SchedulerInterface $scheduler = null): ReturnObservable
+    public static function of($value, ?SchedulerInterface $scheduler = null): ReturnObservable
     {
         return new ReturnObservable($value, $scheduler ?: Scheduler::getDefault());
     }
@@ -196,7 +196,7 @@ abstract class Observable implements ObservableInterface
      * @param SchedulerInterface|null $scheduler
      * @return ReturnObservable
      */
-    public static function just($value, SchedulerInterface $scheduler = null): ReturnObservable
+    public static function just($value, ?SchedulerInterface $scheduler = null): ReturnObservable
     {
         return static::of($value, $scheduler);
     }
@@ -211,7 +211,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex empty-never-throw
      */
-    public static function empty(SchedulerInterface $scheduler = null): EmptyObservable
+    public static function empty(?SchedulerInterface $scheduler = null): EmptyObservable
     {
         return new EmptyObservable($scheduler ?: Scheduler::getDefault());
     }
@@ -223,7 +223,7 @@ abstract class Observable implements ObservableInterface
      * @param SchedulerInterface|null $scheduler
      * @return EmptyObservable
      */
-    public static function emptyObservable(SchedulerInterface $scheduler = null): EmptyObservable
+    public static function emptyObservable(?SchedulerInterface $scheduler = null): EmptyObservable
     {
         return static::empty($scheduler);
     }
@@ -253,7 +253,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex empty-never-throw
      */
-    public static function error(\Throwable $error, SchedulerInterface $scheduler = null): ErrorObservable
+    public static function error(\Throwable $error, ?SchedulerInterface $scheduler = null): ErrorObservable
     {
         return new ErrorObservable($error, $scheduler ?: Scheduler::getImmediate());
     }
@@ -304,7 +304,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex from
      */
-    public static function fromArray(array $array, SchedulerInterface $scheduler = null): ArrayObservable
+    public static function fromArray(array $array, ?SchedulerInterface $scheduler = null): ArrayObservable
     {
         return new ArrayObservable($array, $scheduler ?: Scheduler::getDefault());
     }
@@ -320,7 +320,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex from
      */
-    public static function fromIterator(\Iterator $iterator, SchedulerInterface $scheduler = null): IteratorObservable
+    public static function fromIterator(\Iterator $iterator, ?SchedulerInterface $scheduler = null): IteratorObservable
     {
         return new IteratorObservable($iterator, $scheduler ?: Scheduler::getDefault());
     }
@@ -336,7 +336,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex defer
      */
-    public static function defer(callable $factory, SchedulerInterface $scheduler = null): Observable
+    public static function defer(callable $factory, ?SchedulerInterface $scheduler = null): Observable
     {
         return static::empty($scheduler)
             ->lift(function () use ($factory) {
@@ -358,7 +358,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex range
      */
-    public static function range(int $start, int $count, SchedulerInterface $scheduler = null): RangeObservable
+    public static function range(int $start, int $count, ?SchedulerInterface $scheduler = null): RangeObservable
     {
         return new RangeObservable($start, $count, $scheduler ?: Scheduler::getDefault());
     }
@@ -375,7 +375,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex start
      */
-    public static function start(callable $action, SchedulerInterface $scheduler = null): Observable
+    public static function start(callable $action, ?SchedulerInterface $scheduler = null): Observable
     {
         $scheduler = $scheduler ?? Scheduler::getDefault();
         $subject   = new AsyncSubject();
@@ -731,7 +731,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex groupBy
      */
-    public function groupBy(callable $keySelector, callable $elementSelector = null, callable $keySerializer = null): Observable
+    public function groupBy(callable $keySelector, ?callable $elementSelector = null, ?callable $keySerializer = null): Observable
     {
         return $this->groupByUntil($keySelector, $elementSelector, function () {
             return static::never();
@@ -751,7 +751,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex groupBy
      */
-    public function groupByUntil(callable $keySelector, callable $elementSelector = null, callable $durationSelector = null, callable $keySerializer = null): Observable
+    public function groupByUntil(callable $keySelector, ?callable $elementSelector = null, ?callable $durationSelector = null, ?callable $keySerializer = null): Observable
     {
         return $this->lift(function () use ($keySelector, $elementSelector, $durationSelector, $keySerializer) {
             return new GroupByUntilOperator($keySelector, $elementSelector, $durationSelector, $keySerializer);
@@ -835,7 +835,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex distinct
      */
-    public function distinct(callable $comparer = null): Observable
+    public function distinct(?callable $comparer = null): Observable
     {
         return $this->lift(function () use ($comparer) {
             return new DistinctOperator(null, $comparer);
@@ -853,7 +853,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex distinct
      */
-    public function distinctKey(callable $keySelector, callable $comparer = null): Observable
+    public function distinctKey(callable $keySelector, ?callable $comparer = null): Observable
     {
         return $this->lift(function () use ($keySelector, $comparer) {
             return new DistinctOperator($keySelector, $comparer);
@@ -870,7 +870,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex distinct
      */
-    public function distinctUntilChanged(callable $comparer = null): Observable
+    public function distinctUntilChanged(?callable $comparer = null): Observable
     {
         return $this->lift(function () use ($comparer) {
             return new DistinctUntilChangedOperator(null, $comparer);
@@ -889,7 +889,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex distinct
      */
-    public function distinctUntilKeyChanged(callable $keySelector = null, callable $comparer = null): Observable
+    public function distinctUntilKeyChanged(?callable $keySelector = null, ?callable $comparer = null): Observable
     {
         return $this->lift(function () use ($keySelector, $comparer) {
             return new DistinctUntilChangedOperator($keySelector, $comparer);
@@ -920,7 +920,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex do
      */
-    public function do($onNextOrObserver = null, callable $onError = null, callable $onCompleted = null): Observable
+    public function do($onNextOrObserver = null, ?callable $onError = null, ?callable $onCompleted = null): Observable
     {
         if ($onNextOrObserver instanceof ObserverInterface) {
             $observer = $onNextOrObserver;
@@ -1084,7 +1084,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex timer
      */
-    public static function timer(int $dueTime, AsyncSchedulerInterface $scheduler = null): TimerObservable
+    public static function timer(int $dueTime, ?AsyncSchedulerInterface $scheduler = null): TimerObservable
     {
         return new TimerObservable($dueTime, $scheduler ?: Scheduler::getAsync());
     }
@@ -1147,7 +1147,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex flatMap
      */
-    public function concatMap(callable $selector, callable $resultSelector = null): Observable
+    public function concatMap(callable $selector, ?callable $resultSelector = null): Observable
     {
         return $this->lift(function () use ($selector, $resultSelector) {
             return new ConcatMapOperator(new ObservableFactoryWrapper($selector), $resultSelector);
@@ -1176,7 +1176,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex flatMap
      */
-    public function concatMapTo(ObservableInterface $observable, callable $resultSelector = null): Observable
+    public function concatMapTo(ObservableInterface $observable, ?callable $resultSelector = null): Observable
     {
         return $this->concatMap(function () use ($observable) {
             return $observable;
@@ -1210,7 +1210,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex count
      */
-    public function count(callable $predicate = null): Observable
+    public function count(?callable $predicate = null): Observable
     {
         return $this->lift(function () use ($predicate) {
             return new CountOperator($predicate);
@@ -1231,7 +1231,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex publish
      */
-    public function multicast(Subject $subject, callable $selector = null): Observable
+    public function multicast(Subject $subject, ?callable $selector = null): Observable
     {
         return $selector ?
             new MulticastObservable($this, function () use ($subject) {
@@ -1253,7 +1253,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex publish
      */
-    public function multicastWithSelector(callable $subjectSelector, callable $selector = null): MulticastObservable
+    public function multicastWithSelector(callable $subjectSelector, ?callable $selector = null): MulticastObservable
     {
         return new MulticastObservable($this, $subjectSelector, $selector);
     }
@@ -1270,7 +1270,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex publish
      */
-    public function publish(callable $selector = null): Observable
+    public function publish(?callable $selector = null): Observable
     {
         return $this->multicast(new Subject(), $selector);
     }
@@ -1287,7 +1287,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex publish
      */
-    public function publishLast(callable $selector = null): Observable
+    public function publishLast(?callable $selector = null): Observable
     {
         return $this->multicast(new AsyncSubject(), $selector);
     }
@@ -1305,7 +1305,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex publish
      */
-    public function publishValue($initialValue, callable $selector = null): Observable
+    public function publishValue($initialValue, ?callable $selector = null): Observable
     {
         return $this->multicast(new BehaviorSubject($initialValue), $selector);
     }
@@ -1403,7 +1403,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex replay
      */
-    public function replay(callable $selector = null, int $bufferSize = null, int $windowSize = null, SchedulerInterface $scheduler = null): Observable
+    public function replay(?callable $selector = null, ?int $bufferSize = null, ?int $windowSize = null, ?SchedulerInterface $scheduler = null): Observable
     {
         return $this->multicast(new ReplaySubject($bufferSize, $windowSize, $scheduler ?: Scheduler::getDefault()), $selector);
     }
@@ -1425,7 +1425,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex replay
      */
-    public function shareReplay(int $bufferSize, int $windowSize = null, SchedulerInterface $scheduler = null): RefCountObservable
+    public function shareReplay(int $bufferSize, ?int $windowSize = null, ?SchedulerInterface $scheduler = null): RefCountObservable
     {
         return $this->replay(null, $bufferSize, $windowSize, $scheduler)->refCount();
     }
@@ -1445,7 +1445,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex zip
      */
-    public function zip(array $observables, callable $selector = null): Observable
+    public function zip(array $observables, ?callable $selector = null): Observable
     {
         return $this->lift(function () use ($observables, $selector) {
             return new ZipOperator($observables, $selector);
@@ -1463,7 +1463,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex zip
      */
-    public static function forkJoin(array $observables = [], callable $resultSelector = null): ForkJoinObservable
+    public static function forkJoin(array $observables = [], ?callable $resultSelector = null): ForkJoinObservable
     {
         return new ForkJoinObservable($observables, $resultSelector);
     }
@@ -1518,7 +1518,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex combinelatest
      */
-    public function combineLatest(array $observables, callable $selector = null): Observable
+    public function combineLatest(array $observables, ?callable $selector = null): Observable
     {
         return $this->lift(function () use ($observables, $selector) {
             return new CombineLatestOperator($observables, $selector);
@@ -1536,7 +1536,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex combinelatest
      */
-    public function withLatestFrom(array $observables, callable $selector = null): Observable
+    public function withLatestFrom(array $observables, ?callable $selector = null): Observable
     {
         return $this->lift(function () use ($observables, $selector) {
             return new WithLatestFromOperator($observables, $selector);
@@ -1626,7 +1626,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex delay
      */
-    public function delay(int $delay, AsyncSchedulerInterface $scheduler = null): Observable
+    public function delay(int $delay, ?AsyncSchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($delay, $scheduler) {
             return new DelayOperator($delay, $scheduler ?: Scheduler::getAsync());
@@ -1646,7 +1646,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex timeout
      */
-    public function timeout(int $timeout, ObservableInterface $timeoutObservable = null, AsyncSchedulerInterface $scheduler = null): Observable
+    public function timeout(int $timeout, ?ObservableInterface $timeoutObservable = null, ?AsyncSchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($timeout, $timeoutObservable, $scheduler) {
             return new TimeoutOperator($timeout, $timeoutObservable, $scheduler ?: Scheduler::getAsync());
@@ -1667,7 +1667,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex buffer
      */
-    public function bufferWithCount(int $count, int $skip = null): Observable
+    public function bufferWithCount(int $count, ?int $skip = null): Observable
     {
         return $this->lift(function () use ($count, $skip) {
             return new BufferWithCountOperator($count, $skip);
@@ -1714,7 +1714,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex startwith
      */
-    public function startWith($startValue, SchedulerInterface $scheduler = null): Observable
+    public function startWith($startValue, ?SchedulerInterface $scheduler = null): Observable
     {
         return $this->startWithArray([$startValue], $scheduler);
     }
@@ -1730,7 +1730,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex startwith
      */
-    public function startWithArray(array $startArray, SchedulerInterface $scheduler = null): Observable
+    public function startWithArray(array $startArray, ?SchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($startArray, $scheduler) {
             return new StartWithArrayOperator($startArray, $scheduler ?: Scheduler::getDefault());
@@ -1748,7 +1748,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex min
      */
-    public function min(callable $comparer = null): Observable
+    public function min(?callable $comparer = null): Observable
     {
         return $this->lift(function () use ($comparer) {
             return new MinOperator($comparer);
@@ -1766,7 +1766,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex max
      */
-    public function max(callable $comparer = null): Observable
+    public function max(?callable $comparer = null): Observable
     {
         return $this->lift(function () use ($comparer) {
             return new MaxOperator($comparer);
@@ -1813,7 +1813,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex timestamp
      */
-    public function timestamp(SchedulerInterface $scheduler = null): Observable
+    public function timestamp(?SchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($scheduler) {
             return new TimestampOperator($scheduler ?: Scheduler::getDefault());
@@ -1907,7 +1907,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex amb
      */
-    public static function race(array $observables, SchedulerInterface $scheduler = null): Observable
+    public static function race(array $observables, ?SchedulerInterface $scheduler = null): Observable
     {
         if (count($observables) === 1) {
             return $observables[0];
@@ -2004,7 +2004,7 @@ abstract class Observable implements ObservableInterface
      * @operator
      * @reactivex debounce
      */
-    public function throttle(int $throttleDuration, SchedulerInterface $scheduler = null): Observable
+    public function throttle(int $throttleDuration, ?SchedulerInterface $scheduler = null): Observable
     {
         return $this->lift(function () use ($throttleDuration, $scheduler) {
             return new ThrottleOperator($throttleDuration, $scheduler ?: Scheduler::getDefault());
@@ -2069,7 +2069,7 @@ abstract class Observable implements ObservableInterface
      * @return PromiseInterface
      * @throws \InvalidArgumentException
      */
-    public function toPromise(Deferred $deferred = null): PromiseInterface
+    public function toPromise(?Deferred $deferred = null): PromiseInterface
     {
         return Promise::fromObservable($this, $deferred);
     }

--- a/src/Observable/AnonymousObservable.php
+++ b/src/Observable/AnonymousObservable.php
@@ -27,7 +27,7 @@ class AnonymousObservable extends Observable
 
         $autoDetachObserver->setDisposable($subscribeAction($autoDetachObserver));
 
-        return new CallbackDisposable(function () use ($autoDetachObserver) {
+        return new CallbackDisposable(function () use ($autoDetachObserver): void {
             $autoDetachObserver->dispose();
         });
     }

--- a/src/Observable/ArrayObservable.php
+++ b/src/Observable/ArrayObservable.php
@@ -28,7 +28,7 @@ class ArrayObservable extends Observable
         $keys   = array_keys($values);
         $count  = 0;
 
-        return $this->scheduler->scheduleRecursive(function ($reschedule) use (&$observer, &$values, $max, &$count, $keys) {
+        return $this->scheduler->scheduleRecursive(function ($reschedule) use (&$observer, &$values, $max, &$count, $keys): void {
             if ($count < $max) {
                 $observer->onNext($values[$keys[$count]]);
                 $count++;

--- a/src/Observable/ConnectableObservable.php
+++ b/src/Observable/ConnectableObservable.php
@@ -34,7 +34,7 @@ class ConnectableObservable extends Observable
      * @param Observable $source
      * @param \Rx\Subject\Subject $subject
      */
-    public function __construct(Observable $source, Subject $subject = null)
+    public function __construct(Observable $source, ?Subject $subject = null)
     {
         $this->sourceObservable = $source->asObservable();
         $this->subject          = $subject ?: new Subject();

--- a/src/Observable/ConnectableObservable.php
+++ b/src/Observable/ConnectableObservable.php
@@ -54,7 +54,7 @@ class ConnectableObservable extends Observable
 
         $this->hasSubscription = true;
 
-        $connectableDisposable = new CallbackDisposable(function () {
+        $connectableDisposable = new CallbackDisposable(function (): void {
             $this->hasSubscription = false;
         });
 

--- a/src/Observable/EmptyObservable.php
+++ b/src/Observable/EmptyObservable.php
@@ -20,7 +20,7 @@ class EmptyObservable extends Observable
 
     protected function _subscribe(ObserverInterface $observer): DisposableInterface
     {
-        return $this->scheduler->schedule(function () use ($observer) {
+        return $this->scheduler->schedule(function () use ($observer): void {
             $observer->onCompleted();
         });
     }

--- a/src/Observable/ErrorObservable.php
+++ b/src/Observable/ErrorObservable.php
@@ -22,7 +22,7 @@ class ErrorObservable extends Observable
 
     protected function _subscribe(ObserverInterface $observer): DisposableInterface
     {
-        return $this->scheduler->schedule(function () use ($observer) {
+        return $this->scheduler->schedule(function () use ($observer): void {
             $observer->onError($this->error);
         });
     }

--- a/src/Observable/ForkJoinObservable.php
+++ b/src/Observable/ForkJoinObservable.php
@@ -43,11 +43,11 @@ class ForkJoinObservable extends Observable
 
         foreach ($this->observables as $i => $observable) {
             $innerDisp = $observable->subscribe(
-                function ($v) use ($i) {
+                function ($v) use ($i): void {
                     $this->values[$i] = $v;
                 },
                 [$autoObs, 'onError'],
-                function () use ($len, $i, $autoObs) {
+                function () use ($len, $i, $autoObs): void {
                     $this->completed++;
 
                     if (!array_key_exists($i, $this->values)) {

--- a/src/Observable/ForkJoinObservable.php
+++ b/src/Observable/ForkJoinObservable.php
@@ -23,7 +23,7 @@ class ForkJoinObservable extends Observable
 
     private $resultSelector;
 
-    public function __construct(array $observables = [], callable $resultSelector = null)
+    public function __construct(array $observables = [], ?callable $resultSelector = null)
     {
         $this->observables    = $observables;
         $this->resultSelector = $resultSelector;

--- a/src/Observable/GroupedObservable.php
+++ b/src/Observable/GroupedObservable.php
@@ -16,7 +16,7 @@ class GroupedObservable extends Observable
     private $key;
     private $underlyingObservable;
 
-    public function __construct($key, ObservableInterface $underlyingObservable, RefCountDisposable $mergedDisposable = null)
+    public function __construct($key, ObservableInterface $underlyingObservable, ?RefCountDisposable $mergedDisposable = null)
     {
         $this->key = $key;
 

--- a/src/Observable/IntervalObservable.php
+++ b/src/Observable/IntervalObservable.php
@@ -32,7 +32,7 @@ class IntervalObservable extends Observable
         $counter = 0;
 
         return $this->scheduler->schedulePeriodic(
-            function () use (&$counter, $observer) {
+            function () use (&$counter, $observer): void {
                 $observer->onNext($counter++);
             },
             $this->interval, // this is to match RxJS behavior which delays the first item by the interval

--- a/src/Observable/IteratorObservable.php
+++ b/src/Observable/IteratorObservable.php
@@ -15,7 +15,7 @@ class IteratorObservable extends Observable
 
     private $scheduler;
 
-    public function __construct(\Iterator $items, SchedulerInterface $scheduler = null)
+    public function __construct(\Iterator $items, ?SchedulerInterface $scheduler = null)
     {
         $this->items     = $items;
         $this->scheduler = $scheduler;

--- a/src/Observable/IteratorObservable.php
+++ b/src/Observable/IteratorObservable.php
@@ -25,7 +25,7 @@ class IteratorObservable extends Observable
     {
         $key = 0;
 
-        $action = function ($reschedule) use (&$observer, &$key) {
+        $action = function ($reschedule) use (&$observer, &$key): void {
             try {
                 if (null === $key || !$this->items->valid()) {
 

--- a/src/Observable/RangeObservable.php
+++ b/src/Observable/RangeObservable.php
@@ -28,7 +28,7 @@ class RangeObservable extends Observable
     {
         $i = 0;
 
-        return $this->scheduler->scheduleRecursive(function ($reschedule) use (&$observer, &$i) {
+        return $this->scheduler->scheduleRecursive(function ($reschedule) use (&$observer, &$i): void {
             if ($i < $this->count) {
                 $observer->onNext($this->start + $i);
                 $i++;

--- a/src/Observable/RefCountObservable.php
+++ b/src/Observable/RefCountObservable.php
@@ -41,7 +41,7 @@ class RefCountObservable extends Observable
             $this->connectableSubscription = $this->source->connect();
         }
 
-        return new CallbackDisposable(function () use ($subscription) {
+        return new CallbackDisposable(function () use ($subscription): void {
             $subscription->dispose();
 
             $this->count--;

--- a/src/Observable/ReturnObservable.php
+++ b/src/Observable/ReturnObservable.php
@@ -25,11 +25,11 @@ class ReturnObservable extends Observable
     {
         $disposable = new CompositeDisposable();
 
-        $disposable->add($this->scheduler->schedule(function () use ($observer) {
+        $disposable->add($this->scheduler->schedule(function () use ($observer): void {
             $observer->onNext($this->value);
         }));
 
-        $disposable->add($this->scheduler->schedule(function () use ($observer) {
+        $disposable->add($this->scheduler->schedule(function () use ($observer): void {
             $observer->onCompleted();
         }));
 

--- a/src/Observable/TimerObservable.php
+++ b/src/Observable/TimerObservable.php
@@ -24,7 +24,7 @@ class TimerObservable extends Observable
     protected function _subscribe(ObserverInterface $observer): DisposableInterface
     {
         return $this->scheduler->schedule(
-            function () use ($observer) {
+            function () use ($observer): void {
                 $observer->onNext(0);
                 $observer->onCompleted();
             },

--- a/src/ObservableInterface.php
+++ b/src/ObservableInterface.php
@@ -13,5 +13,5 @@ interface ObservableInterface
      * @return DisposableInterface
      * @throws \InvalidArgumentException
      */
-    public function subscribe($onNextOrObserver = null, callable  $onError = null, callable $onCompleted = null): DisposableInterface;
+    public function subscribe($onNextOrObserver = null, ?callable  $onError = null, ?callable $onCompleted = null): DisposableInterface;
 }

--- a/src/Observer/AutoDetachObserver.php
+++ b/src/Observer/AutoDetachObserver.php
@@ -21,7 +21,7 @@ class AutoDetachObserver extends AbstractObserver
         $this->disposable = new SingleAssignmentDisposable();
     }
 
-    public function setDisposable(DisposableInterface $disposable = null)
+    public function setDisposable(?DisposableInterface $disposable = null)
     {
         $disposable = $disposable ?: new EmptyDisposable();
 

--- a/src/Observer/CallbackObserver.php
+++ b/src/Observer/CallbackObserver.php
@@ -17,12 +17,12 @@ class CallbackObserver extends AbstractObserver
 
     public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
     {
-        $default = function () {
+        $default = function (): void {
         };
 
         $this->onNext = $this->getOrDefault($onNext, $default);
 
-        $this->onError = $this->getOrDefault($onError, function ($e) {
+        $this->onError = $this->getOrDefault($onError, function ($e): void {
             throw $e;
         });
 

--- a/src/Observer/CallbackObserver.php
+++ b/src/Observer/CallbackObserver.php
@@ -15,7 +15,7 @@ class CallbackObserver extends AbstractObserver
     /** @var callable|null */
     private $onCompleted;
 
-    public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
+    public function __construct(?callable $onNext = null, ?callable $onError = null, ?callable $onCompleted = null)
     {
         $default = function (): void {
         };
@@ -45,7 +45,7 @@ class CallbackObserver extends AbstractObserver
         ($this->onNext)($value);
     }
 
-    private function getOrDefault(callable $callback = null, $default = null): callable
+    private function getOrDefault(?callable $callback = null, $default = null): callable
     {
         if (null === $callback) {
             return $default;

--- a/src/Observer/DoObserver.php
+++ b/src/Observer/DoObserver.php
@@ -17,7 +17,7 @@ class DoObserver implements ObserverInterface
     /** @var callable|null */
     private $onCompleted;
 
-    public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
+    public function __construct(?callable $onNext = null, ?callable $onError = null, ?callable $onCompleted = null)
     {
         $default = function (): void {
         };
@@ -46,7 +46,7 @@ class DoObserver implements ObserverInterface
         ($this->onNext)($value);
     }
 
-    private function getOrDefault(callable $callback = null, $default = null): callable
+    private function getOrDefault(?callable $callback = null, $default = null): callable
     {
         if (null === $callback) {
             return $default;

--- a/src/Observer/DoObserver.php
+++ b/src/Observer/DoObserver.php
@@ -19,12 +19,12 @@ class DoObserver implements ObserverInterface
 
     public function __construct(callable $onNext = null, callable $onError = null, callable $onCompleted = null)
     {
-        $default = function () {
+        $default = function (): void {
         };
 
         $this->onNext = $this->getOrDefault($onNext, $default);
 
-        $this->onError = $this->getOrDefault($onError, function ($e) {
+        $this->onError = $this->getOrDefault($onError, function ($e): void {
             throw $e;
         });
 

--- a/src/Observer/ScheduledObserver.php
+++ b/src/Observer/ScheduledObserver.php
@@ -43,21 +43,21 @@ final class ScheduledObserver extends AbstractObserver
 
     protected function completed()
     {
-        $this->queue[] = function () {
+        $this->queue[] = function (): void {
             $this->observer->onCompleted();
         };
     }
 
     protected function next($value)
     {
-        $this->queue[] = function () use ($value) {
+        $this->queue[] = function () use ($value): void {
             $this->observer->onNext($value);
         };
     }
 
     protected function error(\Throwable $error)
     {
-        $this->queue[] = function () use ($error) {
+        $this->queue[] = function () use ($error): void {
             $this->observer->onError($error);
         };
     }
@@ -76,7 +76,7 @@ final class ScheduledObserver extends AbstractObserver
 
         $this->disposable->setDisposable(
             $this->scheduler->scheduleRecursive(
-                function ($recurse) {
+                function ($recurse): void {
                     $parent = $this;
                     if (count($parent->queue) > 0) {
                         $work = array_shift($parent->queue);

--- a/src/Operator/BufferWithCountOperator.php
+++ b/src/Operator/BufferWithCountOperator.php
@@ -26,7 +26,7 @@ final class BufferWithCountOperator implements OperatorInterface
      * @param int $skip
      * @throws \InvalidArgumentException
      */
-    public function __construct(int $count, int $skip = null)
+    public function __construct(int $count, ?int $skip = null)
     {
         if ($count < 1) {
             throw new \InvalidArgumentException('count must be greater than or equal to 1');

--- a/src/Operator/BufferWithCountOperator.php
+++ b/src/Operator/BufferWithCountOperator.php
@@ -49,7 +49,7 @@ final class BufferWithCountOperator implements OperatorInterface
         $currentGroups = [];
 
         return $observable->subscribe(new CallbackObserver(
-            function ($x) use (&$currentGroups, $observer) {
+            function ($x) use (&$currentGroups, $observer): void {
                 if ($this->index % $this->skip === 0) {
                     $currentGroups[] = [];
                 }
@@ -63,10 +63,10 @@ final class BufferWithCountOperator implements OperatorInterface
                     }
                 }
             },
-            function ($err) use ($observer) {
+            function ($err) use ($observer): void {
                 $observer->onError($err);
             },
-            function () use (&$currentGroups, $observer) {
+            function () use (&$currentGroups, $observer): void {
                 foreach ($currentGroups as &$group) {
                     $observer->onNext($group);
                 }

--- a/src/Operator/CatchErrorOperator.php
+++ b/src/Operator/CatchErrorOperator.php
@@ -28,7 +28,7 @@ final class CatchErrorOperator implements OperatorInterface
         $isDisposed = false;
         $disposable = new CompositeDisposable();
 
-        $onError = function (\Throwable $e) use (&$isDisposed, $observer, $observable, $disposable) {
+        $onError = function (\Throwable $e) use (&$isDisposed, $observer, $observable, $disposable): void {
 
             if ($isDisposed) {
                 return;
@@ -57,7 +57,7 @@ final class CatchErrorOperator implements OperatorInterface
 
         $disposable->add($subscription);
 
-        $disposable->add(new CallbackDisposable(function () use (&$isDisposed) {
+        $disposable->add(new CallbackDisposable(function () use (&$isDisposed): void {
             $isDisposed = true;
         }));
 

--- a/src/Operator/CombineLatestOperator.php
+++ b/src/Operator/CombineLatestOperator.php
@@ -53,7 +53,7 @@ final class CombineLatestOperator implements OperatorInterface
             $hasValue[$key] = false;
 
             $cbObserver = new CallbackObserver(
-                function ($value) use ($count, &$hasValue, $key, &$values, $observer, &$waitingForValues, &$waitingToComplete) {
+                function ($value) use ($count, &$hasValue, $key, &$values, $observer, &$waitingForValues, &$waitingToComplete): void {
 
                     // If an observable has completed before it has emitted, we need to complete right away
                     if ($waitingForValues > $waitingToComplete) {
@@ -77,7 +77,7 @@ final class CombineLatestOperator implements OperatorInterface
                     }
                 },
                 [$observer, 'onError'],
-                function () use (&$waitingToComplete, $observer) {
+                function () use (&$waitingToComplete, $observer): void {
                     $waitingToComplete--;
                     if ($waitingToComplete === 0) {
                         $observer->onCompleted();

--- a/src/Operator/CombineLatestOperator.php
+++ b/src/Operator/CombineLatestOperator.php
@@ -18,7 +18,7 @@ final class CombineLatestOperator implements OperatorInterface
     /** @var callable */
     private $resultSelector;
 
-    public function __construct(array $observables, callable $resultSelector = null)
+    public function __construct(array $observables, ?callable $resultSelector = null)
     {
         if (null === $resultSelector) {
             $resultSelector = function () {

--- a/src/Operator/ConcatAllOperator.php
+++ b/src/Operator/ConcatAllOperator.php
@@ -45,7 +45,7 @@ final class ConcatAllOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         $subscription = $observable->subscribe(new CallbackObserver(
-            function (ObservableInterface $innerObservable) use ($observable, $observer) {
+            function (ObservableInterface $innerObservable) use ($observable, $observer): void {
                 try {
 
                     if ($this->startBuffering === true) {
@@ -53,7 +53,7 @@ final class ConcatAllOperator implements OperatorInterface
                         return;
                     }
 
-                    $onCompleted = function () use (&$subscribeToInner, $observer) {
+                    $onCompleted = function () use (&$subscribeToInner, $observer): void {
 
                         $this->disposable->remove($this->innerDisposable);
                         $this->innerDisposable->dispose();
@@ -73,7 +73,7 @@ final class ConcatAllOperator implements OperatorInterface
                         }
                     };
 
-                    $subscribeToInner = function ($observable) use ($observer, &$onCompleted) {
+                    $subscribeToInner = function ($observable) use ($observer, &$onCompleted): void {
                         $callbackObserver = new CallbackObserver(
                             [$observer, 'onNext'],
                             [$observer, 'onError'],
@@ -94,7 +94,7 @@ final class ConcatAllOperator implements OperatorInterface
                 }
             },
             [$observer, 'onError'],
-            function () use ($observer) {
+            function () use ($observer): void {
                 $this->sourceCompleted = true;
                 if ($this->innerCompleted === true) {
                     $observer->onCompleted();

--- a/src/Operator/ConcatMapOperator.php
+++ b/src/Operator/ConcatMapOperator.php
@@ -16,7 +16,7 @@ final class ConcatMapOperator implements OperatorInterface
     /** @var callable */
     private $resultSelector;
 
-    public function __construct(callable $selector, callable $resultSelector = null)
+    public function __construct(callable $selector, ?callable $resultSelector = null)
     {
         $this->selector       = $selector;
         $this->resultSelector = $resultSelector;

--- a/src/Operator/ConcatOperator.php
+++ b/src/Operator/ConcatOperator.php
@@ -34,7 +34,7 @@ final class ConcatOperator implements OperatorInterface
         $cbObserver = new CallbackObserver(
             [$observer, 'onNext'],
             [$observer, 'onError'],
-            function () use ($observer, $disp) {
+            function () use ($observer, $disp): void {
                 $disp->setDisposable($this->subsequentObservable->subscribe($observer));
             }
         );

--- a/src/Operator/CountOperator.php
+++ b/src/Operator/CountOperator.php
@@ -14,7 +14,7 @@ final class CountOperator implements OperatorInterface
     private $count = 0;
     private $predicate;
 
-    public function __construct(callable $predicate = null)
+    public function __construct(?callable $predicate = null)
     {
         $this->predicate = $predicate;
     }

--- a/src/Operator/CountOperator.php
+++ b/src/Operator/CountOperator.php
@@ -22,7 +22,7 @@ final class CountOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         $callbackObserver = new CallbackObserver(
-            function ($x) use ($observer) {
+            function ($x) use ($observer): void {
                 if ($this->predicate === null) {
                     $this->count++;
 
@@ -38,7 +38,7 @@ final class CountOperator implements OperatorInterface
                 }
             },
             [$observer, 'onError'],
-            function () use ($observer) {
+            function () use ($observer): void {
                 $observer->onNext($this->count);
                 $observer->onCompleted();
             }

--- a/src/Operator/DefaultIfEmptyOperator.php
+++ b/src/Operator/DefaultIfEmptyOperator.php
@@ -27,12 +27,12 @@ final class DefaultIfEmptyOperator implements OperatorInterface
     {
         $disposable = new SerialDisposable();
         $cbObserver = new CallbackObserver(
-            function ($x) use ($observer) {
+            function ($x) use ($observer): void {
                 $this->passThrough = true;
                 $observer->onNext($x);
             },
             [$observer, 'onError'],
-            function () use ($observer, $disposable) {
+            function () use ($observer, $disposable): void {
                 if (!$this->passThrough) {
                     $disposable->setDisposable($this->observable->subscribe($observer));
                     return;

--- a/src/Operator/DelayOperator.php
+++ b/src/Operator/DelayOperator.php
@@ -45,14 +45,14 @@ final class DelayOperator implements OperatorInterface
                 return new Timestamped($x->getTimestampMillis() + $this->delayTime, $x->getValue());
             })
             ->subscribe(new CallbackObserver(
-                function (Timestamped $x) use ($observer) {
+                function (Timestamped $x) use ($observer): void {
                     if ($x->getValue() instanceof Notification\OnErrorNotification) {
                         $x->getValue()->accept($observer);
                         return;
                     }
                     $this->queue->enqueue($x);
                     if ($this->schedulerDisposable === null) {
-                        $doScheduledStuff = function () use ($observer, &$doScheduledStuff) {
+                        $doScheduledStuff = function () use ($observer, &$doScheduledStuff): void {
                             while ((!$this->queue->isEmpty()) && $this->scheduler->now() >= $this->queue->bottom()->getTimestampMillis()) {
                                 /** @var Timestamped $item */
                                 $item = $this->queue->dequeue();
@@ -77,7 +77,7 @@ final class DelayOperator implements OperatorInterface
                 [$observer, 'onError']
             ));
 
-        return new CallbackDisposable(function () use ($disp) {
+        return new CallbackDisposable(function () use ($disp): void {
             if ($this->schedulerDisposable) {
                 $this->schedulerDisposable->dispose();
             }

--- a/src/Operator/DematerializeOperator.php
+++ b/src/Operator/DematerializeOperator.php
@@ -15,7 +15,7 @@ final class DematerializeOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         return $observable->subscribe(new CallbackObserver(
-            function (Notification $x) use ($observer) {
+            function (Notification $x) use ($observer): void {
                 $x->accept($observer);
             },
             [$observer, 'onError'],

--- a/src/Operator/DistinctOperator.php
+++ b/src/Operator/DistinctOperator.php
@@ -20,7 +20,7 @@ final class DistinctOperator implements OperatorInterface
     /** @var callable */
     protected $comparer;
 
-    public function __construct(callable $keySelector = null, callable $comparer = null)
+    public function __construct(?callable $keySelector = null, ?callable $comparer = null)
     {
         $this->comparer = $comparer;
         $this->keySelector = $keySelector;

--- a/src/Operator/DistinctUntilChangedOperator.php
+++ b/src/Operator/DistinctUntilChangedOperator.php
@@ -15,7 +15,7 @@ final class DistinctUntilChangedOperator implements OperatorInterface
 
     protected $comparer;
 
-    public function __construct(callable $keySelector = null, callable $comparer = null)
+    public function __construct(?callable $keySelector = null, ?callable $comparer = null)
     {
         $this->comparer = $comparer ?: function ($x, $y) {
             return $x == $y;

--- a/src/Operator/FilterOperator.php
+++ b/src/Operator/FilterOperator.php
@@ -21,7 +21,7 @@ final class FilterOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         $selectObserver = new CallbackObserver(
-            function ($nextValue) use ($observer) {
+            function ($nextValue) use ($observer): void {
                 $shouldFire = false;
                 try {
                     $shouldFire = ($this->predicate)($nextValue);

--- a/src/Operator/GroupByUntilOperator.php
+++ b/src/Operator/GroupByUntilOperator.php
@@ -22,7 +22,7 @@ final class GroupByUntilOperator implements OperatorInterface
     private $keySerializer;
     private $map = [];
 
-    public function __construct(callable $keySelector, callable $elementSelector = null, callable $durationSelector = null, callable $keySerializer = null)
+    public function __construct(callable $keySelector, ?callable $elementSelector = null, ?callable $durationSelector = null, ?callable $keySerializer = null)
     {
         if (null === $elementSelector) {
             $elementSelector = function ($elem) {

--- a/src/Operator/GroupByUntilOperator.php
+++ b/src/Operator/GroupByUntilOperator.php
@@ -54,7 +54,7 @@ final class GroupByUntilOperator implements OperatorInterface
         $refCountDisposable = new RefCountDisposable($groupDisposable);
         $sourceEmits        = true;
 
-        $handleError = function (\Throwable $e) use ($observer, &$sourceEmits) {
+        $handleError = function (\Throwable $e) use ($observer, &$sourceEmits): void {
             foreach ($this->map as $w) {
                 $w->onError($e);
             }
@@ -64,7 +64,7 @@ final class GroupByUntilOperator implements OperatorInterface
         };
 
         $subscription = $observable->subscribe(
-            function ($element) use ($observer, $handleError, $refCountDisposable, $groupDisposable, &$sourceEmits) {
+            function ($element) use ($observer, $handleError, $refCountDisposable, $groupDisposable, &$sourceEmits): void {
                 try {
                     $key           = call_user_func($this->keySelector, $element);
                     $serializedKey = call_user_func($this->keySerializer, $key);
@@ -98,7 +98,7 @@ final class GroupByUntilOperator implements OperatorInterface
                     $durationSubscription = $duration->take(1)->subscribe(
                         null,
                         $handleError,
-                        function () use ($groupDisposable, $md, $writer, $serializedKey) {
+                        function () use ($groupDisposable, $md, $writer, $serializedKey): void {
                             unset($this->map[$serializedKey]);
                             $writer->onCompleted();
 
@@ -120,7 +120,7 @@ final class GroupByUntilOperator implements OperatorInterface
                 $this->map[$serializedKey]->onNext($element);
             },
             $handleError,
-            function () use ($observer, &$sourceEmits) {
+            function () use ($observer, &$sourceEmits): void {
                 foreach ($this->map as $w) {
                     $w->onCompleted();
                 }
@@ -131,7 +131,7 @@ final class GroupByUntilOperator implements OperatorInterface
 
         $groupDisposable->add($subscription);
 
-        return new CallbackDisposable(function () use (&$sourceEmits, $refCountDisposable) {
+        return new CallbackDisposable(function () use (&$sourceEmits, $refCountDisposable): void {
             $sourceEmits = false;
             $refCountDisposable->dispose();
         });

--- a/src/Operator/IsEmptyOperator.php
+++ b/src/Operator/IsEmptyOperator.php
@@ -12,12 +12,12 @@ final class IsEmptyOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         return $observable->subscribe(
-            function() use ($observer) {
+            function() use ($observer): void {
                 $observer->onNext(false);
                 $observer->onCompleted();
             },
             [$observer, 'onError'],
-            function() use ($observer) {
+            function() use ($observer): void {
                 $observer->onNext(true);
                 $observer->onCompleted();
             }

--- a/src/Operator/MapOperator.php
+++ b/src/Operator/MapOperator.php
@@ -26,7 +26,7 @@ final class MapOperator implements OperatorInterface
         $disposable = new CompositeDisposable();
 
         $selectObserver = new CallbackObserver(
-            function ($nextValue) use ($observer, &$disposed) {
+            function ($nextValue) use ($observer, &$disposed): void {
 
                 $value = null;
                 try {
@@ -42,7 +42,7 @@ final class MapOperator implements OperatorInterface
             [$observer, 'onCompleted']
         );
 
-        $disposable->add(new CallbackDisposable(function () use (&$disposed) {
+        $disposable->add(new CallbackDisposable(function () use (&$disposed): void {
             $disposed = true;
         }));
 

--- a/src/Operator/MaterializeOperator.php
+++ b/src/Operator/MaterializeOperator.php
@@ -17,14 +17,14 @@ final class MaterializeOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         return $observable->subscribe(new CallbackObserver(
-            function ($x) use ($observer) {
+            function ($x) use ($observer): void {
                 $observer->onNext(new OnNextNotification($x));
             },
-            function ($error) use ($observer) {
+            function ($error) use ($observer): void {
                 $observer->onNext(new OnErrorNotification($error));
                 $observer->onCompleted();
             },
-            function () use ($observer) {
+            function () use ($observer): void {
                 $observer->onNext(new OnCompletedNotification());
                 $observer->onCompleted();
             }

--- a/src/Operator/MaxOperator.php
+++ b/src/Operator/MaxOperator.php
@@ -30,7 +30,7 @@ final class MaxOperator implements OperatorInterface
         $comparing   = false;
 
         return $observable->subscribe(new CallbackObserver(
-            function ($x) use (&$comparing, &$previousMax, $observer) {
+            function ($x) use (&$comparing, &$previousMax, $observer): void {
                 if (!$comparing) {
                     $comparing   = true;
                     $previousMax = $x;
@@ -48,7 +48,7 @@ final class MaxOperator implements OperatorInterface
                 }
             },
             [$observer, 'onError'],
-            function () use (&$comparing, &$previousMax, $observer) {
+            function () use (&$comparing, &$previousMax, $observer): void {
                 if ($comparing) {
                     $observer->onNext($previousMax);
                     $observer->onCompleted();

--- a/src/Operator/MaxOperator.php
+++ b/src/Operator/MaxOperator.php
@@ -13,7 +13,7 @@ final class MaxOperator implements OperatorInterface
 {
     private $comparer;
 
-    public function __construct(callable $comparer = null)
+    public function __construct(?callable $comparer = null)
     {
         if ($comparer === null) {
             $comparer = function ($x, $y) {

--- a/src/Operator/MergeAllOperator.php
+++ b/src/Operator/MergeAllOperator.php
@@ -22,19 +22,19 @@ final class MergeAllOperator implements OperatorInterface
         $group->add($sourceSubscription);
 
         $callbackObserver = new CallbackObserver(
-            function (ObservableInterface $innerSource) use (&$group, &$isStopped, $observer) {
+            function (ObservableInterface $innerSource) use (&$group, &$isStopped, $observer): void {
                 $innerSubscription = new SingleAssignmentDisposable();
                 $group->add($innerSubscription);
 
                 $innerSubscription->setDisposable(
                     $innerSource->subscribe(new CallbackObserver(
-                        function ($nextValue) use ($observer) {
+                        function ($nextValue) use ($observer): void {
                             $observer->onNext($nextValue);
                         },
-                        function ($error) use ($observer) {
+                        function ($error) use ($observer): void {
                             $observer->onError($error);
                         },
-                        function () use (&$group, &$innerSubscription, &$isStopped, $observer) {
+                        function () use (&$group, &$innerSubscription, &$isStopped, $observer): void {
                             $group->remove($innerSubscription);
 
                             if ($isStopped && $group->count() === 1) {
@@ -45,7 +45,7 @@ final class MergeAllOperator implements OperatorInterface
                 );
             },
             [$observer, 'onError'],
-            function () use (&$group, &$isStopped, $observer) {
+            function () use (&$group, &$isStopped, $observer): void {
                 $isStopped = true;
                 if ($group->count() === 1) {
                     $observer->onCompleted();

--- a/src/Operator/MinOperator.php
+++ b/src/Operator/MinOperator.php
@@ -30,7 +30,7 @@ final class MinOperator implements OperatorInterface
         $comparing   = false;
 
         return $observable->subscribe(new CallbackObserver(
-            function ($x) use (&$comparing, &$previousMin, $observer) {
+            function ($x) use (&$comparing, &$previousMin, $observer): void {
                 if (!$comparing) {
                     $comparing   = true;
                     $previousMin = $x;
@@ -48,7 +48,7 @@ final class MinOperator implements OperatorInterface
                 }
             },
             [$observer, 'onError'],
-            function () use (&$comparing, &$previousMin, $observer) {
+            function () use (&$comparing, &$previousMin, $observer): void {
                 if ($comparing) {
                     $observer->onNext($previousMin);
                     $observer->onCompleted();

--- a/src/Operator/MinOperator.php
+++ b/src/Operator/MinOperator.php
@@ -13,7 +13,7 @@ final class MinOperator implements OperatorInterface
 {
     private $comparer;
 
-    public function __construct(callable $comparer = null)
+    public function __construct(?callable $comparer = null)
     {
         if ($comparer === null) {
             $comparer = function ($x, $y) {

--- a/src/Operator/RaceOperator.php
+++ b/src/Operator/RaceOperator.php
@@ -37,11 +37,11 @@ final class RaceOperator implements OperatorInterface
     {
 
         $callbackObserver = new CallbackObserver(
-            function (Observable $innerObservable) {
+            function (Observable $innerObservable): void {
                 $this->observables[] = $innerObservable;
             },
             [$observer, 'onError'],
-            function () use ($observer) {
+            function () use ($observer): void {
 
                 if (count($this->observables) === 0) {
                     $observer->onCompleted();
@@ -68,7 +68,7 @@ final class RaceOperator implements OperatorInterface
     private function subscribeToResult(ObservableInterface $observable, ObserverInterface $observer, $outerIndex)
     {
         return $observable->subscribe(new CallbackObserver(
-            function ($value) use ($observer, $outerIndex) {
+            function ($value) use ($observer, $outerIndex): void {
 
                 if (!$this->hasFirst) {
                     $this->hasFirst = true;

--- a/src/Operator/ReduceOperator.php
+++ b/src/Operator/ReduceOperator.php
@@ -33,7 +33,7 @@ final class ReduceOperator implements OperatorInterface
         $accumulation    = null;
         $hasValue        = false;
         $cbObserver      = new CallbackObserver(
-            function ($x) use ($observer, &$hasAccumulation, &$accumulation, &$hasValue) {
+            function ($x) use ($observer, &$hasAccumulation, &$accumulation, &$hasValue): void {
 
                 $hasValue = true;
 
@@ -48,10 +48,10 @@ final class ReduceOperator implements OperatorInterface
                     $observer->onError($e);
                 }
             },
-            function ($e) use ($observer) {
+            function ($e) use ($observer): void {
                 $observer->onError($e);
             },
-            function () use ($observer, &$hasAccumulation, &$accumulation, &$hasValue) {
+            function () use ($observer, &$hasAccumulation, &$accumulation, &$hasValue): void {
                 if ($hasValue) {
                     $observer->onNext($accumulation);
                 } else {

--- a/src/Operator/RepeatOperator.php
+++ b/src/Operator/RepeatOperator.php
@@ -30,11 +30,11 @@ final class RepeatOperator implements OperatorInterface
 
         $disposable = new SerialDisposable();
 
-        $subscribe = function () use (&$disposable, $observable, $observer, &$completeCount, &$subscribe) {
+        $subscribe = function () use (&$disposable, $observable, $observer, &$completeCount, &$subscribe): void {
             $disposable->setDisposable($observable->subscribe(new CallbackObserver(
                 [$observer, 'onNext'],
                 [$observer, 'onError'],
-                function () use (&$completeCount, $observable, $observer, &$disposable, &$subscribe) {
+                function () use (&$completeCount, $observable, $observer, &$disposable, &$subscribe): void {
                     $completeCount++;
                     if ($this->repeatCount === -1 || $completeCount < $this->repeatCount) {
                         $subscribe();
@@ -49,7 +49,7 @@ final class RepeatOperator implements OperatorInterface
 
         $subscribe();
 
-        return new CallbackDisposable(function () use (&$disposable) {
+        return new CallbackDisposable(function () use (&$disposable): void {
             $disposable->dispose();
         });
     }

--- a/src/Operator/RepeatWhenOperator.php
+++ b/src/Operator/RepeatWhenOperator.php
@@ -52,12 +52,12 @@ final class RepeatWhenOperator implements OperatorInterface
         $outerDisposable = new SerialDisposable();
         $this->disposable->add($outerDisposable);
 
-        $subscribe = function () use ($outerDisposable, $observable, $observer, &$subscribe) {
+        $subscribe = function () use ($outerDisposable, $observable, $observer, &$subscribe): void {
             $this->sourceComplete = false;
             $outerSubscription    = $observable->subscribe(new CallbackObserver(
                 [$observer, 'onNext'],
                 [$observer, 'onError'],
-                function () use ($observer, &$subscribe, $outerDisposable) {
+                function () use ($observer, &$subscribe, $outerDisposable): void {
                     $this->sourceComplete = true;
                     if (!$this->repeat) {
                         $observer->onCompleted();
@@ -72,14 +72,14 @@ final class RepeatWhenOperator implements OperatorInterface
         };
 
         $notifierDisposable = $this->notifier->subscribe(new CallbackObserver(
-            function () use (&$subscribe) {
+            function () use (&$subscribe): void {
                 $subscribe();
             },
-            function ($ex) use ($observer) {
+            function ($ex) use ($observer): void {
                 $this->repeat = false;
                 $observer->onError($ex);
             },
-            function () use ($observer) {
+            function () use ($observer): void {
                 $this->repeat = false;
                 if ($this->sourceComplete) {
                     $observer->onCompleted();

--- a/src/Operator/RetryOperator.php
+++ b/src/Operator/RetryOperator.php
@@ -27,7 +27,7 @@ final class RetryOperator implements OperatorInterface
         $getNewObserver = function () use ($observable, $observer, $disposable, &$getNewObserver) {
             return new CallbackObserver(
                 [$observer, 'onNext'],
-                function ($error) use ($observable, $observer, $disposable, &$getNewObserver) {
+                function ($error) use ($observable, $observer, $disposable, &$getNewObserver): void {
                     $this->retryCount--;
                     if ($this->retryCount === 0) {
                         $observer->onError($error);
@@ -37,7 +37,7 @@ final class RetryOperator implements OperatorInterface
                     $subscription = $observable->subscribe($getNewObserver());
                     $disposable->setDisposable($subscription);
                 },
-                function () use ($observer) {
+                function () use ($observer): void {
                     $observer->onCompleted();
                     $this->retryCount = 0;
                 }
@@ -47,7 +47,7 @@ final class RetryOperator implements OperatorInterface
         $subscription = $observable->subscribe($getNewObserver());
         $disposable->setDisposable($subscription);
 
-        return new CallbackDisposable(function () use (&$disposable) {
+        return new CallbackDisposable(function () use (&$disposable): void {
             $disposable->dispose();
         });
     }

--- a/src/Operator/RetryWhenOperator.php
+++ b/src/Operator/RetryWhenOperator.php
@@ -36,7 +36,7 @@ final class RetryWhenOperator implements OperatorInterface
             return new EmptyDisposable();
         }
 
-        $subscribeToSource = function () use ($observer, $disposable, $observable, &$sourceError, $errors, &$sourceDisposable, &$innerCompleted) {
+        $subscribeToSource = function () use ($observer, $disposable, $observable, &$sourceError, $errors, &$sourceDisposable, &$innerCompleted): void {
             $sourceError      = false;
             $sourceDisposable = $observable->subscribe(new CallbackObserver(
                 [$observer, 'onNext'],
@@ -47,7 +47,7 @@ final class RetryWhenOperator implements OperatorInterface
                     &$sourceDisposable,
                     &$innerCompleted,
                     $observer
-                ) {
+                ): void {
                     $sourceError = true;
                     $disposable->remove($sourceDisposable);
                     $sourceDisposable->dispose();
@@ -65,14 +65,14 @@ final class RetryWhenOperator implements OperatorInterface
         };
 
         $whenDisposable = $when->subscribe(new CallbackObserver(
-            function ($x) use ($subscribeToSource, &$sourceError) {
+            function ($x) use ($subscribeToSource, &$sourceError): void {
                 if ($sourceError) {
                     $sourceError = false;
                     $subscribeToSource();
                 }
             },
             [$observer, 'onError'],
-            function () use (&$innerCompleted, &$sourceError, $observer) {
+            function () use (&$innerCompleted, &$sourceError, $observer): void {
                 $innerCompleted = true;
                 if ($sourceError) {
                     $observer->onCompleted();

--- a/src/Operator/ScanOperator.php
+++ b/src/Operator/ScanOperator.php
@@ -28,7 +28,7 @@ final class ScanOperator implements OperatorInterface
         $accumulation    = $this->seed;
         $hasSeed         = $this->seed !== null;
         $cbObserver      = new CallbackObserver(
-            function ($x) use ($observer, &$hasAccumulation, &$accumulation, &$hasSeed, &$hasValue) {
+            function ($x) use ($observer, &$hasAccumulation, &$accumulation, &$hasSeed, &$hasValue): void {
                 $hasValue = true;
                 if ($hasAccumulation) {
                     $accumulation = ($this->tryCatch($this->accumulator))($accumulation, $x);
@@ -43,7 +43,7 @@ final class ScanOperator implements OperatorInterface
                 $observer->onNext($accumulation);
             },
             [$observer, 'onError'],
-            function () use ($observer, &$hasValue, &$hasSeed) {
+            function () use ($observer, &$hasValue, &$hasSeed): void {
                 if (!$hasValue && $hasSeed) {
                     $observer->onNext($this->seed);
                 }

--- a/src/Operator/SkipLastOperator.php
+++ b/src/Operator/SkipLastOperator.php
@@ -28,7 +28,7 @@ final class SkipLastOperator implements OperatorInterface
     {
         $this->q    = [];
         $cbObserver = new CallbackObserver(
-            function ($x) use ($observer) {
+            function ($x) use ($observer): void {
                 $this->q[] = $x;
                 if (count($this->q) > $this->count) {
                     $observer->onNext(array_shift($this->q));

--- a/src/Operator/SkipOperator.php
+++ b/src/Operator/SkipOperator.php
@@ -27,7 +27,7 @@ final class SkipOperator implements OperatorInterface
         $remaining = $this->count;
 
         $cbObserver = new CallbackObserver(
-            function ($nextValue) use ($observer, &$remaining) {
+            function ($nextValue) use ($observer, &$remaining): void {
                 if ($remaining <= 0) {
                     $observer->onNext($nextValue);
                 } else {

--- a/src/Operator/SkipUntilOperator.php
+++ b/src/Operator/SkipUntilOperator.php
@@ -28,28 +28,28 @@ final class SkipUntilOperator implements OperatorInterface
 
         /** @var DisposableInterface $otherDisposable */
         $otherDisposable = $this->other->subscribe(new CallbackObserver(
-            function ($x) use (&$isOpen, &$otherDisposable) {
+            function ($x) use (&$isOpen, &$otherDisposable): void {
                 $isOpen = true;
                 $otherDisposable->dispose();
             },
-            function ($e) use ($observer) {
+            function ($e) use ($observer): void {
                 $observer->onError($e);
             },
-            function () use (&$otherDisposable) {
+            function () use (&$otherDisposable): void {
                 $otherDisposable->dispose();
             }
         ));
 
         $sourceDisposable = $observable->subscribe(new CallbackObserver(
-            function ($x) use ($observer, &$isOpen) {
+            function ($x) use ($observer, &$isOpen): void {
                 if ($isOpen) {
                     $observer->onNext($x);
                 }
             },
-            function ($e) use ($observer) {
+            function ($e) use ($observer): void {
                 $observer->onError($e);
             },
-            function () use ($observer, &$isOpen) {
+            function () use ($observer, &$isOpen): void {
                 if ($isOpen) {
                     $observer->onCompleted();
                 }

--- a/src/Operator/SkipWhileOperator.php
+++ b/src/Operator/SkipWhileOperator.php
@@ -26,7 +26,7 @@ final class SkipWhileOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         $callbackObserver = new CallbackObserver(
-            function ($value) use ($observer, $observable) {
+            function ($value) use ($observer, $observable): void {
                 try {
 
                     if ($this->isSkipping) {

--- a/src/Operator/SubscribeOnOperator.php
+++ b/src/Operator/SubscribeOnOperator.php
@@ -28,7 +28,7 @@ final class SubscribeOnOperator implements OperatorInterface
         $disposable->setDisposable($singleDisposable);
 
         $singleDisposable->setDisposable(
-            $this->scheduler->schedule(function () use ($disposable, $observer, $observable) {
+            $this->scheduler->schedule(function () use ($disposable, $observer, $observable): void {
                 $subscription = $observable->subscribe($observer);
                 $disposable->setDisposable(new ScheduledDisposable($this->scheduler, $subscription));
             })

--- a/src/Operator/SwitchFirstOperator.php
+++ b/src/Operator/SwitchFirstOperator.php
@@ -25,7 +25,7 @@ final class SwitchFirstOperator implements OperatorInterface
         $disposable->add($singleDisposable);
 
         $callbackObserver = new CallbackObserver(
-            function (Observable $x) use ($disposable, $observer) {
+            function (Observable $x) use ($disposable, $observer): void {
                 if ($this->hasCurrent) {
                     return;
                 }
@@ -37,7 +37,7 @@ final class SwitchFirstOperator implements OperatorInterface
                 $innerSub = $x->subscribe(new CallbackObserver(
                     [$observer, 'onNext'],
                     [$observer, 'onError'],
-                    function () use ($disposable, $inner, $observer) {
+                    function () use ($disposable, $inner, $observer): void {
                         $disposable->remove($inner);
                         $this->hasCurrent = false;
 
@@ -50,7 +50,7 @@ final class SwitchFirstOperator implements OperatorInterface
                 $inner->setDisposable($innerSub);
             },
             [$observer, 'onError'],
-            function () use ($disposable, $observer) {
+            function () use ($disposable, $observer): void {
                 $this->isStopped = true;
                 if (!$this->hasCurrent && $disposable->count() === 1) {
                     $observer->onCompleted();

--- a/src/Operator/SwitchLatestOperator.php
+++ b/src/Operator/SwitchLatestOperator.php
@@ -36,7 +36,7 @@ final class SwitchLatestOperator implements OperatorInterface
 
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
-        $onNext = function ($innerSource) use ($observer) {
+        $onNext = function ($innerSource) use ($observer): void {
             $innerDisposable = new SingleAssignmentDisposable();
 
             $id = ++$this->latest;
@@ -45,17 +45,17 @@ final class SwitchLatestOperator implements OperatorInterface
             $this->innerSubscription->setDisposable($innerDisposable);
 
             $innerCallbackObserver = new CallbackObserver(
-                function ($x) use ($id, $observer) {
+                function ($x) use ($id, $observer): void {
                     if ($this->latest === $id) {
                         $observer->onNext($x);
                     }
                 },
-                function ($e) use ($id, $observer) {
+                function ($e) use ($id, $observer): void {
                     if ($this->latest === $id) {
                         $observer->onError($e);
                     }
                 },
-                function () use ($id, $observer) {
+                function () use ($id, $observer): void {
                     if ($this->latest === $id) {
                         $this->hasLatest = false;
                         if ($this->isStopped) {
@@ -72,7 +72,7 @@ final class SwitchLatestOperator implements OperatorInterface
         $callbackObserver = new CallbackObserver(
             $onNext,
             [$observer, 'onError'],
-            function () use ($observer) {
+            function () use ($observer): void {
                 $this->isStopped = true;
                 if (!$this->hasLatest) {
                     $observer->onCompleted();

--- a/src/Operator/TakeLastOperator.php
+++ b/src/Operator/TakeLastOperator.php
@@ -29,7 +29,7 @@ final class TakeLastOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         $callbackObserver = new CallbackObserver(
-            function ($nextValue) use ($observer) {
+            function ($nextValue) use ($observer): void {
                 $this->items[] = $nextValue;
 
                 if (count($this->items) > $this->count) {
@@ -37,7 +37,7 @@ final class TakeLastOperator implements OperatorInterface
                 }
             },
             [$observer, 'onError'],
-            function () use ($observer) {
+            function () use ($observer): void {
 
                 while (count($this->items) > 0) {
                     $observer->onNext(array_shift($this->items));

--- a/src/Operator/TakeOperator.php
+++ b/src/Operator/TakeOperator.php
@@ -27,7 +27,7 @@ final class TakeOperator implements OperatorInterface
         $remaining = $this->count;
 
         $callbackObserver = new CallbackObserver(
-            function ($nextValue) use ($observer, &$remaining) {
+            function ($nextValue) use ($observer, &$remaining): void {
                 if ($remaining > 0) {
                     $remaining--;
                     $observer->onNext($nextValue);

--- a/src/Operator/TakeWhileOperator.php
+++ b/src/Operator/TakeWhileOperator.php
@@ -22,7 +22,7 @@ final class TakeWhileOperator implements OperatorInterface
 
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
-        $onNext = function ($value) use ($observer) {
+        $onNext = function ($value) use ($observer): void {
             try {
                 if (($this->predicate)($value)) {
                     $observer->onNext($value);

--- a/src/Operator/ThrottleOperator.php
+++ b/src/Operator/ThrottleOperator.php
@@ -35,7 +35,7 @@ final class ThrottleOperator implements OperatorInterface
         $innerDisp = new SerialDisposable();
 
         $disp = $observable->subscribe(new CallbackObserver(
-            function ($x) use ($innerDisp, $observer) {
+            function ($x) use ($innerDisp, $observer): void {
                 $now = $this->scheduler->now();
                 if ($this->nextSend <= $now) {
                     $innerDisp->setDisposable(new EmptyDisposable());
@@ -47,7 +47,7 @@ final class ThrottleOperator implements OperatorInterface
                 $newDisp = Observable::of($x, $this->scheduler)
                     ->delay($this->nextSend - $now, $this->scheduler)
                     ->subscribe(new CallbackObserver(
-                        function ($x) use ($observer) {
+                        function ($x) use ($observer): void {
                             $observer->onNext($x);
                             $this->nextSend = $this->scheduler->now() + $this->throttleTime - 1;
                             if ($this->completed) {
@@ -59,11 +59,11 @@ final class ThrottleOperator implements OperatorInterface
 
                 $innerDisp->setDisposable($newDisp);
             },
-            function (\Throwable $e) use ($observer, $innerDisp) {
+            function (\Throwable $e) use ($observer, $innerDisp): void {
                 $innerDisp->dispose();
                 $observer->onError($e);
             },
-            function () use ($observer) {
+            function () use ($observer): void {
                 $this->completed = true;
                 if ($this->nextSend === 0) {
                     $observer->onCompleted();

--- a/src/Operator/TimeoutOperator.php
+++ b/src/Operator/TimeoutOperator.php
@@ -22,7 +22,7 @@ final class TimeoutOperator implements OperatorInterface
 
     private $timeoutObservable;
 
-    public function __construct(int $timeout, ObservableInterface $timeoutObservable = null, AsyncSchedulerInterface $scheduler)
+    public function __construct(int $timeout, ?ObservableInterface $timeoutObservable = null, AsyncSchedulerInterface $scheduler)
     {
         $this->timeout           = $timeout;
         $this->scheduler         = $scheduler;

--- a/src/Operator/TimeoutOperator.php
+++ b/src/Operator/TimeoutOperator.php
@@ -13,6 +13,7 @@ use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
 use Rx\AsyncSchedulerInterface;
 use Rx\Exception\TimeoutException;
+use Rx\Scheduler;
 
 final class TimeoutOperator implements OperatorInterface
 {
@@ -22,14 +23,14 @@ final class TimeoutOperator implements OperatorInterface
 
     private $timeoutObservable;
 
-    public function __construct(int $timeout, ?ObservableInterface $timeoutObservable = null, AsyncSchedulerInterface $scheduler)
+    public function __construct(int $timeout, ?ObservableInterface $timeoutObservable = null, ?AsyncSchedulerInterface $scheduler = null)
     {
         $this->timeout           = $timeout;
-        $this->scheduler         = $scheduler;
+        $this->scheduler         = $scheduler ?: Scheduler::getAsync();
         $this->timeoutObservable = $timeoutObservable;
 
         if ($this->timeoutObservable === null) {
-            $this->timeoutObservable = new ErrorObservable(new TimeoutException('timeout'), $scheduler);
+            $this->timeoutObservable = new ErrorObservable(new TimeoutException('timeout'), $this->scheduler);
         }
     }
 

--- a/src/Operator/TimeoutOperator.php
+++ b/src/Operator/TimeoutOperator.php
@@ -42,7 +42,7 @@ final class TimeoutOperator implements OperatorInterface
 
         $sourceDisposable = new EmptyDisposable();
 
-        $doTimeout = function () use ($observer, $disposable, &$sourceDisposable) {
+        $doTimeout = function () use ($observer, $disposable, &$sourceDisposable): void {
             $disposable->remove($sourceDisposable);
             $sourceDisposable->dispose();
             $disposable->add($this->timeoutObservable->subscribe($observer));
@@ -51,7 +51,7 @@ final class TimeoutOperator implements OperatorInterface
         $doTimeoutDisposable = $this->scheduler->schedule($doTimeout, $this->timeout);
         $disposable->add($doTimeoutDisposable);
 
-        $rescheduleTimeout = function () use ($disposable, &$doTimeoutDisposable, $doTimeout) {
+        $rescheduleTimeout = function () use ($disposable, &$doTimeoutDisposable, $doTimeout): void {
             $disposable->remove($doTimeoutDisposable);
             $doTimeoutDisposable->dispose();
 
@@ -60,15 +60,15 @@ final class TimeoutOperator implements OperatorInterface
         };
 
         $sourceDisposable = $observable->subscribe(new CallbackObserver(
-            function ($x) use ($observer, $rescheduleTimeout) {
+            function ($x) use ($observer, $rescheduleTimeout): void {
                 $rescheduleTimeout();
                 $observer->onNext($x);
             },
-            function ($err) use ($observer, $rescheduleTimeout) {
+            function ($err) use ($observer, $rescheduleTimeout): void {
                 $rescheduleTimeout();
                 $observer->onError($err);
             },
-            function () use ($observer, $rescheduleTimeout) {
+            function () use ($observer, $rescheduleTimeout): void {
                 $rescheduleTimeout();
                 $observer->onCompleted();
             }

--- a/src/Operator/TimestampOperator.php
+++ b/src/Operator/TimestampOperator.php
@@ -15,7 +15,7 @@ final class TimestampOperator implements OperatorInterface
 {
     private $scheduler;
 
-    public function __construct(SchedulerInterface $scheduler = null)
+    public function __construct(?SchedulerInterface $scheduler = null)
     {
         $this->scheduler = $scheduler;
     }

--- a/src/Operator/TimestampOperator.php
+++ b/src/Operator/TimestampOperator.php
@@ -23,7 +23,7 @@ final class TimestampOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         return $observable->subscribe(new CallbackObserver(
-            function ($x) use ($observer) {
+            function ($x) use ($observer): void {
                 $observer->onNext(new Timestamped($this->scheduler->now(), $x));
             },
             [$observer, 'onError'],

--- a/src/Operator/ToArrayOperator.php
+++ b/src/Operator/ToArrayOperator.php
@@ -17,11 +17,11 @@ final class ToArrayOperator implements OperatorInterface
     public function __invoke(ObservableInterface $observable, ObserverInterface $observer): DisposableInterface
     {
         $cbObserver = new CallbackObserver(
-            function ($x) {
+            function ($x): void {
                 $this->arr[] = $x;
             },
             [$observer, 'onError'],
-            function () use ($observer) {
+            function () use ($observer): void {
                 $observer->onNext($this->arr);
                 $observer->onCompleted();
             }

--- a/src/Operator/WithLatestFromOperator.php
+++ b/src/Operator/WithLatestFromOperator.php
@@ -49,12 +49,12 @@ final class WithLatestFromOperator implements OperatorInterface
             $sad = new SingleAssignmentDisposable();
 
             $subscription = $o->subscribe(
-                function ($value) use ($key, &$values, $count, &$hasAllValues) {
+                function ($value) use ($key, &$values, $count, &$hasAllValues): void {
                     $values[$key] = $value;
                     $hasAllValues = $count === count($values);
                 },
                 [$observer, 'onError'],
-                function () {
+                function (): void {
                     //noop
                 });
 
@@ -64,7 +64,7 @@ final class WithLatestFromOperator implements OperatorInterface
 
         $outerSad = new SingleAssignmentDisposable();
         $outerSad->setDisposable($source->subscribe(
-            function ($value) use ($observer, &$values, &$hasAllValues) {
+            function ($value) use ($observer, &$values, &$hasAllValues): void {
                 ksort($values);
                 $allValues = array_merge([$value], $values);
 

--- a/src/Operator/WithLatestFromOperator.php
+++ b/src/Operator/WithLatestFromOperator.php
@@ -18,7 +18,7 @@ final class WithLatestFromOperator implements OperatorInterface
     /** @var callable */
     private $resultSelector;
 
-    public function __construct(array $observables, callable $resultSelector = null)
+    public function __construct(array $observables, ?callable $resultSelector = null)
     {
         if (null === $resultSelector) {
             $resultSelector = function () {

--- a/src/Operator/ZipOperator.php
+++ b/src/Operator/ZipOperator.php
@@ -61,7 +61,7 @@ final class ZipOperator implements OperatorInterface
             $source = $this->sources[$i];
 
             $cbObserver = new CallbackObserver(
-                function ($x) use ($i, $observer) {
+                function ($x) use ($i, $observer): void {
                     // if there is another item in the sequence after one of the other source
                     // observables completes, we need to complete at this time to match the
                     // behavior of RxJS
@@ -94,10 +94,10 @@ final class ZipOperator implements OperatorInterface
                         $observer->onError($e);
                     }
                 },
-                function ($e) use ($observer) {
+                function ($e) use ($observer): void {
                     $observer->onError($e);
                 },
-                function () use ($i, $observer) {
+                function () use ($i, $observer): void {
                     $this->completesRemaining--;
                     $this->completed[$i] = true;
                     if ($this->completesRemaining === 0) {

--- a/src/Operator/ZipOperator.php
+++ b/src/Operator/ZipOperator.php
@@ -30,7 +30,7 @@ final class ZipOperator implements OperatorInterface
     /** @var bool[] */
     private $completed = [];
 
-    public function __construct(array $sources, callable $resultSelector = null)
+    public function __construct(array $sources, ?callable $resultSelector = null)
     {
         $this->sources = $sources;
 

--- a/src/React/Promise.php
+++ b/src/React/Promise.php
@@ -47,20 +47,20 @@ final class Promise
     public static function fromObservable(ObservableInterface $observable, Deferred $deferred = null): ReactPromise
     {
 
-        $d = $deferred ?: new Deferred(function () use (&$subscription) {
+        $d = $deferred ?: new Deferred(function () use (&$subscription): void {
             $subscription->dispose();
         });
 
         $value = null;
 
         $subscription = $observable->subscribe(
-            function ($v) use (&$value) {
+            function ($v) use (&$value): void {
                 $value = $v;
             },
-            function ($error) use ($d) {
+            function ($error) use ($d): void {
                 $d->reject($error);
             },
-            function () use ($d, &$value) {
+            function () use ($d, &$value): void {
                 $d->resolve($value);
             }
         );
@@ -80,11 +80,11 @@ final class Promise
         $subject = new AsyncSubject();
 
         $p = $promise->then(
-            function ($value) use ($subject) {
+            function ($value) use ($subject): void {
                 $subject->onNext($value);
                 $subject->onCompleted();
             },
-            function ($error) use ($subject) {
+            function ($error) use ($subject): void {
                 $error = $error instanceof \Throwable ? $error : new RejectedPromiseException($error);
                 $subject->onError($error);
             }
@@ -92,7 +92,7 @@ final class Promise
 
         return new AnonymousObservable(function ($observer) use ($subject, $p) {
             $disp = $subject->subscribe($observer);
-            return new CallbackDisposable(function () use ($p, $disp) {
+            return new CallbackDisposable(function () use ($p, $disp): void {
                 $disp->dispose();
                 if (\method_exists($p, 'cancel')) {
                     $p->cancel();

--- a/src/React/Promise.php
+++ b/src/React/Promise.php
@@ -44,7 +44,7 @@ final class Promise
      * @return ReactPromise
      * @throws \InvalidArgumentException
      */
-    public static function fromObservable(ObservableInterface $observable, Deferred $deferred = null): ReactPromise
+    public static function fromObservable(ObservableInterface $observable, ?Deferred $deferred = null): ReactPromise
     {
 
         $d = $deferred ?: new Deferred(function () use (&$subscription): void {

--- a/src/Scheduler/EventLoopScheduler.php
+++ b/src/Scheduler/EventLoopScheduler.php
@@ -29,7 +29,7 @@ final class EventLoopScheduler extends VirtualTimeScheduler
         $this->delayCallback = $timerCallableOrLoop instanceof LoopInterface ?
             function ($ms, $callable) use ($timerCallableOrLoop) {
                 $timer = $timerCallableOrLoop->addTimer($ms / 1000, $callable);
-                return new CallbackDisposable(function () use ($timer, $timerCallableOrLoop) {
+                return new CallbackDisposable(function () use ($timer, $timerCallableOrLoop): void {
                     $timerCallableOrLoop->cancelTimer($timer);
                 });
             } :
@@ -56,7 +56,7 @@ final class EventLoopScheduler extends VirtualTimeScheduler
     {
         $disp = new CompositeDisposable([
             parent::scheduleAbsoluteWithState($state, $dueTime, $action),
-            new CallbackDisposable(function () use ($dueTime) {
+            new CallbackDisposable(function () use ($dueTime): void {
                 if ($dueTime > $this->nextTimer) {
                     return;
                 }

--- a/src/Scheduler/ImmediateScheduler.php
+++ b/src/Scheduler/ImmediateScheduler.php
@@ -28,11 +28,11 @@ class ImmediateScheduler implements SchedulerInterface
         $goAgain    = true;
         $disposable = new CompositeDisposable();
 
-        $recursiveAction = function () use ($action, &$goAgain, $disposable) {
+        $recursiveAction = function () use ($action, &$goAgain, $disposable): void {
             while ($goAgain) {
                 $goAgain = false;
                 $disposable->add($this->schedule(function () use ($action, &$goAgain) {
-                    return $action(function () use (&$goAgain) {
+                    return $action(function () use (&$goAgain): void {
                         $goAgain = true;
                     });
                 }));

--- a/src/Scheduler/VirtualTimeScheduler.php
+++ b/src/Scheduler/VirtualTimeScheduler.php
@@ -44,9 +44,9 @@ class VirtualTimeScheduler implements AsyncSchedulerInterface
         $goAgain    = true;
         $disposable = new SerialDisposable();
 
-        $recursiveAction = function () use ($action, &$goAgain, $disposable, &$recursiveAction) {
-            $disposable->setDisposable($this->schedule(function () use ($action, &$recursiveAction) {
-                $action(function () use (&$recursiveAction) {
+        $recursiveAction = function () use ($action, &$goAgain, $disposable, &$recursiveAction): void {
+            $disposable->setDisposable($this->schedule(function () use ($action, &$recursiveAction): void {
+                $action(function () use (&$recursiveAction): void {
                     $recursiveAction();
                 });
             }));
@@ -88,7 +88,7 @@ class VirtualTimeScheduler implements AsyncSchedulerInterface
 
         $this->queue->enqueue($scheduledItem);
 
-        return new CallbackDisposable(function () use ($scheduledItem) {
+        return new CallbackDisposable(function () use ($scheduledItem): void {
             $scheduledItem->getDisposable()->dispose();
             $this->queue->remove($scheduledItem);
         });
@@ -112,7 +112,7 @@ class VirtualTimeScheduler implements AsyncSchedulerInterface
 
         $disposable = new SerialDisposable();
 
-        $doActionAndReschedule = function () use (&$nextTime, $period, $disposable, $action, &$doActionAndReschedule) {
+        $doActionAndReschedule = function () use (&$nextTime, $period, $disposable, $action, &$doActionAndReschedule): void {
             $action();
             $nextTime += $period;
             $delay = $nextTime - $this->now();

--- a/src/Subject/ReplaySubject.php
+++ b/src/Subject/ReplaySubject.php
@@ -146,7 +146,7 @@ class ReplaySubject extends Subject
 
     private function createRemovableDisposable($subject, $observer): DisposableInterface
     {
-        return new CallbackDisposable(function () use ($observer, $subject) {
+        return new CallbackDisposable(function () use ($observer, $subject): void {
             $observer->dispose();
             if (!$subject->isDisposed()) {
                 array_splice($subject->observers, (int)array_search($observer, $subject->observers, true), 1);

--- a/src/Subject/ReplaySubject.php
+++ b/src/Subject/ReplaySubject.php
@@ -35,7 +35,7 @@ class ReplaySubject extends Subject
     /** @var SchedulerInterface */
     private $scheduler;
 
-    public function __construct(int $bufferSize = null, int $windowSize = null, SchedulerInterface $scheduler = null)
+    public function __construct(?int $bufferSize = null, ?int $windowSize = null, ?SchedulerInterface $scheduler = null)
     {
         $bufferSize = $bufferSize ?? $this->maxSafeInt;
 

--- a/src/Testing/ColdObservable.php
+++ b/src/Testing/ColdObservable.php
@@ -38,7 +38,7 @@ class ColdObservable extends Observable
             $notification = $message->getValue();
             $time         = $message->getTime();
 
-            $schedule = function (Notification $innerNotification) use (&$disposable, &$currentObservable, $observer, $scheduler, $time, &$isDisposed) {
+            $schedule = function (Notification $innerNotification) use (&$disposable, &$currentObservable, $observer, $scheduler, $time, &$isDisposed): void {
                 $disposable->add($scheduler->scheduleRelativeWithState(null, $time, function () use ($observer, $innerNotification, &$isDisposed) {
                     if (!$isDisposed) {
                         $innerNotification->accept($observer);
@@ -52,7 +52,7 @@ class ColdObservable extends Observable
 
         $subscriptions = &$this->subscriptions;
 
-        return new CallbackDisposable(function () use (&$currentObservable, $index, $observer, $scheduler, &$subscriptions, &$isDisposed) {
+        return new CallbackDisposable(function () use (&$currentObservable, $index, $observer, $scheduler, &$subscriptions, &$isDisposed): void {
             $isDisposed            = true;
             $subscriptions[$index] = new Subscription($subscriptions[$index]->getSubscribed(), $scheduler->getClock());
         });

--- a/src/Testing/HotObservable.php
+++ b/src/Testing/HotObservable.php
@@ -28,7 +28,7 @@ class HotObservable extends Observable
             $time         = $message->getTime();
             $notification = $message->getValue();
 
-            $schedule = function (Notification $innerNotification) use (&$currentObservable, $scheduler, $time) {
+            $schedule = function (Notification $innerNotification) use (&$currentObservable, $scheduler, $time): void {
                 $scheduler->scheduleAbsolute($time, function () use (&$currentObservable, $innerNotification) {
                     $observers = $currentObservable->getObservers();
 
@@ -56,7 +56,7 @@ class HotObservable extends Observable
         $index     = count($this->subscriptions) - 1;
         $scheduler = $this->scheduler;
 
-        return new CallbackDisposable(function () use (&$currentObservable, $index, $observer, $scheduler, &$subscriptions) {
+        return new CallbackDisposable(function () use (&$currentObservable, $index, $observer, $scheduler, &$subscriptions): void {
             $currentObservable->removeObserver($observer);
             $subscriptions[$index] = new Subscription($subscriptions[$index]->getSubscribed(), $scheduler->getClock());
         });

--- a/src/Testing/Recorded.php
+++ b/src/Testing/Recorded.php
@@ -10,7 +10,7 @@ class Recorded
     private $value;
     private $comparer;
 
-    public function __construct(int $time, $value, callable $comparer = null)
+    public function __construct(int $time, $value, ?callable $comparer = null)
     {
         $this->time     = $time;
         $this->value    = $value;

--- a/src/Testing/TestSubject.php
+++ b/src/Testing/TestSubject.php
@@ -35,7 +35,7 @@ class TestSubject extends Subject
         $this->subscribeCount++;
         $this->observer = $observer;
 
-        return new CallbackDisposable(function () {
+        return new CallbackDisposable(function (): void {
             $this->dispose();
         });
 

--- a/test/Rx/Disposable/BinaryDisposableTest.php
+++ b/test/Rx/Disposable/BinaryDisposableTest.php
@@ -16,13 +16,13 @@ class BinaryDisposableTest extends TestCase
     {
         $disposed1 = false;
 
-        $d1 = new CallbackDisposable(function () use (&$disposed1) {
+        $d1 = new CallbackDisposable(function () use (&$disposed1): void {
             $disposed1 = true;
         });
 
         $disposed2 = false;
 
-        $d2 = new CallbackDisposable(function () use (&$disposed2) {
+        $d2 = new CallbackDisposable(function () use (&$disposed2): void {
             $disposed2 = true;
         });
 
@@ -46,13 +46,13 @@ class BinaryDisposableTest extends TestCase
     {
         $disposed1 = 0;
 
-        $d1 = new CallbackDisposable(function () use (&$disposed1) {
+        $d1 = new CallbackDisposable(function () use (&$disposed1): void {
             $disposed1++;
         });
 
         $disposed2 = 0;
 
-        $d2 = new CallbackDisposable(function () use (&$disposed2) {
+        $d2 = new CallbackDisposable(function () use (&$disposed2): void {
             $disposed2++;
         });
 

--- a/test/Rx/Disposable/BinaryDisposableTest.php
+++ b/test/Rx/Disposable/BinaryDisposableTest.php
@@ -12,7 +12,7 @@ class BinaryDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_the_binary_disposable()
+    public function it_disposes_the_binary_disposable(): void
     {
         $disposed1 = false;
 
@@ -42,7 +42,7 @@ class BinaryDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_does_nothing_if_disposed_twice()
+    public function it_does_nothing_if_disposed_twice(): void
     {
         $disposed1 = 0;
 

--- a/test/Rx/Disposable/CallbackDisposableTest.php
+++ b/test/Rx/Disposable/CallbackDisposableTest.php
@@ -11,7 +11,7 @@ class CallbackDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_callback_on_dispose()
+    public function it_calls_the_callback_on_dispose(): void
     {
         $disposed   = false;
         $disposable = new CallbackDisposable(function() use (&$disposed): void { $disposed = true; });
@@ -26,7 +26,7 @@ class CallbackDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_only_disposes_once()
+    public function it_only_disposes_once(): void
     {
         $disposed    = false;
         $invocations = 0;

--- a/test/Rx/Disposable/CallbackDisposableTest.php
+++ b/test/Rx/Disposable/CallbackDisposableTest.php
@@ -14,7 +14,7 @@ class CallbackDisposableTest extends TestCase
     public function it_calls_the_callback_on_dispose()
     {
         $disposed   = false;
-        $disposable = new CallbackDisposable(function() use (&$disposed) { $disposed = true; });
+        $disposable = new CallbackDisposable(function() use (&$disposed): void { $disposed = true; });
 
         $this->assertFalse($disposed);
 
@@ -30,7 +30,7 @@ class CallbackDisposableTest extends TestCase
     {
         $disposed    = false;
         $invocations = 0;
-        $disposable  = new CallbackDisposable(function () use (&$disposed, &$invocations) {
+        $disposable  = new CallbackDisposable(function () use (&$disposed, &$invocations): void {
             $invocations++;
             $disposed = true;
         });

--- a/test/Rx/Disposable/CompositeDisposableTest.php
+++ b/test/Rx/Disposable/CompositeDisposableTest.php
@@ -11,7 +11,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_the_amount_of_disposables_composed()
+    public function it_exposes_the_amount_of_disposables_composed(): void
     {
         $d1 = new CallbackDisposable(function(): void{});
         $d2 = new CallbackDisposable(function(): void{});
@@ -23,7 +23,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_can_be_checked_if_it_contains_a_disposable()
+    public function it_can_be_checked_if_it_contains_a_disposable(): void
     {
         $d1 = new CallbackDisposable(function(): void{});
         $d2 = new CallbackDisposable(function(): void{});
@@ -38,7 +38,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function a_disposable_can_be_added_after_creation()
+    public function a_disposable_can_be_added_after_creation(): void
     {
         $d1 = new CallbackDisposable(function(): void{});
         $d2 = new CallbackDisposable(function(): void{});
@@ -55,7 +55,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function disposing_disposes_all_disposables()
+    public function disposing_disposes_all_disposables(): void
     {
         $disposed1 = false;
         $disposed2 = false;
@@ -72,7 +72,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function disposing_disposes_all_disposables_only_once()
+    public function disposing_disposes_all_disposables_only_once(): void
     {
         $disposed1 = 0;
         $disposed2 = 0;
@@ -97,7 +97,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_newly_added_disposables_when_already_disposed()
+    public function it_disposes_newly_added_disposables_when_already_disposed(): void
     {
         $disposed1 = false;
         $disposed2 = false;
@@ -114,7 +114,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function a_disposable_can_be_removed()
+    public function a_disposable_can_be_removed(): void
     {
         $disposed2 = false;
         $d1 = new CallbackDisposable(function(): void{});
@@ -129,7 +129,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function a_removed_disposable_is_disposed()
+    public function a_removed_disposable_is_disposed(): void
     {
         $disposed2 = false;
         $d1 = new CallbackDisposable(function(): void{});
@@ -143,7 +143,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function removing_when_disposed_has_no_effect()
+    public function removing_when_disposed_has_no_effect(): void
     {
         $disposable = new CompositeDisposable([]);
         $disposable->dispose();
@@ -161,7 +161,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function removing_a_disposable_that_is_not_contained_has_no_effect()
+    public function removing_a_disposable_that_is_not_contained_has_no_effect(): void
     {
         $disposable = new CompositeDisposable([]);
 
@@ -178,7 +178,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function clear_disposes_all_contained_disposables_but_not_the_composite_disposable()
+    public function clear_disposes_all_contained_disposables_but_not_the_composite_disposable(): void
     {
         $disposed1 = false;
         $disposed2 = false;
@@ -202,7 +202,7 @@ class CompositeDisposableTest extends TestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_can_be_disposed_multiple_times()
+    public function it_can_be_disposed_multiple_times(): void
     {
         $d1 = new CallbackDisposable(function(): void{});
         $d2 = new CallbackDisposable(function(): void{});
@@ -217,7 +217,7 @@ class CompositeDisposableTest extends TestCase
      *
      * see https://github.com/ReactiveX/RxPHP/issues/107
      */
-    public function it_can_distinguish_and_dispose_of_correct_disposable()
+    public function it_can_distinguish_and_dispose_of_correct_disposable(): void
     {
         // factory to create 2 disposables that evaluate the same with ==
         $getSimilarDisposables = function () {
@@ -256,7 +256,7 @@ class CompositeDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_knows_what_it_contains()
+    public function it_knows_what_it_contains(): void
     {
         // factory to create 2 disposables that evaluate the same with ==
         $getSimilarDisposables = function () {

--- a/test/Rx/Disposable/CompositeDisposableTest.php
+++ b/test/Rx/Disposable/CompositeDisposableTest.php
@@ -13,9 +13,9 @@ class CompositeDisposableTest extends TestCase
      */
     public function it_exposes_the_amount_of_disposables_composed()
     {
-        $d1 = new CallbackDisposable(function(){});
-        $d2 = new CallbackDisposable(function(){});
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function(): void{});
+        $d2 = new CallbackDisposable(function(): void{});
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $this->assertEquals(2, $disposable->count());
     }
@@ -25,10 +25,10 @@ class CompositeDisposableTest extends TestCase
      */
     public function it_can_be_checked_if_it_contains_a_disposable()
     {
-        $d1 = new CallbackDisposable(function(){});
-        $d2 = new CallbackDisposable(function(){});
-        $d3 = new CallbackDisposable(function(){});
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function(): void{});
+        $d2 = new CallbackDisposable(function(): void{});
+        $d3 = new CallbackDisposable(function(): void{});
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $this->assertTrue($disposable->contains($d1));
         $this->assertTrue($disposable->contains($d2));
@@ -40,9 +40,9 @@ class CompositeDisposableTest extends TestCase
      */
     public function a_disposable_can_be_added_after_creation()
     {
-        $d1 = new CallbackDisposable(function(){});
-        $d2 = new CallbackDisposable(function(){});
-        $disposable = new CompositeDisposable(array($d1));
+        $d1 = new CallbackDisposable(function(): void{});
+        $d2 = new CallbackDisposable(function(): void{});
+        $disposable = new CompositeDisposable([$d1]);
 
         $this->assertEquals(1, $disposable->count());
         $this->assertFalse($disposable->contains($d2));
@@ -59,9 +59,9 @@ class CompositeDisposableTest extends TestCase
     {
         $disposed1 = false;
         $disposed2 = false;
-        $d1 = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
-        $d2 = new CallbackDisposable(function() use (&$disposed2){ $disposed2 = true; });
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
+        $d2 = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2 = true; });
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $disposable->dispose();
 
@@ -76,9 +76,9 @@ class CompositeDisposableTest extends TestCase
     {
         $disposed1 = 0;
         $disposed2 = 0;
-        $d1 = new CallbackDisposable(function() use (&$disposed1){ $disposed1++; });
-        $d2 = new CallbackDisposable(function() use (&$disposed2){ $disposed2++; });
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1++; });
+        $d2 = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2++; });
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $this->assertEquals(0, $disposed1);
         $this->assertEquals(0, $disposed2);
@@ -101,9 +101,9 @@ class CompositeDisposableTest extends TestCase
     {
         $disposed1 = false;
         $disposed2 = false;
-        $d1 = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
-        $d2 = new CallbackDisposable(function() use (&$disposed2){ $disposed2 = true; });
-        $disposable = new CompositeDisposable(array($d1));
+        $d1 = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
+        $d2 = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2 = true; });
+        $disposable = new CompositeDisposable([$d1]);
 
         $disposable->dispose();
         $disposable->add($d2);
@@ -117,9 +117,9 @@ class CompositeDisposableTest extends TestCase
     public function a_disposable_can_be_removed()
     {
         $disposed2 = false;
-        $d1 = new CallbackDisposable(function(){});
-        $d2 = new CallbackDisposable(function() use (&$disposed2){ $disposed2 = true; });
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function(): void{});
+        $d2 = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2 = true; });
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $disposable->remove($d2);
 
@@ -132,9 +132,9 @@ class CompositeDisposableTest extends TestCase
     public function a_removed_disposable_is_disposed()
     {
         $disposed2 = false;
-        $d1 = new CallbackDisposable(function(){});
-        $d2 = new CallbackDisposable(function() use (&$disposed2){ $disposed2 = true; });
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function(): void{});
+        $d2 = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2 = true; });
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $this->assertTrue($disposable->remove($d2));
         $this->assertTrue($disposed2);
@@ -145,11 +145,11 @@ class CompositeDisposableTest extends TestCase
      */
     public function removing_when_disposed_has_no_effect()
     {
-        $disposable = new CompositeDisposable(array());
+        $disposable = new CompositeDisposable([]);
         $disposable->dispose();
 
         $disposed1 = false;
-        $d1 = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
+        $d1 = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
 
         $removed = $disposable->remove($d1);
 
@@ -163,10 +163,10 @@ class CompositeDisposableTest extends TestCase
      */
     public function removing_a_disposable_that_is_not_contained_has_no_effect()
     {
-        $disposable = new CompositeDisposable(array());
+        $disposable = new CompositeDisposable([]);
 
         $disposed1 = false;
-        $d1 = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
+        $d1 = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
 
         $removed = $disposable->remove($d1);
 
@@ -182,9 +182,9 @@ class CompositeDisposableTest extends TestCase
     {
         $disposed1 = false;
         $disposed2 = false;
-        $d1 = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
-        $d2 = new CallbackDisposable(function() use (&$disposed2){ $disposed2 = true; });
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
+        $d2 = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2 = true; });
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $disposable->clear();
 
@@ -192,7 +192,7 @@ class CompositeDisposableTest extends TestCase
         $this->assertTrue($disposed2);
 
         $disposed3 = false;
-        $d3 = new CallbackDisposable(function() use (&$disposed3){ $disposed3 = true; });
+        $d3 = new CallbackDisposable(function() use (&$disposed3): void{ $disposed3 = true; });
 
         $disposable->add($d3);
         $this->assertFalse($disposed3);
@@ -204,9 +204,9 @@ class CompositeDisposableTest extends TestCase
      */
     public function it_can_be_disposed_multiple_times()
     {
-        $d1 = new CallbackDisposable(function(){});
-        $d2 = new CallbackDisposable(function(){});
-        $disposable = new CompositeDisposable(array($d1, $d2));
+        $d1 = new CallbackDisposable(function(): void{});
+        $d2 = new CallbackDisposable(function(): void{});
+        $disposable = new CompositeDisposable([$d1, $d2]);
 
         $disposable->dispose();
         $disposable->dispose();
@@ -234,7 +234,7 @@ class CompositeDisposableTest extends TestCase
         // all future sets of disp should immediately dispose
         $compositeDisposable->remove($disposables[0]);
         $wasDisposed = false;
-        $disposables[0]->setDisposable(new CallbackDisposable(function () use (&$wasDisposed) {
+        $disposables[0]->setDisposable(new CallbackDisposable(function () use (&$wasDisposed): void {
             $wasDisposed = true;
         }));
         $this->assertTrue($wasDisposed);
@@ -247,7 +247,7 @@ class CompositeDisposableTest extends TestCase
         // all future sets of disp should immediately dispose
         $compositeDisposable->remove($disposables[1]);
         $wasDisposed = false;
-        $disposables[1]->setDisposable(new CallbackDisposable(function () use (&$wasDisposed) {
+        $disposables[1]->setDisposable(new CallbackDisposable(function () use (&$wasDisposed): void {
             $wasDisposed = true;
         }));
         $this->assertTrue($wasDisposed);

--- a/test/Rx/Disposable/EmptyDisposableTest.php
+++ b/test/Rx/Disposable/EmptyDisposableTest.php
@@ -12,7 +12,7 @@ class EmptyDisposableTest extends TestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_can_be_disposed()
+    public function it_can_be_disposed(): void
     {
         $disposable = new EmptyDisposable();
 

--- a/test/Rx/Disposable/RefCountDisposableTest.php
+++ b/test/Rx/Disposable/RefCountDisposableTest.php
@@ -95,7 +95,7 @@ class RefCountDisposableTest extends TestCase
     public function it_does_not_dispose_the_primary_if_already_disposed_via_refcount()
     {
         $called = 0;
-        $d = new CallbackDisposable(function() use (&$called) { $called++; });
+        $d = new CallbackDisposable(function() use (&$called): void { $called++; });
         $r = new RefCountDisposable($d);
 
         $r->dispose();
@@ -110,7 +110,7 @@ class RefCountDisposableTest extends TestCase
     public function it_does_not_dispose_the_primary_if_already_disposed()
     {
         $called = 0;
-        $d = new CallbackDisposable(function() use (&$called) { $called++; });
+        $d = new CallbackDisposable(function() use (&$called): void { $called++; });
         $r = new RefCountDisposable($d);
 
         $d1 = $r->getDisposable();
@@ -129,7 +129,7 @@ class RefCountDisposableTest extends TestCase
     public function it_returns_a_noop_disposable_if_primary_is_already_disposed()
     {
         $called = 0;
-        $d = new CallbackDisposable(function() use (&$called) { $called++; });
+        $d = new CallbackDisposable(function() use (&$called): void { $called++; });
         $r = new RefCountDisposable($d);
 
         $r->dispose();

--- a/test/Rx/Disposable/RefCountDisposableTest.php
+++ b/test/Rx/Disposable/RefCountDisposableTest.php
@@ -12,7 +12,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_holds_a_reference_to_one_disposable()
+    public function it_holds_a_reference_to_one_disposable(): void
     {
         $d = new BooleanDisposable();
         $r = new RefCountDisposable($d);
@@ -26,7 +26,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_if_all_references_are_disposed()
+    public function it_disposes_if_all_references_are_disposed(): void
     {
         $d = new BooleanDisposable();
         $r = new RefCountDisposable($d);
@@ -47,7 +47,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_after_last_reference_is_disposed()
+    public function it_disposes_after_last_reference_is_disposed(): void
     {
         $d = new BooleanDisposable();
         $r = new RefCountDisposable($d);
@@ -68,7 +68,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_dispose_the_primary_if_refcount_inner_disposable_is_disposed_multiple_times()
+    public function it_does_not_dispose_the_primary_if_refcount_inner_disposable_is_disposed_multiple_times(): void
     {
         $d = new BooleanDisposable();
         $r = new RefCountDisposable($d);
@@ -92,7 +92,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_dispose_the_primary_if_already_disposed_via_refcount()
+    public function it_does_not_dispose_the_primary_if_already_disposed_via_refcount(): void
     {
         $called = 0;
         $d = new CallbackDisposable(function() use (&$called): void { $called++; });
@@ -107,7 +107,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_dispose_the_primary_if_already_disposed()
+    public function it_does_not_dispose_the_primary_if_already_disposed(): void
     {
         $called = 0;
         $d = new CallbackDisposable(function() use (&$called): void { $called++; });
@@ -126,7 +126,7 @@ class RefCountDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_a_noop_disposable_if_primary_is_already_disposed()
+    public function it_returns_a_noop_disposable_if_primary_is_already_disposed(): void
     {
         $called = 0;
         $d = new CallbackDisposable(function() use (&$called): void { $called++; });

--- a/test/Rx/Disposable/ScheduledDisposableTest.php
+++ b/test/Rx/Disposable/ScheduledDisposableTest.php
@@ -13,7 +13,7 @@ class ScheduledDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_the_scheduled_disposable()
+    public function it_disposes_the_scheduled_disposable(): void
     {
         $disposed1 = false;
 
@@ -39,7 +39,7 @@ class ScheduledDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_does_nothing_if_disposed_twice()
+    public function it_does_nothing_if_disposed_twice(): void
     {
         $disposed1 = 0;
 

--- a/test/Rx/Disposable/ScheduledDisposableTest.php
+++ b/test/Rx/Disposable/ScheduledDisposableTest.php
@@ -17,7 +17,7 @@ class ScheduledDisposableTest extends TestCase
     {
         $disposed1 = false;
 
-        $d1 = new CallbackDisposable(function () use (&$disposed1) {
+        $d1 = new CallbackDisposable(function () use (&$disposed1): void {
             $disposed1 = true;
         });
 
@@ -43,7 +43,7 @@ class ScheduledDisposableTest extends TestCase
     {
         $disposed1 = 0;
 
-        $d1 = new CallbackDisposable(function () use (&$disposed1) {
+        $d1 = new CallbackDisposable(function () use (&$disposed1): void {
             $disposed1++;
         });
 

--- a/test/Rx/Disposable/SerialDisposableTest.php
+++ b/test/Rx/Disposable/SerialDisposableTest.php
@@ -15,7 +15,7 @@ class SerialDisposableTest extends TestCase
     public function it_disposes_the_assigned_disposable()
     {
         $disposed1  = false;
-        $d1         = new CallbackDisposable(function () use (&$disposed1) {
+        $d1         = new CallbackDisposable(function () use (&$disposed1): void {
             $disposed1 = true;
         });
         $disposable = new SerialDisposable();
@@ -35,7 +35,7 @@ class SerialDisposableTest extends TestCase
     public function it_disposes_the_assigned_disposable_on_reassignment()
     {
         $disposed1  = false;
-        $d1         = new CallbackDisposable(function () use (&$disposed1) { $disposed1 = true; });
+        $d1         = new CallbackDisposable(function () use (&$disposed1): void { $disposed1 = true; });
         $d2         = new EmptyDisposable();
         $disposable = new SerialDisposable();
 
@@ -56,7 +56,7 @@ class SerialDisposableTest extends TestCase
     public function it_unsets_the_disposable_on_dispose()
     {
         $disposed1  = false;
-        $d1         = new CallbackDisposable(function () use (&$disposed1) {
+        $d1         = new CallbackDisposable(function () use (&$disposed1): void {
             $disposed1 = true;
         });
         $disposable = new SerialDisposable();
@@ -79,8 +79,8 @@ class SerialDisposableTest extends TestCase
     {
         $disposed1  = false;
         $disposed2  = false;
-        $d1         = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
-        $d2         = new CallbackDisposable(function() use (&$disposed2){ $disposed2 = true; });
+        $d1         = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
+        $d2         = new CallbackDisposable(function() use (&$disposed2): void{ $disposed2 = true; });
         $disposable = new SerialDisposable();
 
         $disposable->setDisposable($d1);

--- a/test/Rx/Disposable/SerialDisposableTest.php
+++ b/test/Rx/Disposable/SerialDisposableTest.php
@@ -12,7 +12,7 @@ class SerialDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_the_assigned_disposable()
+    public function it_disposes_the_assigned_disposable(): void
     {
         $disposed1  = false;
         $d1         = new CallbackDisposable(function () use (&$disposed1): void {
@@ -32,7 +32,7 @@ class SerialDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_the_assigned_disposable_on_reassignment()
+    public function it_disposes_the_assigned_disposable_on_reassignment(): void
     {
         $disposed1  = false;
         $d1         = new CallbackDisposable(function () use (&$disposed1): void { $disposed1 = true; });
@@ -53,7 +53,7 @@ class SerialDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_unsets_the_disposable_on_dispose()
+    public function it_unsets_the_disposable_on_dispose(): void
     {
         $disposed1  = false;
         $d1         = new CallbackDisposable(function () use (&$disposed1): void {
@@ -75,7 +75,7 @@ class SerialDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_the_assigned_disposable_if_already_disposed()
+    public function it_disposes_the_assigned_disposable_if_already_disposed(): void
     {
         $disposed1  = false;
         $disposed2  = false;

--- a/test/Rx/Disposable/SingleAssignmentDisposableTest.php
+++ b/test/Rx/Disposable/SingleAssignmentDisposableTest.php
@@ -14,7 +14,7 @@ class SingleAssignmentDisposableTest extends TestCase
     public function it_disposes_the_assigned_disposable()
     {
         $disposed1   = false;
-        $d1         = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
+        $d1         = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
         $disposable = new SingleAssignmentDisposable();
 
         $disposable->setDisposable($d1);
@@ -32,8 +32,8 @@ class SingleAssignmentDisposableTest extends TestCase
     public function it_disposes_newly_set_disposable_if_already_disposed()
     {
         $disposed1   = false;
-        $d1         = new CallbackDisposable(function() use (&$disposed1){ $disposed1 = true; });
-        $d2         = new CallbackDisposable(function(){});
+        $d1         = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
+        $d2         = new CallbackDisposable(function(): void{});
         $disposable = new SingleAssignmentDisposable();
 
         $disposable->setDisposable($d2);
@@ -52,8 +52,8 @@ class SingleAssignmentDisposableTest extends TestCase
     public function it_cannot_be_assignmed_multiple_times()
     {
         $this->expectException(\RuntimeException::class);
-        $d1         = new CallbackDisposable(function(){});
-        $d2         = new CallbackDisposable(function(){});
+        $d1         = new CallbackDisposable(function(): void{});
+        $d2         = new CallbackDisposable(function(): void{});
         $disposable = new SingleAssignmentDisposable();
 
         $disposable->setDisposable($d1);

--- a/test/Rx/Disposable/SingleAssignmentDisposableTest.php
+++ b/test/Rx/Disposable/SingleAssignmentDisposableTest.php
@@ -11,7 +11,7 @@ class SingleAssignmentDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_the_assigned_disposable()
+    public function it_disposes_the_assigned_disposable(): void
     {
         $disposed1   = false;
         $d1         = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
@@ -29,7 +29,7 @@ class SingleAssignmentDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_newly_set_disposable_if_already_disposed()
+    public function it_disposes_newly_set_disposable_if_already_disposed(): void
     {
         $disposed1   = false;
         $d1         = new CallbackDisposable(function() use (&$disposed1): void{ $disposed1 = true; });
@@ -49,7 +49,7 @@ class SingleAssignmentDisposableTest extends TestCase
     /**
      * @test
      */
-    public function it_cannot_be_assignmed_multiple_times()
+    public function it_cannot_be_assignmed_multiple_times(): void
     {
         $this->expectException(\RuntimeException::class);
         $d1         = new CallbackDisposable(function(): void{});

--- a/test/Rx/Functional/ColdObservableTest.php
+++ b/test/Rx/Functional/ColdObservableTest.php
@@ -11,21 +11,21 @@ class ColdObservableTest extends FunctionalTestCase
      */
     public function it_calls_relative_to_subscribe_time()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(50, "foo"),
             onNext(75, "Bar"),
             onCompleted(105)
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
             return $xs;
         });
 
         $this->assertCount(3, $results->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(250, "foo"),
             onNext(275, "Bar"),
             onCompleted(305)
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 }

--- a/test/Rx/Functional/ColdObservableTest.php
+++ b/test/Rx/Functional/ColdObservableTest.php
@@ -9,7 +9,7 @@ class ColdObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_relative_to_subscribe_time()
+    public function it_calls_relative_to_subscribe_time(): void
     {
         $xs = $this->createColdObservable([
             onNext(50, "foo"),

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -122,12 +122,12 @@ abstract class FunctionalTestCase extends TestCase
         return new ColdObservable($this->scheduler, $events);
     }
 
-    protected function createCold(string $events, array $eventMap = [], \Exception $customError = null)
+    protected function createCold(string $events, array $eventMap = [], ?\Exception $customError = null)
     {
         return new ColdObservable($this->scheduler, $this->convertMarblesToMessages($events, $eventMap, $customError));
     }
 
-    protected function createHot(string $events, array $eventMap = [], \Exception $customError = null)
+    protected function createHot(string $events, array $eventMap = [], ?\Exception $customError = null)
     {
         return new HotObservable($this->scheduler, $this->convertMarblesToMessages($events, $eventMap, $customError, 200));
     }
@@ -142,7 +142,7 @@ abstract class FunctionalTestCase extends TestCase
         return new TestScheduler();
     }
 
-    protected function convertMarblesToMessages(string $marbles, array $eventMap = [], \Exception $customError = null, $subscribePoint = 0)
+    protected function convertMarblesToMessages(string $marbles, array $eventMap = [], ?\Exception $customError = null, $subscribePoint = 0)
     {
         /** @var Recorded $events */
         $events = [];
@@ -291,7 +291,7 @@ abstract class FunctionalTestCase extends TestCase
         return $disposeAt;
     }
 
-    public function expectObservable(Observable $observable, string $disposeMarble = null): ExpectObservableToBe
+    public function expectObservable(Observable $observable, ?string $disposeMarble = null): ExpectObservableToBe
     {
         if ($disposeMarble) {
             $disposeAt = $this->convertMarblesToDisposeTime($disposeMarble, 200);
@@ -317,7 +317,7 @@ abstract class FunctionalTestCase extends TestCase
                 $this->messages = $messages;
             }
 
-            public function toBe(string $expected, array $values = [], string $errorMessage = null)
+            public function toBe(string $expected, array $values = [], ?string $errorMessage = null)
             {
                 $error = $errorMessage ? new \Exception($errorMessage) : null;
 
@@ -359,5 +359,5 @@ interface ExpectSubscriptionsToBe
 
 interface ExpectObservableToBe
 {
-    public function toBe(string $expected, array $values = [], string $errorMessage = null);
+    public function toBe(string $expected, array $values = [], ?string $errorMessage = null);
 }

--- a/test/Rx/Functional/FunctionalTestCase.php
+++ b/test/Rx/Functional/FunctionalTestCase.php
@@ -183,7 +183,7 @@ abstract class FunctionalTestCase extends TestCase
                     continue 2;
                 default:
                     $eventKey = $marbles[$i];
-                    $events[] = onNext($now, isset($eventMap[$eventKey]) ? $eventMap[$eventKey] : $marbles[$i]);
+                    $events[] = onNext($now, $eventMap[$eventKey] ?? $marbles[$i]);
                     continue 2;
             }
         }
@@ -206,13 +206,13 @@ abstract class FunctionalTestCase extends TestCase
             $lastTime = $time;
 
             $value->accept(
-                function ($x) use (&$output) {
+                function ($x) use (&$output): void {
                     $output .= $x;
                 },
-                function (\Exception $e) use (&$output) {
+                function (\Exception $e) use (&$output): void {
                     $output .= '#';
                 },
-                function () use (&$output) {
+                function () use (&$output): void {
                     $output .= '|';
                 }
             );

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -7,7 +7,7 @@ use Rx\Testing\Subscription;
 
 class MarbleTest extends FunctionalTestCase
 {
-    public function testColdMarble()
+    public function testColdMarble(): void
     {
         $c = $this->createCold('----1----3---|');
 
@@ -22,7 +22,7 @@ class MarbleTest extends FunctionalTestCase
         ], $result->getMessages());
     }
 
-    public function testHotMarble()
+    public function testHotMarble(): void
     {
         $h = $this->createHot('-1-^--a--b---|');
 
@@ -37,7 +37,7 @@ class MarbleTest extends FunctionalTestCase
         ], $result->getMessages());
     }
 
-    public function testColdMarbleWithEqualMessages()
+    public function testColdMarbleWithEqualMessages(): void
     {
         $marbles1 = '----1-^--a--b---|   ';
         $marbles2 = '    1-^--a--b---|---';
@@ -48,7 +48,7 @@ class MarbleTest extends FunctionalTestCase
         );
     }
 
-    public function testMessageConversion()
+    public function testMessageConversion(): void
     {
         $messages = [
             onNext(230, 'a'),
@@ -59,7 +59,7 @@ class MarbleTest extends FunctionalTestCase
         $this->assertEquals('---a--b---|', $this->convertMessagesToMarbles($messages));
     }
 
-    public function testSomethingElse()
+    public function testSomethingElse(): void
     {
         $cold     = '--1--2--|';
         $expected = '--2--3--|';
@@ -71,7 +71,7 @@ class MarbleTest extends FunctionalTestCase
         $this->assertEquals($expected, $this->convertMessagesToMarbles($results->getMessages()));
     }
 
-    public function testMarbleValues()
+    public function testMarbleValues(): void
     {
         $marbles = '--a--b--c--|';
         $values = [
@@ -90,7 +90,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testMarbleValuesDontMatch()
+    public function testMarbleValuesDontMatch(): void
     {
         $marbles = '--a--b--c--|';
         $values = [
@@ -109,7 +109,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testMarbleWithMissingValues()
+    public function testMarbleWithMissingValues(): void
     {
         $marbles = '--a--b--c--|';
         $values = [
@@ -126,7 +126,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testGroupedMarbleValues()
+    public function testGroupedMarbleValues(): void
     {
         $marbles = '---(abc)--|';
 
@@ -140,7 +140,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testMultipleGroupedMarbleValues()
+    public function testMultipleGroupedMarbleValues(): void
     {
         $marbles = '--(abc)---(dfa)--|';
         $values = [
@@ -160,7 +160,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testGroupedMarkerAndComplete()
+    public function testGroupedMarkerAndComplete(): void
     {
         $marbles = '--a---b--(c|)';
 
@@ -174,7 +174,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testGroupedMarkerAndError()
+    public function testGroupedMarkerAndError(): void
     {
         $marbles = '--a---(b#)--c--|';
 
@@ -189,7 +189,7 @@ class MarbleTest extends FunctionalTestCase
         ], $messages);
     }
 
-    public function testSubscriptions()
+    public function testSubscriptions(): void
     {
         $marbles = '--^-----!---^!--';
 
@@ -200,7 +200,7 @@ class MarbleTest extends FunctionalTestCase
         ], $subscriptions);
     }
 
-    public function testSubscriptionsMissingUnsubscribeMarker()
+    public function testSubscriptionsMissingUnsubscribeMarker(): void
     {
         $marbles = '--^--';
 
@@ -210,7 +210,7 @@ class MarbleTest extends FunctionalTestCase
         ], $subscriptions);
     }
 
-    public function testSubscriptionsGroup()
+    public function testSubscriptionsGroup(): void
     {
         $marbles = '--(^!)';
 
@@ -223,7 +223,7 @@ class MarbleTest extends FunctionalTestCase
 
     /**
      */
-    public function testSubscriptionsInvalidMarkers()
+    public function testSubscriptionsInvalidMarkers(): void
     {
         $this->expectException(\Rx\MarbleDiagramException::class);
         $marbles = '--^--a--!-';
@@ -232,7 +232,7 @@ class MarbleTest extends FunctionalTestCase
 
     /**
      */
-    public function testSubscriptionsMultipleSubscribeMarkers()
+    public function testSubscriptionsMultipleSubscribeMarkers(): void
     {
         $this->expectException(\Rx\MarbleDiagramException::class);
         $marbles = '--^-^---!-';
@@ -241,14 +241,14 @@ class MarbleTest extends FunctionalTestCase
 
     /**
      */
-    public function testSubscriptionsMultipleUnsubscribeMarkers()
+    public function testSubscriptionsMultipleUnsubscribeMarkers(): void
     {
         $this->expectException(\Rx\MarbleDiagramException::class);
         $marbles = '--^---!-!-';
         $this->convertMarblesToSubscriptions($marbles);
     }
 
-    public function testMapMarble()
+    public function testMapMarble(): void
     {
         $cold     = '--1--2--|';
         $subs     = '^       !';
@@ -264,7 +264,7 @@ class MarbleTest extends FunctionalTestCase
         $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
     }
 
-    public function testMapErrorMarble()
+    public function testMapErrorMarble(): void
     {
         $cold     = '--x--|';
         $subs     = '^ !   ';
@@ -280,7 +280,7 @@ class MarbleTest extends FunctionalTestCase
         $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
     }
 
-    public function testMapDisposeMarble()
+    public function testMapDisposeMarble(): void
     {
         $cold     = '--1--2--3--|';
         $unsub    = '      !     ';
@@ -297,7 +297,7 @@ class MarbleTest extends FunctionalTestCase
         $this->expectSubscriptions($e1->getSubscriptions())->toBe($subs);
     }
 
-    public function testCountMarble()
+    public function testCountMarble(): void
     {
         $cold     = '--a--b--c--|';
         $subs     = '^          !';

--- a/test/Rx/Functional/MarbleTest.php
+++ b/test/Rx/Functional/MarbleTest.php
@@ -272,7 +272,7 @@ class MarbleTest extends FunctionalTestCase
 
         $e1 = $this->createCold($cold, ['x' => 42]);
 
-        $r = $e1->map(function ($x) {
+        $r = $e1->map(function ($x): void {
             throw new \Exception('too bad');
         });
 

--- a/test/Rx/Functional/Observable/ErrorObservableTest.php
+++ b/test/Rx/Functional/Observable/ErrorObservableTest.php
@@ -11,7 +11,7 @@ use Rx\Scheduler\ImmediateScheduler;
 
 class ErrorObservableTest extends FunctionalTestCase
 {
-    public function testErrorObservableWillAcceptThrowable()
+    public function testErrorObservableWillAcceptThrowable(): void
     {
         $throwable = null;
 

--- a/test/Rx/Functional/Observable/ForkJoinObservableTest.php
+++ b/test/Rx/Functional/Observable/ForkJoinObservableTest.php
@@ -480,7 +480,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
             onCompleted(230),
         ]);
 
-        $xs = Observable::forkJoin([$e0], function () use ($error) {
+        $xs = Observable::forkJoin([$e0], function () use ($error): void {
             throw $error;
         });
 

--- a/test/Rx/Functional/Observable/ForkJoinObservableTest.php
+++ b/test/Rx/Functional/Observable/ForkJoinObservableTest.php
@@ -13,7 +13,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_joins_last_values()
+    public function forkjoin_joins_last_values(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 'a'),
@@ -50,7 +50,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_allows_null()
+    public function forkjoin_allows_null(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 'a'),
@@ -87,7 +87,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_joins_last_values_with_selector()
+    public function forkjoin_joins_last_values_with_selector(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 'a'),
@@ -126,7 +126,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_accepts_single_observable()
+    public function forkjoin_accepts_single_observable(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 'a'),
@@ -151,7 +151,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_accepts_single_observable_with_selector()
+    public function forkjoin_accepts_single_observable_with_selector(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 'a'),
@@ -178,7 +178,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_wont_emit_with_empty_observable()
+    public function forkjoin_wont_emit_with_empty_observable(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -212,7 +212,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_empty_empty()
+    public function forkjoin_empty_empty(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -240,7 +240,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_none()
+    public function forkjoin_none(): void
     {
         $xs = Observable::forkJoin();
 
@@ -256,7 +256,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_empty_return()
+    public function forkjoin_empty_return(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -285,7 +285,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_return_empty()
+    public function forkjoin_return_empty(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -314,7 +314,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_return_return()
+    public function forkjoin_return_return(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -345,7 +345,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_empty_throw()
+    public function forkjoin_empty_throw(): void
     {
         $error = new \Exception();
 
@@ -376,7 +376,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_throw_empty()
+    public function forkjoin_throw_empty(): void
     {
         $error = new \Exception();
 
@@ -407,7 +407,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_return_throw()
+    public function forkjoin_return_throw(): void
     {
         $error = new \Exception();
 
@@ -439,7 +439,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_throw_return()
+    public function forkjoin_throw_return(): void
     {
         $error = new \Exception();
 
@@ -471,7 +471,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_throw_inside_selector()
+    public function forkjoin_throw_inside_selector(): void
     {
         $error = new \Exception();
 
@@ -496,7 +496,7 @@ class ForkJoinObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function forkjoin_disposed_after_emit()
+    public function forkjoin_disposed_after_emit(): void
     {
         $e0 = $this->createHotObservable([
             onNext(250, 1),

--- a/test/Rx/Functional/Observable/IntervalObservableTest.php
+++ b/test/Rx/Functional/Observable/IntervalObservableTest.php
@@ -13,7 +13,7 @@ class IntervalObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function interval_relative_time_basic()
+    public function interval_relative_time_basic(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return new IntervalObservable(100, $this->scheduler);
@@ -36,7 +36,7 @@ class IntervalObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function interval_relative_time_zero()
+    public function interval_relative_time_zero(): void
     {
         $results = $this->scheduler->startWithDispose(function () {
             return new IntervalObservable(0, $this->scheduler);
@@ -61,7 +61,7 @@ class IntervalObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function interval_relative_time_Negative()
+    public function interval_relative_time_Negative(): void
     {
         $results = $this->scheduler->startWithDispose(function () {
             return new IntervalObservable(-1, $this->scheduler);
@@ -86,7 +86,7 @@ class IntervalObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function interval_relative_time_disposed()
+    public function interval_relative_time_disposed(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return new IntervalObservable(1000, $this->scheduler);
@@ -98,7 +98,7 @@ class IntervalObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function interval_relative_time_observer_throws()
+    public function interval_relative_time_observer_throws(): void
     {
         $this->expectException(\Exception::class);
         $xs = new IntervalObservable(1, $this->scheduler);

--- a/test/Rx/Functional/Observable/IntervalObservableTest.php
+++ b/test/Rx/Functional/Observable/IntervalObservableTest.php
@@ -103,7 +103,7 @@ class IntervalObservableTest extends FunctionalTestCase
         $this->expectException(\Exception::class);
         $xs = new IntervalObservable(1, $this->scheduler);
 
-        $xs->subscribe(new CallbackObserver(function () {
+        $xs->subscribe(new CallbackObserver(function (): void {
             throw new \Exception();
         }));
 

--- a/test/Rx/Functional/Observable/IteratorObservableTest.php
+++ b/test/Rx/Functional/Observable/IteratorObservableTest.php
@@ -14,7 +14,7 @@ class IteratorObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_schedules_all_elements_from_the_generator()
+    public function it_schedules_all_elements_from_the_generator(): void
     {
         $generator = $this->genOneToThree();
 
@@ -35,7 +35,7 @@ class IteratorObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function generator_yields_null()
+    public function generator_yields_null(): void
     {
         $generator = $this->genNull();
 
@@ -54,7 +54,7 @@ class IteratorObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function generator_yields_one()
+    public function generator_yields_one(): void
     {
         $generator = $this->genOne();
 
@@ -71,7 +71,7 @@ class IteratorObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function generator_throws_error()
+    public function generator_throws_error(): void
     {
         $error     = new \Exception();
         $generator = $this->genError($error);
@@ -88,7 +88,7 @@ class IteratorObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function generator_dispose()
+    public function generator_dispose(): void
     {
         $generator = $this->genOneToThree();
 
@@ -104,7 +104,7 @@ class IteratorObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_schedules_all_elements_from_the_generator_with_return()
+    public function it_schedules_all_elements_from_the_generator_with_return(): void
     {
         $generator = $this->genOneToThreeAndReturn();
 
@@ -125,7 +125,7 @@ class IteratorObservableTest extends FunctionalTestCase
      * @test
      * RxPHP Issue 188
      */
-    public function it_completes_if_subscribed_second_time_without_return_value()
+    public function it_completes_if_subscribed_second_time_without_return_value(): void
     {
         $generator = $this->genOneToThree();
 
@@ -159,7 +159,7 @@ class IteratorObservableTest extends FunctionalTestCase
      * @test
      * RxPHP Issue 188
      */
-    public function it_returns_value_if_subscribed_second_time_with_return_value()
+    public function it_returns_value_if_subscribed_second_time_with_return_value(): void
     {
         $generator = $this->genOneToThreeAndReturn();
 

--- a/test/Rx/Functional/Observable/IteratorObservableTest.php
+++ b/test/Rx/Functional/Observable/IteratorObservableTest.php
@@ -131,13 +131,13 @@ class IteratorObservableTest extends FunctionalTestCase
 
         $results1 = new MockObserver($this->scheduler);
 
-        $this->scheduler->scheduleAbsolute(200, function () use ($generator, $results1) {
+        $this->scheduler->scheduleAbsolute(200, function () use ($generator, $results1): void {
             Observable::fromIterator($generator, $this->scheduler)->subscribe($results1);
         });
 
         $results2 = new MockObserver($this->scheduler);
 
-        $this->scheduler->scheduleAbsolute(400, function () use ($generator, $results2) {
+        $this->scheduler->scheduleAbsolute(400, function () use ($generator, $results2): void {
             Observable::fromIterator($generator, $this->scheduler)->subscribe($results2);
         });
 
@@ -165,13 +165,13 @@ class IteratorObservableTest extends FunctionalTestCase
 
         $results1 = new MockObserver($this->scheduler);
 
-        $this->scheduler->scheduleAbsolute(200, function () use ($generator, $results1) {
+        $this->scheduler->scheduleAbsolute(200, function () use ($generator, $results1): void {
             Observable::fromIterator($generator, $this->scheduler)->subscribe($results1);
         });
 
         $results2 = new MockObserver($this->scheduler);
 
-        $this->scheduler->scheduleAbsolute(400, function () use ($generator, $results2) {
+        $this->scheduler->scheduleAbsolute(400, function () use ($generator, $results2): void {
             Observable::fromIterator($generator, $this->scheduler)->subscribe($results2);
         });
 

--- a/test/Rx/Functional/Observable/ReturnObservableTest.php
+++ b/test/Rx/Functional/Observable/ReturnObservableTest.php
@@ -11,7 +11,7 @@ use Rx\Scheduler;
 
 class ReturnObservableTest extends FunctionalTestCase
 {
-    public function testReturnObservableSubscribeTwice()
+    public function testReturnObservableSubscribeTwice(): void
     {
         $o = new ReturnObservable('The Value', Scheduler::getImmediate());
 

--- a/test/Rx/Functional/Observable/ReturnObservableTest.php
+++ b/test/Rx/Functional/Observable/ReturnObservableTest.php
@@ -18,14 +18,14 @@ class ReturnObservableTest extends FunctionalTestCase
         $goodCount = 0;
 
         $o->subscribe(new CallbackObserver(
-            function ($x) use (&$goodCount) {
+            function ($x) use (&$goodCount): void {
                 $this->assertEquals('The Value', $x);
                 $goodCount++;
             }
         ));
 
         $o->subscribe(new CallbackObserver(
-            function ($x) use (&$goodCount) {
+            function ($x) use (&$goodCount): void {
                 $this->assertEquals('The Value', $x);
                 $goodCount++;
             }

--- a/test/Rx/Functional/Observable/TimerObservableTest.php
+++ b/test/Rx/Functional/Observable/TimerObservableTest.php
@@ -14,7 +14,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_basic()
+    public function timer_one_shot_relative_time_basic(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return new TimerObservable(300, $this->scheduler);
@@ -32,7 +32,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_zero()
+    public function timer_one_shot_relative_time_zero(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return new TimerObservable(0, $this->scheduler);
@@ -50,7 +50,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_zero_non_int()
+    public function timer_one_shot_relative_time_zero_non_int(): void
     {
         $this->expectException(\TypeError::class);
         $this->scheduler->startWithCreate(function () {
@@ -61,7 +61,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_negative()
+    public function timer_one_shot_relative_time_negative(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return new TimerObservable(-1, $this->scheduler);
@@ -79,7 +79,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_disposed()
+    public function timer_one_shot_relative_time_disposed(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return new TimerObservable(1000, $this->scheduler);
@@ -91,7 +91,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_dispose_before_dueTime()
+    public function timer_one_shot_relative_time_dispose_before_dueTime(): void
     {
         $results = $this->scheduler->startWithDispose(function () {
             return new TimerObservable(500, $this->scheduler);
@@ -103,7 +103,7 @@ class TimerObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timer_one_shot_relative_time_throws()
+    public function timer_one_shot_relative_time_throws(): void
     {
 
         $scheduler1 = new TestScheduler();

--- a/test/Rx/Functional/Observable/TimerObservableTest.php
+++ b/test/Rx/Functional/Observable/TimerObservableTest.php
@@ -109,22 +109,22 @@ class TimerObservableTest extends FunctionalTestCase
         $scheduler1 = new TestScheduler();
 
         $xs = Observable::timer(1, $scheduler1);
-        $xs->subscribe(function () {
+        $xs->subscribe(function (): void {
             throw new \Exception();
         });
 
-        $this->assertException(function () use ($scheduler1) {
+        $this->assertException(function () use ($scheduler1): void {
             $scheduler1->start();
         });
 
         $scheduler2 = new TestScheduler();
 
         $ys = Observable::timer(1, $scheduler2);
-        $ys->subscribe(null, null, function () {
+        $ys->subscribe(null, null, function (): void {
             throw new \Exception();
         });
 
-        $this->assertException(function () use ($scheduler2) {
+        $this->assertException(function () use ($scheduler2): void {
             $scheduler2->start();
         });
     }

--- a/test/Rx/Functional/ObservableTest.php
+++ b/test/Rx/Functional/ObservableTest.php
@@ -22,9 +22,9 @@ class ObservableTest extends FunctionalTestCase
 
         $disposable = null;
 
-        $this->scheduler->scheduleAbsolute(200, function () use ($xs, $results, &$disposable) {
+        $this->scheduler->scheduleAbsolute(200, function () use ($xs, $results, &$disposable): void {
             $disposable = $xs->subscribe(
-                function ($value) use ($results) {
+                function ($value) use ($results): void {
                     if ($value === 3) {
                         throw new TestException();
                     }
@@ -35,7 +35,7 @@ class ObservableTest extends FunctionalTestCase
             );
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$disposable) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$disposable): void {
             $disposable->dispose();
         });
 

--- a/test/Rx/Functional/ObservableTest.php
+++ b/test/Rx/Functional/ObservableTest.php
@@ -7,7 +7,7 @@ use Rx\Testing\MockObserver;
 
 class ObservableTest extends FunctionalTestCase
 {
-    public function testExceptionInOnNextByDefaultGoesToErrorAndDisposes()
+    public function testExceptionInOnNextByDefaultGoesToErrorAndDisposes(): void
     {
         $xs = $this->createHotObservable(
             [

--- a/test/Rx/Functional/Operator/AsObservableTest.php
+++ b/test/Rx/Functional/Operator/AsObservableTest.php
@@ -21,7 +21,7 @@ class AsObservableTest extends FunctionalTestCase
         return ($someObservable->asObservable() !== $someObservable);
     }
 
-    public function testAsObservableNever()
+    public function testAsObservableNever(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -34,7 +34,7 @@ class AsObservableTest extends FunctionalTestCase
         );
     }
 
-    public function testAsObservableEmpty()
+    public function testAsObservableEmpty(): void
     {
 
         $xs = $this->createHotObservable(
@@ -56,7 +56,7 @@ class AsObservableTest extends FunctionalTestCase
         );
     }
 
-    public function testAsObservableThrow()
+    public function testAsObservableThrow(): void
     {
         $error = new Exception();
 
@@ -79,7 +79,7 @@ class AsObservableTest extends FunctionalTestCase
         );
     }
 
-    public function testAsObservableJust()
+    public function testAsObservableJust(): void
     {
 
         $xs = $this->createHotObservable(
@@ -103,7 +103,7 @@ class AsObservableTest extends FunctionalTestCase
         );
     }
 
-    public function testAsObservableIsNotEager()
+    public function testAsObservableIsNotEager(): void
     {
 
         $subscribed = false;

--- a/test/Rx/Functional/Operator/AverageTest.php
+++ b/test/Rx/Functional/Operator/AverageTest.php
@@ -13,7 +13,7 @@ class AverageTest extends FunctionalTestCase
      *
      * @test
      */
-    public function average_Number_Empty()
+    public function average_Number_Empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -34,7 +34,7 @@ class AverageTest extends FunctionalTestCase
      *
      * @test
      */
-    public function average_Number_Return()
+    public function average_Number_Return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -57,7 +57,7 @@ class AverageTest extends FunctionalTestCase
      *
      * @test
      */
-    public function average_Number_Some()
+    public function average_Number_Some(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -81,7 +81,7 @@ class AverageTest extends FunctionalTestCase
      *
      * @test
      */
-    public function average_Number_Throw()
+    public function average_Number_Throw(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -102,7 +102,7 @@ class AverageTest extends FunctionalTestCase
      *
      * @test
      */
-    public function average_Number_Never()
+    public function average_Number_Never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)

--- a/test/Rx/Functional/Operator/BufferWithCountTest.php
+++ b/test/Rx/Functional/Operator/BufferWithCountTest.php
@@ -11,7 +11,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountpartialwindow()
+    public function bufferWithCountpartialwindow(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -35,7 +35,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountfullwindows()
+    public function bufferWithCountfullwindows(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -60,7 +60,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountfullandpartialwindows()
+    public function bufferWithCountfullandpartialwindows(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -85,7 +85,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountError()
+    public function bufferWithCountError(): void
     {
         $error = new \Exception();
 
@@ -110,7 +110,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountskipless()
+    public function bufferWithCountskipless(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -137,7 +137,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountskipmore()
+    public function bufferWithCountskipmore(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -162,7 +162,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountbasic()
+    public function bufferWithCountbasic(): void
     {
         $xs = $this->createHotObservable([
             onNext(100, 1),
@@ -197,7 +197,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCountdisposed()
+    public function bufferWithCountdisposed(): void
     {
         $xs = $this->createHotObservable([
             onNext(100, 1),
@@ -229,7 +229,7 @@ class BufferWithCountTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function bufferWithCount_invalid_skip()
+    public function bufferWithCount_invalid_skip(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $xs = $this->createHotObservable([
@@ -247,7 +247,7 @@ class BufferWithCountTest extends FunctionalTestCase
      * @test
      *
      */
-    public function bufferWithCount_invalid_count()
+    public function bufferWithCount_invalid_count(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/CatchErrorTest.php
+++ b/test/Rx/Functional/Operator/CatchErrorTest.php
@@ -14,7 +14,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_NoErrors()
+    public function catchError_NoErrors(): void
     {
         $o1 = $this->createHotObservable(
             [
@@ -51,7 +51,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Never()
+    public function catchError_Never(): void
     {
         $o1 = Observable::never();
 
@@ -77,7 +77,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Empty()
+    public function catchError_Empty(): void
     {
         $o1 = $this->createHotObservable(
             [
@@ -110,7 +110,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Return()
+    public function catchError_Return(): void
     {
         $o1 = $this->createHotObservable(
             [
@@ -145,7 +145,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Error()
+    public function catchError_Error(): void
     {
         $error = new \Exception();
 
@@ -185,7 +185,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Error_Never()
+    public function catchError_Error_Never(): void
     {
         $error = new \Exception();
 
@@ -219,7 +219,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Error_Never_Dispose()
+    public function catchError_Error_Never_Dispose(): void
     {
         $error = new \Exception();
 
@@ -251,7 +251,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Error_Error()
+    public function catchError_Error_Error(): void
     {
         $error = new \Exception();
 
@@ -291,7 +291,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Error_Error_Dispose()
+    public function catchError_Error_Error_Dispose(): void
     {
         $error = new \Exception();
 
@@ -330,7 +330,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_HandlerThrows()
+    public function catchError_HandlerThrows(): void
     {
         $error = new \Exception();
 
@@ -365,7 +365,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_handler_returns_invalid_string()
+    public function catchError_handler_returns_invalid_string(): void
     {
         $o1 = $this->createHotObservable(
             [
@@ -395,7 +395,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_Nested_OuterCatches()
+    public function catchError_Nested_OuterCatches(): void
     {
         $error               = new \Exception();
         $firstHandlerCalled  = false;
@@ -451,7 +451,7 @@ class CatchErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function catchError_ThrowFromNestedCatch()
+    public function catchError_ThrowFromNestedCatch(): void
     {
         $error  = new \Exception();
         $error2 = new \InvalidArgumentException();
@@ -515,7 +515,7 @@ class CatchErrorTest extends FunctionalTestCase
      * does not lose subscription to underlying observable
      * @test
      */
-    public function catchError_does_not_lose_subscription()
+    public function catchError_does_not_lose_subscription(): void
     {
         $subscribes   = 0;
         $unsubscribes = 0;

--- a/test/Rx/Functional/Operator/CatchErrorTest.php
+++ b/test/Rx/Functional/Operator/CatchErrorTest.php
@@ -346,7 +346,7 @@ class CatchErrorTest extends FunctionalTestCase
         );
 
         $results = $this->scheduler->startWithCreate(function () use ($o1, $error2) {
-            return $o1->catch(function () use ($error2) {
+            return $o1->catch(function () use ($error2): void {
                 throw $error2;
 
             });
@@ -523,7 +523,7 @@ class CatchErrorTest extends FunctionalTestCase
         $tracer = Observable::create(function () use (&$subscribes, &$unsubscribes) {
             ++$subscribes;
 
-            return new CallbackDisposable(function () use (&$unsubscribes) {
+            return new CallbackDisposable(function () use (&$unsubscribes): void {
                 ++$unsubscribes;
             });
         });

--- a/test/Rx/Functional/Operator/CombineLatestTest.php
+++ b/test/Rx/Functional/Operator/CombineLatestTest.php
@@ -880,7 +880,7 @@ class CombineLatestTest extends FunctionalTestCase
         );
 
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
-            return $e1->combineLatest([$e2], function () {
+            return $e1->combineLatest([$e2], function (): void {
                 throw new \Exception();
             });
         });

--- a/test/Rx/Functional/Operator/CombineLatestTest.php
+++ b/test/Rx/Functional/Operator/CombineLatestTest.php
@@ -19,7 +19,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_never_never()
+    public function combineLatest_never_never(): void
     {
 
         $e1 = new NeverObservable();
@@ -36,7 +36,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_never_empty()
+    public function combineLatest_never_empty(): void
     {
 
         $e1 = new NeverObservable();
@@ -58,7 +58,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_empty_never()
+    public function combineLatest_empty_never(): void
     {
         $e1 = new NeverObservable();
         $e2 = $this->createHotObservable(
@@ -80,7 +80,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_empty_empty()
+    public function combineLatest_empty_empty(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -108,7 +108,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_empty_return()
+    public function combineLatest_empty_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -135,7 +135,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_never_return()
+    public function combineLatest_never_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -157,7 +157,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_return_return()
+    public function combineLatest_return_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -192,7 +192,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_return_return_return()
+    public function combineLatest_return_return_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -234,7 +234,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_return_return_no_selector()
+    public function combineLatest_return_return_no_selector(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -269,7 +269,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_empty_error()
+    public function combineLatest_empty_error(): void
     {
         $error = new \Exception();
 
@@ -302,7 +302,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_error_empty()
+    public function combineLatest_error_empty(): void
     {
         $error = new \Exception();
 
@@ -335,7 +335,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_return_throw()
+    public function combineLatest_return_throw(): void
     {
         $error = new \Exception();
 
@@ -370,7 +370,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_return()
+    public function combineLatest_throw_return(): void
     {
         $error = new \Exception();
 
@@ -405,7 +405,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_throw()
+    public function combineLatest_throw_throw(): void
     {
         $error1 = new \Exception('first');
         $error2 = new \Exception('second');
@@ -439,7 +439,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_error_throw()
+    public function combineLatest_error_throw(): void
     {
         $error1 = new \Exception();
         $error2 = new \Exception();
@@ -474,7 +474,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_error()
+    public function combineLatest_throw_error(): void
     {
         $error1 = new \Exception();
         $error2 = new \Exception();
@@ -510,7 +510,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_never_throw()
+    public function combineLatest_never_throw(): void
     {
         $error = new \Exception();
 
@@ -538,7 +538,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_never()
+    public function combineLatest_throw_never(): void
     {
         $error = new \Exception();
 
@@ -566,7 +566,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_some_throw()
+    public function combineLatest_some_throw(): void
     {
         $error = new \Exception();
 
@@ -600,7 +600,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_some()
+    public function combineLatest_throw_some(): void
     {
         $error = new \Exception();
 
@@ -634,7 +634,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_after_complete_left()
+    public function combineLatest_throw_after_complete_left(): void
     {
         $error = new \Exception();
 
@@ -668,7 +668,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_throw_after_complete_right()
+    public function combineLatest_throw_after_complete_right(): void
     {
         $error = new \Exception();
 
@@ -702,7 +702,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_interleaved_with_tail()
+    public function combineLatest_interleaved_with_tail(): void
     {
 
         $e1 = $this->createHotObservable(
@@ -746,7 +746,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_consecutive()
+    public function combineLatest_consecutive(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -783,7 +783,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_consecutive_end_with_error_left()
+    public function combineLatest_consecutive_end_with_error_left(): void
     {
         $error = new \Exception();
 
@@ -820,7 +820,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_consecutive_end_with_error_right()
+    public function combineLatest_consecutive_end_with_error_right(): void
     {
         $error = new \Exception();
 
@@ -859,7 +859,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_selector_throws()
+    public function combineLatest_selector_throws(): void
     {
         $error = new \Exception();
 
@@ -896,7 +896,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_delay()
+    public function combineLatest_delay(): void
     {
         $source1 = Observable::timer(100, $this->scheduler);
         $source2 = Observable::timer(120, $this->scheduler);
@@ -917,7 +917,7 @@ class CombineLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function combineLatest_args_order()
+    public function combineLatest_args_order(): void
     {
 
         $e1 = $this->createHotObservable(

--- a/test/Rx/Functional/Operator/ComposeTest.php
+++ b/test/Rx/Functional/Operator/ComposeTest.php
@@ -6,7 +6,7 @@ use Rx\Functional\FunctionalTestCase;
 
 class ComposeTest extends FunctionalTestCase
 {
-    public function testSimpleCompose()
+    public function testSimpleCompose(): void
     {
         $xs = $this->createHotObservable(
             [

--- a/test/Rx/Functional/Operator/ConcatAllTest.php
+++ b/test/Rx/Functional/Operator/ConcatAllTest.php
@@ -40,7 +40,7 @@ class ConcatAllTest extends FunctionalTestCase
      */
     public function concatAll_errors_when_exception_during_inner_subscribe()
     {
-        $o1 = Observable::create(function () {
+        $o1 = Observable::create(function (): void {
             throw new \Exception("Exception in inner subscribe");
         });
 

--- a/test/Rx/Functional/Operator/ConcatAllTest.php
+++ b/test/Rx/Functional/Operator/ConcatAllTest.php
@@ -12,7 +12,7 @@ class ConcatAllTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatAll_timer_missing_item()
+    public function concatAll_timer_missing_item(): void
     {
         $xs = $this->createHotObservable([
             onNext(201, 0),
@@ -38,7 +38,7 @@ class ConcatAllTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatAll_errors_when_exception_during_inner_subscribe()
+    public function concatAll_errors_when_exception_during_inner_subscribe(): void
     {
         $o1 = Observable::create(function (): void {
             throw new \Exception("Exception in inner subscribe");

--- a/test/Rx/Functional/Operator/ConcatMapTest.php
+++ b/test/Rx/Functional/Operator/ConcatMapTest.php
@@ -23,13 +23,13 @@ class ConcatMapTest extends FunctionalTestCase
 
         $xs->concatMapTo($ys)
             ->subscribe(
-                function ($x) use (&$results) {
+                function ($x) use (&$results): void {
                     $results[] = $x;
                 },
-                function ($e) {
+                function ($e): void {
                     $this->fail();
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );
@@ -52,14 +52,14 @@ class ConcatMapTest extends FunctionalTestCase
 
         $xs->concatMapTo($ys)
             ->subscribe(
-                function ($x) use (&$results) {
+                function ($x) use (&$results): void {
                     $results[] = $x;
                 },
-                function (\Exception $e) use (&$results, &$error) {
+                function (\Exception $e) use (&$results, &$error): void {
                     $error = true;
                     $this->assertSame('test', $e->getMessage());
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );
@@ -87,13 +87,13 @@ class ConcatMapTest extends FunctionalTestCase
                 return $x + $y + $oi;
             })
             ->subscribe(
-                function ($x) use (&$results) {
+                function ($x) use (&$results): void {
                     $results[] = $x;
                 },
-                function ($e) {
+                function ($e): void {
                     $this->fail();
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );
@@ -118,17 +118,17 @@ class ConcatMapTest extends FunctionalTestCase
             function ($x, $i) {
                 return Observable::of($x + $i);
             },
-            function ($x, $y, $i) use ($error) {
+            function ($x, $y, $i) use ($error): void {
                 throw $error;
             })
             ->subscribe(
-                function ($x) use (&$results) {
+                function ($x) use (&$results): void {
                     $results[] = $x;
                 },
-                function ($e) use (&$returnError) {
+                function ($e) use (&$returnError): void {
                     $returnError = $e;
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );
@@ -152,13 +152,13 @@ class ConcatMapTest extends FunctionalTestCase
             return Observable::of($x + $i);
         })
             ->subscribe(
-                function ($x) use (&$results) {
+                function ($x) use (&$results): void {
                     $results[] = $x;
                 },
-                function ($e) {
+                function ($e): void {
                     $this->fail('Should not get an error');
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );
@@ -182,14 +182,14 @@ class ConcatMapTest extends FunctionalTestCase
             return Observable::error(new Exception((string)($x + $i)));
         })
             ->subscribe(
-                function ($x) use (&$results) {
+                function ($x) use (&$results): void {
                     $results[] = $x;
                 },
-                function (\Exception $e) use (&$results, &$error) {
+                function (\Exception $e) use (&$results, &$error): void {
                     $error = true;
                     $this->assertEquals(4, $e->getMessage());
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );

--- a/test/Rx/Functional/Operator/ConcatMapTest.php
+++ b/test/Rx/Functional/Operator/ConcatMapTest.php
@@ -13,7 +13,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Complete_Task()
+    public function concatMapTo_Then_Complete_Task(): void
     {
         $xs = Observable::fromArray([4, 3, 2, 1]);
         $ys = Observable::of(42);
@@ -41,7 +41,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Error_Task()
+    public function concatMapTo_Then_Error_Task(): void
     {
         $xs = Observable::fromArray([4, 3, 2, 1]);
         $ys = Observable::error(new \Exception('test'));
@@ -71,7 +71,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_result_Complete_Task()
+    public function concatMap_result_Complete_Task(): void
     {
         $xs = Observable::fromArray([4, 3, 2, 1]);
 
@@ -105,7 +105,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_result_Error_Task()
+    public function concatMap_result_Error_Task(): void
     {
         $xs = Observable::fromArray([4, 3, 2, 1]);
 
@@ -141,7 +141,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Then_Complete_Task()
+    public function concatMap_Then_Complete_Task(): void
     {
         $xs = Observable::fromArray([4, 3, 2, 1]);
 
@@ -170,7 +170,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Then_Error_Task()
+    public function concatMap_Then_Error_Task(): void
     {
         $xs = Observable::fromArray([4, 3, 2, 1]);
 
@@ -201,7 +201,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Complete_Complete()
+    public function concatMapTo_Then_Complete_Complete(): void
     {
 
         $xs = $this->createColdObservable(
@@ -266,7 +266,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Complete_Complete_2()
+    public function concatMapTo_Then_Complete_Complete_2(): void
     {
 
         $xs = $this->createColdObservable(
@@ -331,7 +331,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Never_Complete()
+    public function concatMapTo_Then_Never_Complete(): void
     {
 
         $xs = $this->createColdObservable(
@@ -406,7 +406,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Complete_Never()
+    public function concatMapTo_Then_Complete_Never(): void
     {
 
         $xs = $this->createColdObservable(
@@ -454,7 +454,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Complete_Error()
+    public function concatMapTo_Then_Complete_Error(): void
     {
 
         $ex = new Exception();
@@ -506,7 +506,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Error_Complete()
+    public function concatMapTo_Then_Error_Complete(): void
     {
 
         $ex = new Exception();
@@ -561,7 +561,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMapTo_Then_Error_Error()
+    public function concatMapTo_Then_Error_Error(): void
     {
 
         $ex = new Exception();
@@ -613,7 +613,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Complete()
+    public function concatMap_Complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -683,7 +683,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Complete_OuterNotComplete()
+    public function concatMap_Complete_OuterNotComplete(): void
     {
 
 
@@ -753,7 +753,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Error_Outer()
+    public function concatMap_Error_Outer(): void
     {
         $ex = new Exception();
 
@@ -822,7 +822,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Error_Inner()
+    public function concatMap_Error_Inner(): void
     {
         $ex = new Exception();
 
@@ -891,7 +891,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Dispose()
+    public function concatMap_Dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -957,7 +957,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_Throw()
+    public function concatMap_Throw(): void
     {
         $invoked = 0;
         $ex      = new Exception('ex');
@@ -1030,7 +1030,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_UseFunction()
+    public function concatMap_UseFunction(): void
     {
         $xs = $this->createHotObservable([
             onNext(210, 4),
@@ -1077,7 +1077,7 @@ class ConcatMapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function concatMap_return_invalid_string()
+    public function concatMap_return_invalid_string(): void
     {
         $xs = $this->createHotObservable([
             onNext(5, $this->createColdObservable([

--- a/test/Rx/Functional/Operator/ConcatTest.php
+++ b/test/Rx/Functional/Operator/ConcatTest.php
@@ -10,7 +10,7 @@ use Rx\Observable\EmptyObservable;
 
 class ConcatTest extends FunctionalTestCase
 {
-    public function testConcatEmptyEmpty()
+    public function testConcatEmptyEmpty(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -26,7 +26,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onCompleted(250)], $results->getMessages());
     }
 
-    public function testConcatEmptyNever()
+    public function testConcatEmptyNever(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -39,7 +39,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testConcatNeverEmpty()
+    public function testConcatNeverEmpty(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -52,7 +52,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testConcatNeverNever()
+    public function testConcatNeverNever(): void
     {
         $e1      = Observable::never();
         $e2      = Observable::never();
@@ -62,7 +62,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testConcatEmptyThrow()
+    public function testConcatEmptyThrow(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -78,7 +78,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onError(250, new \Exception('error'))], $results->getMessages());
     }
 
-    public function testConcatThrowEmpty()
+    public function testConcatThrowEmpty(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -94,7 +94,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onError(230, new \Exception('error'))], $results->getMessages());
     }
 
-    public function testConcatThrowThrow()
+    public function testConcatThrowThrow(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -110,7 +110,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onError(230, new \ErrorException())], $results->getMessages());
     }
 
-    public function testConcatReturnEmpty()
+    public function testConcatReturnEmpty(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -127,7 +127,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onNext(210, 2), onCompleted(250)], $results->getMessages());
     }
 
-    public function testConcatEmptyReturn()
+    public function testConcatEmptyReturn(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -144,7 +144,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onNext(240, 2), onCompleted(250)], $results->getMessages());
     }
 
-    public function testConcatReturnNever()
+    public function testConcatReturnNever(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -158,7 +158,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onNext(210, 2)], $results->getMessages());
     }
 
-    public function testConcatNeverReturn()
+    public function testConcatNeverReturn(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -172,7 +172,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testConcatReturnReturn()
+    public function testConcatReturnReturn(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -190,7 +190,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onNext(220, 2), onNext(240, 3), onCompleted(250)], $results->getMessages());
     }
 
-    public function testConcatThrowReturn()
+    public function testConcatThrowReturn(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -207,7 +207,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onError(220, new \Exception())], $results->getMessages());
     }
 
-    public function testConcatReturnThrow()
+    public function testConcatReturnThrow(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -224,7 +224,7 @@ class ConcatTest extends FunctionalTestCase
         $this->assertMessages([onNext(220, 2), onError(250, new \Exception())], $results->getMessages());
     }
 
-    public function testConcatSomeDataOnBothSides()
+    public function testConcatSomeDataOnBothSides(): void
     {
         $e1      = $this->createHotObservable([
             onNext(150, 1),
@@ -251,7 +251,7 @@ class ConcatTest extends FunctionalTestCase
             $results->getMessages());
     }
 
-    public function testConcatAsArguments()
+    public function testConcatAsArguments(): void
     {
         $xs1     = $this->createColdObservable([
             onNext(10, 1),
@@ -299,7 +299,7 @@ class ConcatTest extends FunctionalTestCase
 
     }
 
-    public function testConcatAll()
+    public function testConcatAll(): void
     {
 
         $sources = Observable::fromArray([
@@ -329,7 +329,7 @@ class ConcatTest extends FunctionalTestCase
     }
 
 
-    public function testConcatAllError()
+    public function testConcatAllError(): void
     {
 
         $sources = Observable::fromArray([
@@ -361,7 +361,7 @@ class ConcatTest extends FunctionalTestCase
 
     }
 
-    public function testConcatDispose()
+    public function testConcatDispose(): void
     {
         $o1 = $this->createHotObservable([
             onNext(250, 1),

--- a/test/Rx/Functional/Operator/ConcatTest.php
+++ b/test/Rx/Functional/Operator/ConcatTest.php
@@ -313,13 +313,13 @@ class ConcatTest extends FunctionalTestCase
         $completed = false;
 
         $sources->concatAll()->subscribe(
-            function ($x) use (&$res) {
+            function ($x) use (&$res): void {
                 $res[] = $x;
             },
-            function ($e) {
+            function ($e): void {
                 $this->fail();
             },
-            function () use (&$completed) {
+            function () use (&$completed): void {
                 $completed = true;
             }
         );
@@ -344,14 +344,14 @@ class ConcatTest extends FunctionalTestCase
         $completed = false;
 
         $sources->concatAll()->subscribe(
-            function ($x) use (&$res) {
+            function ($x) use (&$res): void {
                 $res[] = $x;
             },
-            function ($e) use (&$res, &$error) {
+            function ($e) use (&$res, &$error): void {
                 $this->assertEquals([0], $res);
                 $error = true;
             },
-            function () use (&$completed) {
+            function () use (&$completed): void {
                 $completed = true;
             }
         );

--- a/test/Rx/Functional/Operator/CountTest.php
+++ b/test/Rx/Functional/Operator/CountTest.php
@@ -9,7 +9,7 @@ use Rx\Observable;
 
 class CountTest extends FunctionalTestCase
 {
-    public function testCountEmpty()
+    public function testCountEmpty(): void
     {
 
         $xs = $this->createHotObservable(
@@ -32,7 +32,7 @@ class CountTest extends FunctionalTestCase
         );
     }
 
-    public function testCountSome()
+    public function testCountSome(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -57,7 +57,7 @@ class CountTest extends FunctionalTestCase
         );
     }
 
-    public function testCountThrow()
+    public function testCountThrow(): void
     {
 
         $xs = $this->createHotObservable(
@@ -74,7 +74,7 @@ class CountTest extends FunctionalTestCase
         $this->assertMessages([onError(210, new \Exception())], $results->getMessages());
     }
 
-    public function testCountNever()
+    public function testCountNever(): void
     {
 
         $xs = $this->createHotObservable(
@@ -89,7 +89,7 @@ class CountTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testCountPredicateEmptyTrue()
+    public function testCountPredicateEmptyTrue(): void
     {
 
         $xs = $this->createHotObservable(
@@ -114,7 +114,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateEmptyFalse()
+    public function testCountPredicateEmptyFalse(): void
     {
 
         $xs = $this->createHotObservable(
@@ -140,7 +140,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateReturnTrue()
+    public function testCountPredicateReturnTrue(): void
     {
 
         $xs = $this->createHotObservable([onNext(150, 1), onNext(210, 2), onCompleted(250)]);
@@ -153,7 +153,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateReturnFalse()
+    public function testCountPredicateReturnFalse(): void
     {
 
         $xs = $this->createHotObservable(
@@ -179,7 +179,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateAllMatched()
+    public function testCountPredicateAllMatched(): void
     {
 
         $xs = $this->createHotObservable(
@@ -207,7 +207,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateNoneMatched()
+    public function testCountPredicateNoneMatched(): void
     {
 
         $xs = $this->createHotObservable(
@@ -235,7 +235,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateSomeEven()
+    public function testCountPredicateSomeEven(): void
     {
 
         $xs = $this->createHotObservable(
@@ -261,7 +261,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 250)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateThrowTrue()
+    public function testCountPredicateThrowTrue(): void
     {
 
         $xs = $this->createHotObservable(
@@ -281,7 +281,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 210)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateThrowFalse()
+    public function testCountPredicateThrowFalse(): void
     {
 
         $xs = $this->createHotObservable(
@@ -301,7 +301,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 210)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateNever()
+    public function testCountPredicateNever(): void
     {
 
         $xs = $this->createHotObservable(
@@ -321,7 +321,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 1000)], $xs->getSubscriptions());
     }
 
-    public function testCountPredicateThrowsError()
+    public function testCountPredicateThrowsError(): void
     {
 
         $xs = $this->createHotObservable(
@@ -346,7 +346,7 @@ class CountTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 230)], $xs->getSubscriptions());
     }
 
-    public function testCountAfterRange()
+    public function testCountAfterRange(): void
     {
 
         $xs = Observable::fromArray(range(1, 10), $this->scheduler);

--- a/test/Rx/Functional/Operator/CreateTest.php
+++ b/test/Rx/Functional/Operator/CreateTest.php
@@ -15,7 +15,7 @@ class CreateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function create_next()
+    public function create_next(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -35,7 +35,7 @@ class CreateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function create_null_disposable()
+    public function create_null_disposable(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -54,7 +54,7 @@ class CreateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function create_completed()
+    public function create_completed(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -75,7 +75,7 @@ class CreateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function create_error()
+    public function create_error(): void
     {
 
         $error = new \Exception();
@@ -98,7 +98,7 @@ class CreateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function create_throws_errors()
+    public function create_throws_errors(): void
     {
         $this->expectException(\Exception::class);
         Observable::create(function ($o): void {
@@ -109,7 +109,7 @@ class CreateTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function create_dispose()
+    public function create_dispose(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -163,7 +163,7 @@ class CreateTest extends FunctionalTestCase
      * @test
      *
      */
-    public function create_observer_does_not_catch()
+    public function create_observer_does_not_catch(): void
     {
         $this->assertException(function (): void {
             Observable::create(function (ObserverInterface $o) {

--- a/test/Rx/Functional/Operator/CreateTest.php
+++ b/test/Rx/Functional/Operator/CreateTest.php
@@ -39,7 +39,7 @@ class CreateTest extends FunctionalTestCase
     {
 
         $results = $this->scheduler->startWithCreate(function () {
-            return Observable::create(function (ObserverInterface $o) {
+            return Observable::create(function (ObserverInterface $o): void {
                 $o->onNext(1);
                 $o->onNext(2);
             });
@@ -101,7 +101,7 @@ class CreateTest extends FunctionalTestCase
     public function create_throws_errors()
     {
         $this->expectException(\Exception::class);
-        Observable::create(function ($o) {
+        Observable::create(function ($o): void {
             throw new \Exception;
         })->subscribe(new CallbackObserver());
     }
@@ -120,31 +120,31 @@ class CreateTest extends FunctionalTestCase
                 $o->onNext(1);
                 $o->onNext(2);
 
-                $this->scheduler->scheduleAbsolute(600, function () use ($o, &$isStopped) {
+                $this->scheduler->scheduleAbsolute(600, function () use ($o, &$isStopped): void {
                     if (!$isStopped) {
                         $o->onNext(3);
                     }
                 });
 
-                $this->scheduler->scheduleAbsolute(700, function () use ($o, &$isStopped) {
+                $this->scheduler->scheduleAbsolute(700, function () use ($o, &$isStopped): void {
                     if (!$isStopped) {
                         $o->onNext(4);
                     }
                 });
 
-                $this->scheduler->scheduleAbsolute(900, function () use ($o, &$isStopped) {
+                $this->scheduler->scheduleAbsolute(900, function () use ($o, &$isStopped): void {
                     if (!$isStopped) {
                         $o->onNext(5);
                     }
                 });
 
-                $this->scheduler->scheduleAbsolute(1100, function () use ($o, &$isStopped) {
+                $this->scheduler->scheduleAbsolute(1100, function () use ($o, &$isStopped): void {
                     if (!$isStopped) {
                         $o->onNext(6);
                     }
                 });
 
-                return new CallbackDisposable(function () use (&$isStopped) {
+                return new CallbackDisposable(function () use (&$isStopped): void {
                     $isStopped = true;
                 });
             });
@@ -165,31 +165,31 @@ class CreateTest extends FunctionalTestCase
      */
     public function create_observer_does_not_catch()
     {
-        $this->assertException(function () {
+        $this->assertException(function (): void {
             Observable::create(function (ObserverInterface $o) {
                 $o->onNext(1);
                 return new EmptyDisposable();
-            })->subscribe(new CallbackObserver(function () {
+            })->subscribe(new CallbackObserver(function (): void {
                 throw new \Exception;
             }));
         });
 
 
-        $this->assertException(function () {
+        $this->assertException(function (): void {
             Observable::create(function (ObserverInterface $o) {
                 $o->onError(new \Exception());
                 return new EmptyDisposable();
             })->subscribe(
                 new CallbackObserver(
                     null,
-                    function () {
+                    function (): void {
                         throw new \Exception;
                     }
                 )
             );
         });
 
-        $this->assertException(function () {
+        $this->assertException(function (): void {
             Observable::create(function (ObserverInterface $o) {
                 $o->onCompleted();
                 return new EmptyDisposable();
@@ -197,7 +197,7 @@ class CreateTest extends FunctionalTestCase
                 new CallbackObserver(
                     null,
                     null,
-                    function () {
+                    function (): void {
                         throw new \Exception;
                     }
                 )

--- a/test/Rx/Functional/Operator/CustomTest.php
+++ b/test/Rx/Functional/Operator/CustomTest.php
@@ -9,7 +9,7 @@ use Rx\Observable;
 
 class CustomTest extends FunctionalTestCase
 {
-    public function testCustomOperator()
+    public function testCustomOperator(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::of(1, $this->scheduler)
@@ -22,7 +22,7 @@ class CustomTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testExternalNamespacedOperator()
+    public function testExternalNamespacedOperator(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::of(1, $this->scheduler)

--- a/test/Rx/Functional/Operator/DefaultIfEmptyTest.php
+++ b/test/Rx/Functional/Operator/DefaultIfEmptyTest.php
@@ -14,7 +14,7 @@ class DefaultIfEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defaultIfEmpty_nonEmpty_1()
+    public function defaultIfEmpty_nonEmpty_1(): void
     {
 
         $xs = $this->createHotObservable([
@@ -40,7 +40,7 @@ class DefaultIfEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defaultIfEmpty_nonEmpty_2()
+    public function defaultIfEmpty_nonEmpty_2(): void
     {
 
         $xs = $this->createHotObservable([
@@ -66,7 +66,7 @@ class DefaultIfEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defaultIfEmpty_empty_1()
+    public function defaultIfEmpty_empty_1(): void
     {
 
         $xs = $this->createHotObservable([
@@ -93,7 +93,7 @@ class DefaultIfEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defaultIfEmpty_empty_2()
+    public function defaultIfEmpty_empty_2(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/DeferTest.php
+++ b/test/Rx/Functional/Operator/DeferTest.php
@@ -108,7 +108,7 @@ class DeferTest extends FunctionalTestCase
         $invoked = 0;
 
         $results = $this->scheduler->startWithCreate(function () use (&$invoked) {
-            return Observable::defer(function () use (&$invoked) {
+            return Observable::defer(function () use (&$invoked): void {
                 $invoked++;
                 throw new \Exception('error');
             });
@@ -154,7 +154,7 @@ class DeferTest extends FunctionalTestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('I take exception');
         Observable::defer(function () {
-            return Observable::create(function (ObserverInterface $observer) {
+            return Observable::create(function (ObserverInterface $observer): void {
                 $observer->onError(new \Exception('I take exception'));
             });
         }, new ImmediateScheduler())->subscribe();
@@ -168,10 +168,10 @@ class DeferTest extends FunctionalTestCase
         $onErrorCalled = false;
 
         Observable::defer(function () {
-            return Observable::create(function (ObserverInterface $observer) {
+            return Observable::create(function (ObserverInterface $observer): void {
                 $observer->onError(new \Exception('I take exception'));
             });
-        }, new ImmediateScheduler())->subscribe(null, function (\Exception $e) use (&$onErrorCalled) {
+        }, new ImmediateScheduler())->subscribe(null, function (\Exception $e) use (&$onErrorCalled): void {
             $onErrorCalled = true;
             $this->assertEquals('I take exception', $e->getMessage());
         });

--- a/test/Rx/Functional/Operator/DeferTest.php
+++ b/test/Rx/Functional/Operator/DeferTest.php
@@ -15,7 +15,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_complete()
+    public function defer_complete(): void
     {
         $invoked = 0;
         $xs      = null;
@@ -44,7 +44,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_error()
+    public function defer_error(): void
     {
         $invoked = 0;
         $xs      = null;
@@ -73,7 +73,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_dispose()
+    public function defer_dispose(): void
     {
         $invoked = 0;
         $xs      = null;
@@ -103,7 +103,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_throw()
+    public function defer_throw(): void
     {
         $invoked = 0;
 
@@ -128,7 +128,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_factory_returns_invalid_string()
+    public function defer_factory_returns_invalid_string(): void
     {
         $invoked = 0;
 
@@ -149,7 +149,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_error_while_subscribe_with_immediate_scheduler()
+    public function defer_error_while_subscribe_with_immediate_scheduler(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('I take exception');
@@ -163,7 +163,7 @@ class DeferTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function defer_error_while_subscribe_with_immediate_scheduler_passes_through()
+    public function defer_error_while_subscribe_with_immediate_scheduler_passes_through(): void
     {
         $onErrorCalled = false;
 

--- a/test/Rx/Functional/Operator/DelayTest.php
+++ b/test/Rx/Functional/Operator/DelayTest.php
@@ -281,12 +281,12 @@ class DelayTest extends FunctionalTestCase
     {
         $completes = false;
 
-        Observable::create(function ($observer) {
+        Observable::create(function ($observer): void {
             $observer->onCompleted();
         })->delay(1, $this->scheduler)->subscribe(
             null,
             null,
-            function () use (&$completes) {
+            function () use (&$completes): void {
                 $completes = true;
             }
         );

--- a/test/Rx/Functional/Operator/DelayTest.php
+++ b/test/Rx/Functional/Operator/DelayTest.php
@@ -12,7 +12,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_relative_time_simple_1()
+    public function delay_relative_time_simple_1(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -47,7 +47,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_relative_time_simple_2_implementation()
+    public function delay_relative_time_simple_2_implementation(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -82,7 +82,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_relative_time_simple_3_implementation()
+    public function delay_relative_time_simple_3_implementation(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -117,7 +117,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_relative_time_error_1_implementation()
+    public function delay_relative_time_error_1_implementation(): void
     {
         $error = new \Exception();
 
@@ -154,7 +154,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_relative_time_error_2_implementation()
+    public function delay_relative_time_error_2_implementation(): void
     {
         $error = new \Exception();
 
@@ -190,7 +190,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_empty()
+    public function delay_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -219,7 +219,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_error()
+    public function delay_error(): void
     {
         $error = new \Exception();
 
@@ -250,7 +250,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_never()
+    public function delay_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)
@@ -277,7 +277,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_completes_during_subscribe_without_throwing()
+    public function delay_completes_during_subscribe_without_throwing(): void
     {
         $completes = false;
 
@@ -299,7 +299,7 @@ class DelayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function delay_disposed_after_emit()
+    public function delay_disposed_after_emit(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),

--- a/test/Rx/Functional/Operator/DistinctTest.php
+++ b/test/Rx/Functional/Operator/DistinctTest.php
@@ -221,7 +221,7 @@ class DistinctTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $error) {
-            return $xs->distinct(function ($x) use ($error) {
+            return $xs->distinct(function ($x) use ($error): void {
                 if ($x === 12) {
                     throw $error;
                 }

--- a/test/Rx/Functional/Operator/DistinctTest.php
+++ b/test/Rx/Functional/Operator/DistinctTest.php
@@ -13,7 +13,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_default_comparer_all_distinct()
+    public function distinct_default_comparer_all_distinct(): void
     {
         $xs = $this->createHotObservable([
             onNext(280, 4),
@@ -47,7 +47,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_default_comparer_some_duplicates()
+    public function distinct_default_comparer_some_duplicates(): void
     {
         $xs = $this->createHotObservable([
             onNext(280, 4),
@@ -79,7 +79,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_default_comparer_some_error()
+    public function distinct_default_comparer_some_error(): void
     {
         $error = new \Exception();
 
@@ -111,7 +111,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_default_comparer_dispose()
+    public function distinct_default_comparer_dispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(280, 4),
@@ -141,7 +141,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_CustomComparer_all_distinct()
+    public function distinct_CustomComparer_all_distinct(): void
     {
         $xs = $this->createHotObservable([
             onNext(280, 4),
@@ -175,7 +175,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_CustomComparer_some_duplicates()
+    public function distinct_CustomComparer_some_duplicates(): void
     {
         $xs = $this->createHotObservable([
             onNext(280, 4),
@@ -207,7 +207,7 @@ class DistinctTest extends FunctionalTestCase
      *
      * @test
      */
-    public function distinct_CustomComparer_some_throw()
+    public function distinct_CustomComparer_some_throw(): void
     {
         $error = new \Exception();
 
@@ -244,7 +244,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_CustomKey_all_distinct()
+    public function distinct_CustomKey_all_distinct(): void
     {
         $xs = $this->createHotObservable([
             onNext(280, ['id' => 4]),
@@ -282,7 +282,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_CustomKey_some_duplicates()
+    public function distinct_CustomKey_some_duplicates(): void
     {
 
         $xs = $this->createHotObservable([
@@ -319,7 +319,7 @@ class DistinctTest extends FunctionalTestCase
      *
      * @test
      */
-    public function distinct_CustomKey_some_throw()
+    public function distinct_CustomKey_some_throw(): void
     {
         $error = new \Exception();
 
@@ -358,7 +358,7 @@ class DistinctTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_CustomKey_and_CustomComparer_some_duplicates()
+    public function distinct_CustomKey_and_CustomComparer_some_duplicates(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/DistinctUntilChangedTest.php
+++ b/test/Rx/Functional/Operator/DistinctUntilChangedTest.php
@@ -300,7 +300,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->distinctUntilKeyChanged(function ($x) {
+            return $xs->distinctUntilKeyChanged(function ($x): void {
                 throw new \Exception('ex');
             });
         });
@@ -321,7 +321,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->distinctUntilChanged(function ($x, $y) {
+            return $xs->distinctUntilChanged(function ($x, $y): void {
                 throw new \Exception('ex');
             });
         });

--- a/test/Rx/Functional/Operator/DistinctUntilChangedTest.php
+++ b/test/Rx/Functional/Operator/DistinctUntilChangedTest.php
@@ -16,7 +16,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_never()
+    public function distinct_until_changed_never(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -32,7 +32,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_empty()
+    public function distinct_until_changed_empty(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -52,7 +52,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_return()
+    public function distinct_until_changed_return(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -77,7 +77,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_throw()
+    public function distinct_until_changed_throw(): void
     {
         $ex = new \Exception('ex');
         $xs = $this->createHotObservable([
@@ -95,7 +95,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_all_changes()
+    public function distinct_until_changed_all_changes(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -136,7 +136,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_all_same()
+    public function distinct_until_changed_all_same(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -165,7 +165,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_some_changes()
+    public function distinct_until_changed_some_changes(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -214,7 +214,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_comparer_all_different()
+    public function distinct_until_changed_comparer_all_different(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -255,7 +255,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_keyselector_div2()
+    public function distinct_until_changed_keyselector_div2(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -290,7 +290,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_key_selector_throws()
+    public function distinct_until_changed_key_selector_throws(): void
     {
 
         $xs = $this->createHotObservable([
@@ -311,7 +311,7 @@ class DistinctUntilChangedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function distinct_until_changed_comparer_throws()
+    public function distinct_until_changed_comparer_throws(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),

--- a/test/Rx/Functional/Operator/DoOnCompletedTest.php
+++ b/test/Rx/Functional/Operator/DoOnCompletedTest.php
@@ -11,7 +11,7 @@ class DoOnCompletedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnCompleted_should_be_called()
+    public function doOnCompleted_should_be_called(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -34,7 +34,7 @@ class DoOnCompletedTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnCompleted_should_call_after_resubscription()
+    public function doOnCompleted_should_call_after_resubscription(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),

--- a/test/Rx/Functional/Operator/DoOnCompletedTest.php
+++ b/test/Rx/Functional/Operator/DoOnCompletedTest.php
@@ -23,7 +23,7 @@ class DoOnCompletedTest extends FunctionalTestCase
         $called = 0;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$called) {
-            return $xs->doOnCompleted(function () use (&$called) {
+            return $xs->doOnCompleted(function () use (&$called): void {
                 $called++;
             });
         });
@@ -44,7 +44,7 @@ class DoOnCompletedTest extends FunctionalTestCase
         $messages = [];
 
         $xs
-            ->doOnCompleted(function () use (&$messages) {
+            ->doOnCompleted(function () use (&$messages): void {
                 $messages[] = onCompleted($this->scheduler->getClock());
             })
             ->repeat(2)

--- a/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
+++ b/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
@@ -12,7 +12,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_should_see_all_values()
+    public function doOnEach_should_see_all_values(): void
     {
 
         $xs = $this->createHotObservable([
@@ -42,7 +42,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_plain_action()
+    public function doOnEach_plain_action(): void
     {
 
         $xs = $this->createHotObservable([
@@ -68,7 +68,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_completed()
+    public function doOnEach_next_completed(): void
     {
 
         $xs = $this->createHotObservable([
@@ -107,7 +107,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_completed_never()
+    public function doOnEach_next_completed_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)
@@ -137,7 +137,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error()
+    public function doOnEach_next_error(): void
     {
 
         $ex = new \Exception();
@@ -178,7 +178,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_not()
+    public function doOnEach_next_error_not(): void
     {
 
         $ex = new \Exception();
@@ -219,7 +219,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_completed()
+    public function doOnEach_next_error_completed(): void
     {
 
         $xs = $this->createHotObservable([
@@ -261,7 +261,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_completed_error()
+    public function doOnEach_next_error_completed_error(): void
     {
         $ex = new \Exception();
 
@@ -305,7 +305,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_completed_never()
+    public function doOnEach_next_error_completed_never(): void
     {
 
         $xs = $this->createHotObservable([
@@ -339,7 +339,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_next_throws()
+    public function doOnEach_next_next_throws(): void
     {
         $ex = new \Exception();
 
@@ -362,7 +362,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_completed_next_throws()
+    public function doOnEach_next_completed_next_throws(): void
     {
         $ex = new \Exception();
 
@@ -389,7 +389,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_completed_completed_throws()
+    public function doOnEach_next_completed_completed_throws(): void
     {
         $ex = new \Exception();
 
@@ -416,7 +416,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_next_throws()
+    public function doOnEach_next_error_next_throws(): void
     {
         $ex = new \Exception();
 
@@ -443,7 +443,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_error_throws()
+    public function doOnEach_next_error_error_throws(): void
     {
         $ex1 = new \Exception("error1");
         $ex2 = new \Exception("error2");
@@ -471,7 +471,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_completed_next_throws()
+    public function doOnEach_next_error_completed_next_throws(): void
     {
         $ex = new \Exception();
 
@@ -500,7 +500,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_completed_error_throws()
+    public function doOnEach_next_error_completed_error_throws(): void
     {
         $ex1 = new \Exception("error1");
         $ex2 = new \Exception("error2");
@@ -529,7 +529,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_next_error_completed_completed_throws()
+    public function doOnEach_next_error_completed_completed_throws(): void
     {
         $ex = new \Exception();
 
@@ -559,7 +559,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_observer_next_throws()
+    public function doOnEach_observer_next_throws(): void
     {
         $ex = new \Exception();
 
@@ -589,7 +589,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_observer_error_throws()
+    public function doOnEach_observer_error_throws(): void
     {
         $ex1 = new \Exception("error1");
         $ex2 = new \Exception("error2");
@@ -618,7 +618,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnEach_observer_completed_throws()
+    public function doOnEach_observer_completed_throws(): void
     {
         $ex = new \Exception();
 
@@ -647,7 +647,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function do_plain_action()
+    public function do_plain_action(): void
     {
 
         $xs = $this->createHotObservable([
@@ -673,7 +673,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function do_next_completed()
+    public function do_next_completed(): void
     {
 
         $xs = $this->createHotObservable([
@@ -712,7 +712,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function do_next_error()
+    public function do_next_error(): void
     {
 
         $ex = new \Exception();
@@ -752,7 +752,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
      * @test
      *
      */
-    public function do_throws_when_args_invalid()
+    public function do_throws_when_args_invalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
+++ b/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
@@ -92,7 +92,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
                     return $sum -= $x;
                 },
                 null,
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));
@@ -118,12 +118,12 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$completed) {
             return $xs->do(new CallbackObserver(
-                function ($x) use (&$i) {
+                function ($x) use (&$i): void {
                     $i++;
 
                 },
                 null,
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));
@@ -163,7 +163,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
                     return $sum -= $x;
                 },
 
-                function ($e) use (&$sawError, $ex) {
+                function ($e) use (&$sawError, $ex): void {
                     $sawError = $e === $ex;
                 }
             ));
@@ -204,7 +204,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
                     return $sum -= $x;
                 },
 
-                function ($e) use (&$sawError, $ex) {
+                function ($e) use (&$sawError, $ex): void {
                     $sawError = $e === $ex;
                 }
             ));
@@ -238,14 +238,14 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
             return $xs->do(new CallbackObserver(
-                function ($x) use (&$i, &$sum) {
+                function ($x) use (&$i, &$sum): void {
                     $i++;
                     $sum -= $x;
                 },
-                function () use (&$sawError) {
+                function () use (&$sawError): void {
                     $sawError = true;
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));
@@ -281,14 +281,14 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
             return $xs->do(new CallbackObserver(
-                function ($x) use (&$i, &$sum) {
+                function ($x) use (&$i, &$sum): void {
                     $i++;
                     $sum -= $x;
                 },
-                function () use (&$sawError) {
+                function () use (&$sawError): void {
                     $sawError = true;
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));
@@ -318,13 +318,13 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$completed, &$sawError) {
             return $xs->do(new CallbackObserver(
-                function ($x) use (&$i, &$sum) {
+                function ($x) use (&$i, &$sum): void {
                     $i++;
                 },
-                function () use (&$sawError) {
+                function () use (&$sawError): void {
                     $sawError = true;
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));
@@ -350,7 +350,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->do(new CallbackObserver(function () use ($ex) {
+            return $xs->do(new CallbackObserver(function () use ($ex): void {
                 throw $ex;
             }));
         });
@@ -374,11 +374,11 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 },
                 null,
-                function () {
+                function (): void {
                 }));
         });
 
@@ -401,10 +401,10 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
-                function () {
+                function (): void {
                 },
                 null,
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 }));
         });
@@ -428,10 +428,10 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 },
-                function () {
+                function (): void {
                 }
             ));
         });
@@ -455,9 +455,9 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
             return $xs->do(new CallbackObserver(
-                function () {
+                function (): void {
                 },
-                function () use ($ex2) {
+                function () use ($ex2): void {
                     throw $ex2;
                 }
             ));
@@ -483,12 +483,12 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 },
-                function () {
+                function (): void {
                 },
-                function () {
+                function (): void {
                 }
             ));
         });
@@ -512,12 +512,12 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
             return $xs->do(new CallbackObserver(
-                function () {
+                function (): void {
                 },
-                function () use ($ex2) {
+                function () use ($ex2): void {
                     throw $ex2;
                 },
-                function () {
+                function (): void {
                 }
             ));
         });
@@ -542,11 +542,11 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
 
-                function () {
+                function (): void {
                 },
-                function () {
+                function (): void {
                 },
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 }
             ));
@@ -572,12 +572,12 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
 
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 },
-                function () {
+                function (): void {
                 },
-                function () {
+                function (): void {
                 }
             ));
         });
@@ -601,12 +601,12 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
             return $xs->do(new CallbackObserver(
-                function () {
+                function (): void {
                 },
-                function () use ($ex2) {
+                function () use ($ex2): void {
                     throw $ex2;
                 },
-                function () {
+                function (): void {
                 }
             ));
         });
@@ -630,11 +630,11 @@ class DoOnEachOperatorTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
             return $xs->do(new CallbackObserver(
-                function () { //noop
+                function (): void { //noop
                 },
-                function () { //noop
+                function (): void { //noop
                 },
-                function () use ($ex) {
+                function () use ($ex): void {
                     throw $ex;
                 }
             ));
@@ -697,7 +697,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
                     return $sum -= $x;
                 },
                 null,
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );
@@ -738,7 +738,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
                     return $sum -= $x;
                 },
 
-                function ($e) use (&$sawError, $ex) {
+                function ($e) use (&$sawError, $ex): void {
                     $sawError = $e === $ex;
                 }
             );

--- a/test/Rx/Functional/Operator/DoOnErrorTest.php
+++ b/test/Rx/Functional/Operator/DoOnErrorTest.php
@@ -12,7 +12,7 @@ class DoOnErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnError_should_see_errors()
+    public function doOnError_should_see_errors(): void
     {
         $ex = new RuntimeException('boom!');
         $xs = $this->createHotObservable([
@@ -39,7 +39,7 @@ class DoOnErrorTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnError_should_call_after_resubscription()
+    public function doOnError_should_call_after_resubscription(): void
     {
         $xs = $this->createColdObservable([
             onError(10, new \Exception("Hello")),

--- a/test/Rx/Functional/Operator/DoOnErrorTest.php
+++ b/test/Rx/Functional/Operator/DoOnErrorTest.php
@@ -26,7 +26,7 @@ class DoOnErrorTest extends FunctionalTestCase
         $error = null;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$called, &$error) {
-            return $xs->doOnError(function ($err) use (&$called, &$error) {
+            return $xs->doOnError(function ($err) use (&$called, &$error): void {
                 $called++;
                 $error = $err;
             });
@@ -49,11 +49,11 @@ class DoOnErrorTest extends FunctionalTestCase
         $messages = [];
 
         $xs
-            ->doOnError(function ($x) use (&$messages) {
+            ->doOnError(function ($x) use (&$messages): void {
                 $messages[] = onError($this->scheduler->getClock(), $x);
             })
             ->retry(2)
-            ->subscribe(null, function () {}, null, $this->scheduler);
+            ->subscribe(null, function (): void {}, null, $this->scheduler);
 
         $this->scheduler->start();
 

--- a/test/Rx/Functional/Operator/DoOnNextTest.php
+++ b/test/Rx/Functional/Operator/DoOnNextTest.php
@@ -50,7 +50,7 @@ class DoOnNextTest extends FunctionalTestCase
         $messages = [];
         
         $xs
-            ->doOnNext(function ($x) use (&$messages) {
+            ->doOnNext(function ($x) use (&$messages): void {
                 $messages[] = onNext($this->scheduler->getClock(), $x);
             })
             ->repeat(2)

--- a/test/Rx/Functional/Operator/DoOnNextTest.php
+++ b/test/Rx/Functional/Operator/DoOnNextTest.php
@@ -11,7 +11,7 @@ class DoOnNextTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnNext_should_see_all_values()
+    public function doOnNext_should_see_all_values(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -40,7 +40,7 @@ class DoOnNextTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function doOnNext_should_call_after_resubscription()
+    public function doOnNext_should_call_after_resubscription(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),

--- a/test/Rx/Functional/Operator/FinallyTest.php
+++ b/test/Rx/Functional/Operator/FinallyTest.php
@@ -18,7 +18,7 @@ class FinallyCallTest extends FunctionalTestCase
         $completed = false;
 
         Observable::fromArray([1, 2, 3])
-            ->finally(function() use (&$completed) {
+            ->finally(function() use (&$completed): void {
                 $completed = true;
             })
             ->subscribe(new CallbackObserver());
@@ -40,10 +40,10 @@ class FinallyCallTest extends FunctionalTestCase
                 }
                 return $value;
             })
-            ->finally(function() use (&$thrown) {
+            ->finally(function() use (&$thrown): void {
                 $thrown = true;
             })
-            ->subscribe(new CallbackObserver(null, function() {})); // Ignore the default error handler
+            ->subscribe(new CallbackObserver(null, function(): void {})); // Ignore the default error handler
 
         $this->assertTrue($thrown);
     }
@@ -55,10 +55,10 @@ class FinallyCallTest extends FunctionalTestCase
     {
         $disposed = false;
 
-        Observable::create(function(ObserverInterface $obs) {
+        Observable::create(function(ObserverInterface $obs): void {
                 $obs->onNext(1);
             })
-            ->finally(function() use (&$disposed) {
+            ->finally(function() use (&$disposed): void {
                 $disposed = true;
             })
             ->subscribe(new CallbackObserver())
@@ -74,10 +74,10 @@ class FinallyCallTest extends FunctionalTestCase
     {
         $disposed = false;
 
-        Observable::create(function(ObserverInterface $obs) {
+        Observable::create(function(ObserverInterface $obs): void {
                 $obs->onNext(1);
             })
-            ->finally(function() use (&$disposed) {
+            ->finally(function() use (&$disposed): void {
                 $disposed = true;
             })
             ->share()
@@ -95,10 +95,10 @@ class FinallyCallTest extends FunctionalTestCase
         $invoked = 0;
 
         Observable::fromArray([1, 2, 3])
-            ->finally(function() use (&$invoked) {
+            ->finally(function() use (&$invoked): void {
                 $invoked++;
             })
-            ->finally(function() use (&$invoked) {
+            ->finally(function() use (&$invoked): void {
                 $invoked++;
             })
             ->share()
@@ -119,7 +119,7 @@ class FinallyCallTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         });
@@ -145,7 +145,7 @@ class FinallyCallTest extends FunctionalTestCase
         $xs = $this->createHotObservable([ ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         });
@@ -173,7 +173,7 @@ class FinallyCallTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         });
@@ -204,7 +204,7 @@ class FinallyCallTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         });
@@ -238,7 +238,7 @@ class FinallyCallTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         });
@@ -274,7 +274,7 @@ class FinallyCallTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         });
@@ -307,7 +307,7 @@ class FinallyCallTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithDispose(function() use ($xs, &$executed) {
-            return $xs->finally(function() use (&$executed) {
+            return $xs->finally(function() use (&$executed): void {
                 $executed = true;
             });
         }, 450);

--- a/test/Rx/Functional/Operator/FinallyTest.php
+++ b/test/Rx/Functional/Operator/FinallyTest.php
@@ -13,7 +13,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_call_finally_after_complete()
+    public function should_call_finally_after_complete(): void
     {
         $completed = false;
 
@@ -29,7 +29,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_call_finally_after_error()
+    public function should_call_finally_after_error(): void
     {
         $thrown = false;
 
@@ -51,7 +51,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_call_finally_upon_disposal()
+    public function should_call_finally_upon_disposal(): void
     {
         $disposed = false;
 
@@ -70,7 +70,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_call_finally_when_synchronously_subscribing_to_and_unsubscribing_from_a_shared_observable()
+    public function should_call_finally_when_synchronously_subscribing_to_and_unsubscribing_from_a_shared_observable(): void
     {
         $disposed = false;
 
@@ -90,7 +90,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_call_two_finally_instances_in_succession_on_a_shared_observable()
+    public function should_call_two_finally_instances_in_succession_on_a_shared_observable(): void
     {
         $invoked = 0;
 
@@ -110,7 +110,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_empty()
+    public function should_handle_empty(): void
     {
         $executed = false;
 
@@ -138,7 +138,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_never()
+    public function should_handle_never(): void
     {
         $executed = false;
 
@@ -162,7 +162,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_throw()
+    public function should_handle_throw(): void
     {
         $executed = false;
 
@@ -192,7 +192,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_basic_hot_observable()
+    public function should_handle_basic_hot_observable(): void
     {
         $executed = false;
 
@@ -226,7 +226,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_basic_cold_observable()
+    public function should_handle_basic_cold_observable(): void
     {
         $executed = false;
 
@@ -260,7 +260,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_basic_error()
+    public function should_handle_basic_error(): void
     {
         $executed = false;
 
@@ -296,7 +296,7 @@ class FinallyCallTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_handle_unsubscription()
+    public function should_handle_unsubscription(): void
     {
         $executed = false;
 

--- a/test/Rx/Functional/Operator/FlatMapLatestTest.php
+++ b/test/Rx/Functional/Operator/FlatMapLatestTest.php
@@ -226,7 +226,7 @@ class FlatMapLatestTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ys) {
-            return $xs->flatMapLatest(function () use ($ys) {
+            return $xs->flatMapLatest(function () use ($ys): void {
                 throw new \Exception('error');
             });
         });

--- a/test/Rx/Functional/Operator/FlatMapLatestTest.php
+++ b/test/Rx/Functional/Operator/FlatMapLatestTest.php
@@ -12,7 +12,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_empty()
+    public function flatMapLatest_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -42,7 +42,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_inner_empty()
+    public function flatMapLatest_inner_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -73,7 +73,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_many()
+    public function flatMapLatest_many(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -120,7 +120,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_errors()
+    public function flatMapLatest_errors(): void
     {
         $error = new \Exception();
 
@@ -163,7 +163,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_inner_errors()
+    public function flatMapLatest_inner_errors(): void
     {
         $error = new \Exception();
 
@@ -207,7 +207,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_throws()
+    public function flatMapLatest_throws(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -242,7 +242,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_returns_invalid_string()
+    public function flatMapLatest_returns_invalid_string(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -277,7 +277,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_dispose()
+    public function flatMapLatest_dispose(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -322,7 +322,7 @@ class FlatMapLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapLatest_dispose_before_outer_completes()
+    public function flatMapLatest_dispose_before_outer_completes(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),

--- a/test/Rx/Functional/Operator/FromArrayTest.php
+++ b/test/Rx/Functional/Operator/FromArrayTest.php
@@ -11,7 +11,7 @@ class FromArrayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_schedules_all_elements_from_the_array()
+    public function it_schedules_all_elements_from_the_array(): void
     {
         $xs = Observable::fromArray(['foo', 'bar', 'baz'], $this->scheduler);
 
@@ -30,7 +30,7 @@ class FromArrayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_on_complete_when_the_array_is_empty()
+    public function it_calls_on_complete_when_the_array_is_empty(): void
     {
         $xs = Observable::fromArray([], $this->scheduler);
 
@@ -46,7 +46,7 @@ class FromArrayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function fromArray_one()
+    public function fromArray_one(): void
     {
         $xs = Observable::fromArray([1], $this->scheduler);
 
@@ -63,7 +63,7 @@ class FromArrayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function fromArray_dispose()
+    public function fromArray_dispose(): void
     {
         $xs = Observable::fromArray(['foo', 'bar', 'baz'], $this->scheduler);
 

--- a/test/Rx/Functional/Operator/GroupByTest.php
+++ b/test/Rx/Functional/Operator/GroupByTest.php
@@ -30,13 +30,13 @@ class GroupByTest extends FunctionalTestCase
 
         $this->assertEquals(12, $keyInvoked);
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, "foo"),
             onNext(270, "bar"),
             onNext(350, "baz"),
             onNext(360, "qux"),
             onCompleted(570),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -58,13 +58,13 @@ class GroupByTest extends FunctionalTestCase
 
         $this->assertEquals(12, $keyInvoked);
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, "foo"),
             onNext(270, "bar"),
             onNext(350, "baz"),
             onNext(360, "qux"),
             onError(570, new Exception()),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -86,11 +86,11 @@ class GroupByTest extends FunctionalTestCase
 
         $this->assertEquals(5, $keyInvoked);
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, "foo"),
             onNext(270, "bar"),
             onNext(350, "baz"),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -117,13 +117,13 @@ class GroupByTest extends FunctionalTestCase
 
         $this->assertEquals(10, $keyInvoked);
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, "foo"),
             onNext(270, "bar"),
             onNext(350, "baz"),
             onNext(360, "qux"),
             onError(480, new Exception()),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -152,13 +152,13 @@ class GroupByTest extends FunctionalTestCase
 
         $this->assertEquals(10, $elementInvoked);
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, "foo"),
             onNext(270, "bar"),
             onNext(350, "baz"),
             onNext(360, "qux"),
             onError(480, new Exception()),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -171,15 +171,15 @@ class GroupByTest extends FunctionalTestCase
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
             return $xs->groupByUntil(function($elem) { return $elem; },
                 null,
-                function() { throw new Exception(''); }
+                function(): void { throw new Exception(''); }
             )->select(function(GroupedObservable $observable) {
                 return $observable->getKey();
             });
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onError(220, new Exception()),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
 
@@ -196,17 +196,17 @@ class GroupByTest extends FunctionalTestCase
                 },
                 null,
                 function(GroupedObservable $observable) {
-                    return $observable->select(function() { throw new Exception('meh.'); });
+                    return $observable->select(function(): void { throw new Exception('meh.'); });
             })->select(function(GroupedObservable $observable) {
                 return $observable->getKey();
             });
         });
 
         $this->scheduler->start();
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, 'foo'),
             onError(220, new Exception()),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -225,71 +225,71 @@ class GroupByTest extends FunctionalTestCase
             }
         );
 
-        $innerSubscriptions = array();
+        $innerSubscriptions = [];
         $scheduler = $this->scheduler;
-        $observable->subscribe(function(GroupedObservable $observable) use (&$innerSubscriptions, $scheduler) {
+        $observable->subscribe(function(GroupedObservable $observable) use (&$innerSubscriptions, $scheduler): void {
             $observer = new MockObserver($scheduler);
             $observable->subscribe($observer);
 
-            $innerSubscriptions[] = array(
+            $innerSubscriptions[] = [
                 'key'      => $observable->getKey(),
                 'observer' => $observer,
-            );
+            ];
         });
 
         $this->scheduler->start();
 
         // on complete gets called after duration is "over"
         $this->assertCount(4, $innerSubscriptions[0]['observer']->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(90, "error"),
             onNext(110, "error"),
             onNext(130, "error"),
             onCompleted(130),
-        ), $innerSubscriptions[0]['observer']->getMessages());
+        ], $innerSubscriptions[0]['observer']->getMessages());
 
         $this->assertCount(4, $innerSubscriptions[1]['observer']->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(220, "  foo"),
             onNext(240, " FoO "),
             onNext(310, "foO "),
             onCompleted(310),
-        ), $innerSubscriptions[1]['observer']->getMessages());
+        ], $innerSubscriptions[1]['observer']->getMessages());
 
         $this->assertCount(4, $innerSubscriptions[2]['observer']->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(270, "baR  "),
             onNext(390, "   bar"),
             onNext(420, " BAR  "),
             onCompleted(420),
-        ), $innerSubscriptions[2]['observer']->getMessages());
+        ], $innerSubscriptions[2]['observer']->getMessages());
 
         $this->assertCount(4, $innerSubscriptions[3]['observer']->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(350, " Baz   "),
             onNext(480, "baz  "),
             onNext(510, " bAZ "),
             onCompleted(510),
-        ), $innerSubscriptions[3]['observer']->getMessages());
+        ], $innerSubscriptions[3]['observer']->getMessages());
 
         // Otherwise the original on complete is passed
         $this->assertCount(2, $innerSubscriptions[4]['observer']->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(360, "  qux "),
             onCompleted(570),
-        ), $innerSubscriptions[4]['observer']->getMessages());
+        ], $innerSubscriptions[4]['observer']->getMessages());
 
         $this->assertCount(3, $innerSubscriptions[5]['observer']->getMessages());
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(470, "FOO "),
             onNext(530, "    fOo    "),
             onCompleted(570),
-        ), $innerSubscriptions[5]['observer']->getMessages());
+        ], $innerSubscriptions[5]['observer']->getMessages());
     }
 
     protected function createHotObservableWithData($error = false)
     {
-        return $this->createHotObservable(array(
+        return $this->createHotObservable([
             onNext(90, "error"),
             onNext(110, "error"),
             onNext(130, "error"),
@@ -309,6 +309,6 @@ class GroupByTest extends FunctionalTestCase
             onNext(580, "error"),
             onCompleted(600),
             onError(650, new Exception()),
-        ));
+        ]);
     }
 }

--- a/test/Rx/Functional/Operator/GroupByTest.php
+++ b/test/Rx/Functional/Operator/GroupByTest.php
@@ -14,7 +14,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_complete()
+    public function it_passes_on_complete(): void
     {
         $xs         = $this->createHotObservableWithData();
         $keyInvoked = 0;
@@ -42,7 +42,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_error()
+    public function it_passes_on_error(): void
     {
         $xs         = $this->createHotObservableWithData(true);
         $keyInvoked = 0;
@@ -70,7 +70,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_disposes_the_outer_subscription()
+    public function it_disposes_the_outer_subscription(): void
     {
         $xs         = $this->createHotObservableWithData(true);
         $keyInvoked = 0;
@@ -96,7 +96,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_on_error_if_keyselector_throws()
+    public function it_calls_on_error_if_keyselector_throws(): void
     {
         $xs         = $this->createHotObservableWithData(true);
         $keyInvoked = 0;
@@ -129,7 +129,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_on_error_if_elementselector_throws()
+    public function it_calls_on_error_if_elementselector_throws(): void
     {
         $xs             = $this->createHotObservableWithData(true);
         $elementInvoked = 0;
@@ -164,7 +164,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_on_error_if_durationselector_throws()
+    public function it_calls_on_error_if_durationselector_throws(): void
     {
         $xs             = $this->createHotObservableWithData(true);
 
@@ -186,7 +186,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_error_if_duration_observable_calls_on_error()
+    public function it_passes_on_error_if_duration_observable_calls_on_error(): void
     {
         $xs = $this->createHotObservableWithData();
 
@@ -212,7 +212,7 @@ class GroupByTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_on_completed_on_inner_subscription_if_subscription_expires_otherwise_it_passes()
+    public function it_calls_on_completed_on_inner_subscription_if_subscription_expires_otherwise_it_passes(): void
     {
         $xs = $this->createHotObservableWithData();
 

--- a/test/Rx/Functional/Operator/GroupByUntilTest.php
+++ b/test/Rx/Functional/Operator/GroupByUntilTest.php
@@ -552,7 +552,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outer              = null;
         $outerSubscription  = null;
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use ($xs, &$outer) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use ($xs, &$outer): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -564,17 +564,17 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outer, &$outerSubscription, &$inners, &$results, &$innerSubscriptions) {
+            function () use (&$outer, &$outerSubscription, &$inners, &$results, &$innerSubscriptions): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     &$inners,
                     &$results
-                ) {
+                ): void {
                     $result = $this->scheduler->createObserver();
 
                     $inners[$group->getKey()]  = $group;
                     $results[$group->getKey()] = $result;
 
-                    $this->scheduler->scheduleRelativeWithState(null, 100, function () use ($group, $result) {
+                    $this->scheduler->scheduleRelativeWithState(null, 100, function () use ($group, $result): void {
                         $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
                     });
                 });
@@ -583,7 +583,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -651,7 +651,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $innerSubscriptions = [];
         $results            = [];
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use ($xs, &$outer) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use ($xs, &$outer): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -663,12 +663,12 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$results, &$innerSubscriptions, &$inners) {
+            function () use (&$outerSubscription, &$outer, &$results, &$innerSubscriptions, &$inners): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     &$inners,
                     &$results,
                     &$innerSubscriptions
-                ) {
+                ): void {
                     $result = $this->scheduler->createObserver();
 
                     $inners[$group->getKey()]  = $group;
@@ -681,7 +681,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -758,7 +758,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $innerSubscriptions = [];
         $results            = [];
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -770,13 +770,13 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$inners, &$results, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$outer, &$inners, &$results, &$innerSubscriptions): void {
                 $outerSubscription = $outer->subscribeCallback(
                     function (GroupedObservable $group) use (
                         &$inners,
                         &$results,
                         &$innerSubscriptions
-                    ) {
+                    ): void {
                         $result = $this->scheduler->createObserver();
 
                         $inners[$group->getKey()]  = $group;
@@ -785,12 +785,12 @@ class GroupByUntilTest extends FunctionalTestCase
                         $this->scheduler->scheduleRelativeWithState(
                             null,
                             100,
-                            function () use (&$innerSubscriptions, $group, $result) {
+                            function () use (&$innerSubscriptions, $group, $result): void {
                                 $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
                             }
                         );
                     },
-                    function () {
+                    function (): void {
                     }
                 );
             }
@@ -798,7 +798,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -866,7 +866,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outer              = null;
         $outerSubscription  = null;
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, &$xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, &$xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -878,12 +878,12 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$innerSubscriptions, &$results, &$inners) {
+            function () use (&$outerSubscription, &$outer, &$innerSubscriptions, &$results, &$inners): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     &$inners,
                     &$results,
                     &$innerSubscriptions
-                ) {
+                ): void {
                     $result = $this->scheduler->createObserver();
 
                     $inners[$group->getKey()]  = $group;
@@ -894,7 +894,7 @@ class GroupByUntilTest extends FunctionalTestCase
             }
         );
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$outerSubscription, &$innerSubscriptions) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$outerSubscription, &$innerSubscriptions): void {
             $outerSubscription->dispose();
             foreach ($innerSubscriptions as $innerSubscription) {
                 $innerSubscription->dispose();
@@ -968,7 +968,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::CREATED,
-            function () use (&$outer, $xs, &$keyInvoked, $error) {
+            function () use (&$outer, $xs, &$keyInvoked, $error): void {
                 $outer = $xs->groupByUntil(function ($x) use (&$keyInvoked, $error) {
                     $keyInvoked++;
                     if ($keyInvoked === 6) {
@@ -985,26 +985,26 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$inners, &$results, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$outer, &$inners, &$results, &$innerSubscriptions): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     &$inners,
                     &$results,
                     &$innerSubscriptions
-                ) {
+                ): void {
                     $result = $this->scheduler->createObserver();
 
                     $inners[$group->getKey()]  = $group;
                     $results[$group->getKey()] = $result;
 
                     $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
-                }, function () {
+                }, function (): void {
                 });
             }
         );
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -1076,7 +1076,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::CREATED,
-            function () use (&$outer, $xs, &$eleInvoked, $error) {
+            function () use (&$outer, $xs, &$eleInvoked, $error): void {
                 $outer = $xs->groupByUntil(function ($x) {
                     return trim(strtolower($x));
                 }, function ($x) use (&$eleInvoked, $error) {
@@ -1093,26 +1093,26 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$inners, &$results) {
+            function () use (&$outerSubscription, &$outer, &$inners, &$results): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     &$inners,
                     &$results,
                     &$innerSubscriptions
-                ) {
+                ): void {
                     $result = $this->scheduler->createObserver();
 
                     $inners[$group->getKey()]  = $group;
                     $results[$group->getKey()] = $result;
 
                     $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
-                }, function () {
+                }, function (): void {
                 });
             }
         );
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -1184,7 +1184,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outerSubscription  = null;
         $outerResults       = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -1196,13 +1196,13 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$outerResults, &$inners, &$results) {
+            function () use (&$outerSubscription, &$outer, &$outerResults, &$inners, &$results): void {
                 $outerSubscription = $outer->subscribe(function (GroupedObservable $group) use (
                     &$outerResults,
                     &$inners,
                     &$results,
                     &$innerSubscriptions
-                ) {
+                ): void {
                     $outerResults->onNext($group->getKey());
 
                     $result = $this->scheduler->createObserver();
@@ -1211,9 +1211,9 @@ class GroupByUntilTest extends FunctionalTestCase
                     $results[$group->getKey()] = $result;
 
                     $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
-                }, function ($e) use (&$outerResults) {
+                }, function ($e) use (&$outerResults): void {
                     $outerResults->onError($e);
-                }, function () use (&$outerResults) {
+                }, function () use (&$outerResults): void {
                     $outerResults->onCompleted();
                 });
             }
@@ -1221,7 +1221,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -1229,7 +1229,7 @@ class GroupByUntilTest extends FunctionalTestCase
             }
         );
 
-        $this->scheduler->scheduleAbsolute(320, function () use (&$outerSubscription) {
+        $this->scheduler->scheduleAbsolute(320, function () use (&$outerSubscription): void {
             $outerSubscription->dispose();
         });
 
@@ -1295,7 +1295,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outerSubscription  = null;
         $outerResults       = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -1307,13 +1307,13 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$outerResults, &$inners, &$results, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$outer, &$outerResults, &$inners, &$results, &$innerSubscriptions): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     &$outerResults,
                     &$innerSubscriptions,
                     &$results,
                     &$inners
-                ) {
+                ): void {
                     $outerResults->onNext($group->getKey());
 
                     $result = $this->scheduler->createObserver();
@@ -1322,9 +1322,9 @@ class GroupByUntilTest extends FunctionalTestCase
                     $results[$group->getKey()] = $result;
 
                     $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
-                }, function ($e) use (&$outerResults) {
+                }, function ($e) use (&$outerResults): void {
                     $outerResults->onError($e);
-                }, function () use (&$outerResults) {
+                }, function () use (&$outerResults): void {
                     $outerResults->onCompleted();
                 });
             }
@@ -1332,7 +1332,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -1340,7 +1340,7 @@ class GroupByUntilTest extends FunctionalTestCase
             }
         );
 
-        $this->scheduler->scheduleAbsolute(320, function () use (&$innerSubscriptions) {
+        $this->scheduler->scheduleAbsolute(320, function () use (&$innerSubscriptions): void {
             $innerSubscriptions['foo']->dispose();
         });
 
@@ -1412,7 +1412,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outerSubscription  = null;
         $outerResults       = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -1424,13 +1424,13 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use ($outerResults, &$outerSubscription, &$inners, &$results, &$innerSubscriptions, &$outer) {
+            function () use ($outerResults, &$outerSubscription, &$inners, &$results, &$innerSubscriptions, &$outer): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (
                     $outerResults,
                     &$inners,
                     &$results,
                     &$innerSubscriptions
-                ) {
+                ): void {
                     $outerResults->onNext($group->getKey());
 
                     $result = $this->scheduler->createObserver();
@@ -1439,9 +1439,9 @@ class GroupByUntilTest extends FunctionalTestCase
                     $results[$group->getKey()] = $result;
 
                     $innerSubscriptions[$group->getKey()] = $group->subscribe($result);
-                }, function ($e) use ($outerResults) {
+                }, function ($e) use ($outerResults): void {
                     $outerResults->onError($e);
-                }, function () use ($outerResults) {
+                }, function () use ($outerResults): void {
                     $outerResults->onCompleted();
                 });
             }
@@ -1449,7 +1449,7 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscriptions) {
+            function () use (&$outerSubscription, &$innerSubscriptions): void {
                 $outerSubscription->dispose();
                 foreach ($innerSubscriptions as $innerSubscription) {
                     $innerSubscription->dispose();
@@ -1457,19 +1457,19 @@ class GroupByUntilTest extends FunctionalTestCase
             }
         );
 
-        $this->scheduler->scheduleAbsolute(320, function () use (&$innerSubscriptions) {
+        $this->scheduler->scheduleAbsolute(320, function () use (&$innerSubscriptions): void {
             $innerSubscriptions['foo']->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(280, function () use (&$innerSubscriptions) {
+        $this->scheduler->scheduleAbsolute(280, function () use (&$innerSubscriptions): void {
             $innerSubscriptions['bar']->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(355, function () use (&$innerSubscriptions) {
+        $this->scheduler->scheduleAbsolute(355, function () use (&$innerSubscriptions): void {
             $innerSubscriptions['baz']->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$innerSubscriptions) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$innerSubscriptions): void {
             $innerSubscriptions['qux']->dispose();
         });
 
@@ -1520,7 +1520,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outer             = null;
         $outerSubscription = null;
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -1532,20 +1532,20 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$inner) {
+            function () use (&$outerSubscription, &$outer, &$inner): void {
                 $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (&$inner) {
                     return $inner = $group;
                 });
             }
         );
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$innerSubscription, &$inner, $results) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$innerSubscription, &$inner, $results): void {
             $innerSubscription = $inner->subscribe($results);
         });
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$outerSubscription, &$innerSubscription) {
+            function () use (&$outerSubscription, &$innerSubscription): void {
                 $outerSubscription->dispose();
                 $innerSubscription->dispose();
             }
@@ -1584,7 +1584,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outer             = null;
         $outerSubscription = null;
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -1596,21 +1596,21 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$inner) {
-                $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (&$inner) {
+            function () use (&$outerSubscription, &$outer, &$inner): void {
+                $outerSubscription = $outer->subscribeCallback(function (GroupedObservable $group) use (&$inner): void {
                     $inner = $group;
-                }, function () {
+                }, function (): void {
                 });
             }
         );
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$innerSubscription, &$inner, $results) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$innerSubscription, &$inner, $results): void {
             $innerSubscription = $inner->subscribe($results);
         });
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::DISPOSED,
-            function () use (&$innerSubscription, &$outerSubscription) {
+            function () use (&$innerSubscription, &$outerSubscription): void {
                 $outerSubscription->dispose();
                 $innerSubscription->dispose();
             }
@@ -1647,7 +1647,7 @@ class GroupByUntilTest extends FunctionalTestCase
         $outer             = null;
         $outerSubscription = null;
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$outer, $xs): void {
             $outer = $xs->groupByUntil(function ($x) {
                 return trim(strtolower($x));
             }, function ($x) {
@@ -1659,22 +1659,22 @@ class GroupByUntilTest extends FunctionalTestCase
 
         $this->scheduler->scheduleAbsolute(
             TestScheduler::SUBSCRIBED,
-            function () use (&$outerSubscription, &$outer, &$inner) {
-                $outerSubscription = $outer->subscribeCallback(function ($group) use (&$inner) {
+            function () use (&$outerSubscription, &$outer, &$inner): void {
+                $outerSubscription = $outer->subscribeCallback(function ($group) use (&$inner): void {
                     $inner = $group;
                 });
             }
         );
 
-        $this->scheduler->scheduleAbsolute(290, function () use (&$outerSubscription) {
+        $this->scheduler->scheduleAbsolute(290, function () use (&$outerSubscription): void {
             $outerSubscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$innerSubscription, &$inner, $results) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$innerSubscription, &$inner, $results): void {
             $innerSubscription = $inner->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$outerSubscription) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$outerSubscription): void {
             $outerSubscription->dispose();
         });
 
@@ -1761,7 +1761,7 @@ class GroupByUntilTest extends FunctionalTestCase
                 return $x;
             }, function ($x) {
                 return $x;
-            }, function () use ($error) {
+            }, function () use ($error): void {
                 throw $error;
             });
         });

--- a/test/Rx/Functional/Operator/GroupByUntilTest.php
+++ b/test/Rx/Functional/Operator/GroupByUntilTest.php
@@ -15,7 +15,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilWithKeyComparer()
+    public function groupByUntilWithKeyComparer(): void
     {
         $keyInvoked = 0;
 
@@ -85,7 +85,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilWithKeyComparerDefaultDurationSelector()
+    public function groupByUntilWithKeyComparerDefaultDurationSelector(): void
     {
         $keyInvoked = 0;
 
@@ -159,7 +159,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilOuterComplete()
+    public function groupByUntilOuterComplete(): void
     {
         $keyInvoked = 0;
         $eleInvoked = 0;
@@ -232,7 +232,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilOuterError()
+    public function groupByUntilOuterError(): void
     {
         $error = new \Exception();
 
@@ -307,7 +307,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilOuterDispose()
+    public function groupByUntilOuterDispose(): void
     {
         $keyInvoked = 0;
         $eleInvoked = 0;
@@ -381,7 +381,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilOuterKeyThrow()
+    public function groupByUntilOuterKeyThrow(): void
     {
         $error = new \Exception();
 
@@ -456,7 +456,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilOuterEleThrow()
+    public function groupByUntilOuterEleThrow(): void
     {
         $error = new \Exception();
 
@@ -522,7 +522,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerComplete()
+    public function groupByUntilInnerComplete(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, new \Exception()),
@@ -621,7 +621,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerCompleteAll()
+    public function groupByUntilInnerCompleteAll(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, new \Exception()),
@@ -726,7 +726,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerError()
+    public function groupByUntilInnerError(): void
     {
         $error = new \Exception();
 
@@ -836,7 +836,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerDispose()
+    public function groupByUntilInnerDispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, new \Exception()),
@@ -933,7 +933,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerKeyThrow()
+    public function groupByUntilInnerKeyThrow(): void
     {
         $error      = new \Exception();
         $keyInvoked = 0;
@@ -1041,7 +1041,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerEleThrow()
+    public function groupByUntilInnerEleThrow(): void
     {
         $error      = new \Exception();
         $eleInvoked = 0;
@@ -1153,7 +1153,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilOuterIndependence()
+    public function groupByUntilOuterIndependence(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, new \Exception()),
@@ -1264,7 +1264,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerIndependence()
+    public function groupByUntilInnerIndependence(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, new \Exception()),
@@ -1381,7 +1381,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerMultipleIndependence()
+    public function groupByUntilInnerMultipleIndependence(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, new \Exception()),
@@ -1503,7 +1503,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerEscapeComplete()
+    public function groupByUntilInnerEscapeComplete(): void
     {
         $xs = $this->createHotObservable([
             onNext(220, '  foo'),
@@ -1565,7 +1565,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerEscapeError()
+    public function groupByUntilInnerEscapeError(): void
     {
         $error = new \Exception();
 
@@ -1630,7 +1630,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilInnerEscapeDispose()
+    public function groupByUntilInnerEscapeDispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(220, '  foo'),
@@ -1690,7 +1690,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilDefault()
+    public function groupByUntilDefault(): void
     {
         $keyInvoked = 0;
         $eleInvoked = 0;
@@ -1751,7 +1751,7 @@ class GroupByUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function groupByUntilDurationSelectorThrows()
+    public function groupByUntilDurationSelectorThrows(): void
     {
         $error = new \Exception();
         $xs    = $this->createHotObservable([onNext(210, 'foo')]);

--- a/test/Rx/Functional/Operator/IsEmptyTest.php
+++ b/test/Rx/Functional/Operator/IsEmptyTest.php
@@ -10,7 +10,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_return_true_if_source_is_empty()
+    public function should_return_true_if_source_is_empty(): void
     {
         $xs = $this->createHotObservable([
             onCompleted(300)
@@ -33,7 +33,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_return_false_if_source_emits_element()
+    public function should_return_false_if_source_emits_element(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'a'),
@@ -58,7 +58,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_return_true_if_source_emits_before_subscription()
+    public function should_return_true_if_source_emits_before_subscription(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'a'),
@@ -82,7 +82,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_raise_error_if_source_raise_error()
+    public function should_raise_error_if_source_raise_error(): void
     {
         $e = new \Exception();
 
@@ -106,7 +106,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_not_complete_if_source_never_emits()
+    public function should_not_complete_if_source_never_emits(): void
     {
         $xs = $this->createHotObservable([]);
 
@@ -123,7 +123,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_return_true_if_source_completes_immediately()
+    public function should_return_true_if_source_completes_immediately(): void
     {
         $xs = $this->createHotObservable([
             onCompleted(201),
@@ -145,7 +145,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_allow_unsubscribing_explicitly_and_early()
+    public function should_allow_unsubscribing_explicitly_and_early(): void
     {
         $xs = $this->createHotObservable([
             onNext(600, 'a'),
@@ -166,7 +166,7 @@ class IsEmptyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function should_not_break_unsubscription_chains_when_result_is_unsubscribed_explicitly()
+    public function should_not_break_unsubscription_chains_when_result_is_unsubscribed_explicitly(): void
     {
         $xs = $this->createHotObservable([
             onNext(600, 'a'),

--- a/test/Rx/Functional/Operator/MaterializeTest.php
+++ b/test/Rx/Functional/Operator/MaterializeTest.php
@@ -52,7 +52,7 @@ class MaterializeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function materialize_never()
+    public function materialize_never(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::never()->materialize();
@@ -64,7 +64,7 @@ class MaterializeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function materialize_empty()
+    public function materialize_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -84,7 +84,7 @@ class MaterializeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function materialize_return()
+    public function materialize_return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -106,7 +106,7 @@ class MaterializeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function materialize_throw()
+    public function materialize_throw(): void
     {
         $error = new \Exception();
 
@@ -129,7 +129,7 @@ class MaterializeTest extends FunctionalTestCase
      * @test
      * @requires function Rx\Observable::dematerialize
      */
-    public function materialize_dematerialize_never()
+    public function materialize_dematerialize_never(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::never()->materialize()->dematerialize();
@@ -142,7 +142,7 @@ class MaterializeTest extends FunctionalTestCase
      * @test
      * @requires function Rx\Observable::dematerialize
      */
-    public function materialize_dematerialize_empty()
+    public function materialize_dematerialize_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -162,7 +162,7 @@ class MaterializeTest extends FunctionalTestCase
      * @test
      * @requires function Rx\Observable::dematerialize
      */
-    public function materialize_dematerialize_return()
+    public function materialize_dematerialize_return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -184,7 +184,7 @@ class MaterializeTest extends FunctionalTestCase
      * @test
      * @requires function Rx\Observable::dematerialize
      */
-    public function materialize_dematerialize_throw()
+    public function materialize_dematerialize_throw(): void
     {
         $error = new \Exception();
 
@@ -205,7 +205,7 @@ class MaterializeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function materialize_dispose()
+    public function materialize_dispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -228,7 +228,7 @@ class MaterializeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function materialize_dematerialize_dispose()
+    public function materialize_dematerialize_dispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),

--- a/test/Rx/Functional/Operator/MaterializeTest.php
+++ b/test/Rx/Functional/Operator/MaterializeTest.php
@@ -20,7 +20,7 @@ class MaterializeTest extends FunctionalTestCase
         }
 
         $value = null;
-        $valueGrabber = function ($v) use (&$value) {
+        $valueGrabber = function ($v) use (&$value): void {
             $value = $v;
         };
 

--- a/test/Rx/Functional/Operator/MaxTest.php
+++ b/test/Rx/Functional/Operator/MaxTest.php
@@ -11,7 +11,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_number_empty()
+    public function max_number_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -30,7 +30,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_number_Return()
+    public function max_number_Return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -51,7 +51,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_number_Some()
+    public function max_number_Some(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -74,7 +74,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_number_throw()
+    public function max_number_throw(): void
     {
         $error = new \Exception();
 
@@ -95,7 +95,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_number_Never()
+    public function max_number_Never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)
@@ -111,7 +111,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_comparer_empty()
+    public function max_comparer_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -132,7 +132,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_comparer_return()
+    public function max_comparer_return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'z'),
@@ -155,7 +155,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_comparer_some()
+    public function max_comparer_some(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'z'),
@@ -180,7 +180,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_comparer_throw()
+    public function max_comparer_throw(): void
     {
         $error = new \Exception();
 
@@ -203,7 +203,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_comparer_never()
+    public function max_comparer_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'z')
@@ -221,7 +221,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_comparer_throws()
+    public function max_comparer_throws(): void
     {
         $error = new \Exception();
 
@@ -247,7 +247,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_never_dispose()
+    public function max_never_dispose(): void
     {
         $error = new \Exception();
 
@@ -269,7 +269,7 @@ class MaxTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function max_some_dispose()
+    public function max_some_dispose(): void
     {
         $error = new \Exception();
 

--- a/test/Rx/Functional/Operator/MaxTest.php
+++ b/test/Rx/Functional/Operator/MaxTest.php
@@ -120,7 +120,7 @@ class MaxTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->max(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -142,7 +142,7 @@ class MaxTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->max(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -167,7 +167,7 @@ class MaxTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->max(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -191,7 +191,7 @@ class MaxTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->max(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -211,7 +211,7 @@ class MaxTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->max(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -234,7 +234,7 @@ class MaxTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $error) {
-            return $xs->max(function () use ($error) {
+            return $xs->max(function () use ($error): void {
                 throw $error;
             });
         });

--- a/test/Rx/Functional/Operator/MergeAllTest.php
+++ b/test/Rx/Functional/Operator/MergeAllTest.php
@@ -15,31 +15,31 @@ class MergeAllTest extends FunctionalTestCase
      */
     public function it_passes_on_error_from_sources()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(100, 4),
             onNext(200, 2),
             onNext(300, 3),
             onNext(400, 1),
             onCompleted(500)
-        ));
+        ]);
 
-        $ys = $this->createColdObservable(array(
+        $ys = $this->createColdObservable([
             onNext(50,  $xs),
             onError(200, new Exception()),
             onCompleted(250)
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($ys) {
             return $ys->mergeAll();
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(350, 4),
             onError(400, new Exception()),
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-       $this->assertSubscriptions(array(subscribe(250, 400)), $xs->getSubscriptions());
-       $this->assertSubscriptions(array(subscribe(200, 400)), $ys->getSubscriptions());
+       $this->assertSubscriptions([subscribe(250, 400)], $xs->getSubscriptions());
+       $this->assertSubscriptions([subscribe(200, 400)], $ys->getSubscriptions());
     }
 
     /**
@@ -47,18 +47,18 @@ class MergeAllTest extends FunctionalTestCase
      */
     public function it_passes_on_completed_from_sources()
     {
-        $ys = $this->createHotObservable(array(
+        $ys = $this->createHotObservable([
             onCompleted(250),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($ys) {
             return $ys->mergeAll();
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onCompleted(250),
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-       $this->assertSubscriptions(array(subscribe(200, 250)), $ys->getSubscriptions());
+       $this->assertSubscriptions([subscribe(200, 250)], $ys->getSubscriptions());
     }
 }

--- a/test/Rx/Functional/Operator/MergeAllTest.php
+++ b/test/Rx/Functional/Operator/MergeAllTest.php
@@ -13,7 +13,7 @@ class MergeAllTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_error_from_sources()
+    public function it_passes_on_error_from_sources(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -45,7 +45,7 @@ class MergeAllTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_completed_from_sources()
+    public function it_passes_on_completed_from_sources(): void
     {
         $ys = $this->createHotObservable([
             onCompleted(250),

--- a/test/Rx/Functional/Operator/MergeTest.php
+++ b/test/Rx/Functional/Operator/MergeTest.php
@@ -14,27 +14,27 @@ class MergeTest extends FunctionalTestCase
      */
     public function it_passes_the_last_on_complete()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(100, 4),
             onNext(200, 2),
             onNext(300, 3),
             onNext(400, 1),
             onCompleted(500)
-        ));
+        ]);
 
-        $ys = $this->createColdObservable(array(
+        $ys = $this->createColdObservable([
             onNext(50, 'foo'),
             onNext(100, 'bar'),
             onNext(150, 'baz'),
             onNext(200, 'qux'),
             onCompleted(250)
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, $ys) {
             return $xs->merge($ys);
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(250, 'foo'),
             onNext(300, 4),
             onNext(300, 'bar'),
@@ -44,9 +44,9 @@ class MergeTest extends FunctionalTestCase
             onNext(500, 3),
             onNext(600, 1),
             onCompleted(700)
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-        $this->assertSubscriptions(array(subscribe(200, 700)), $xs->getSubscriptions());
-        $this->assertSubscriptions(array(subscribe(200, 450)), $ys->getSubscriptions());
+        $this->assertSubscriptions([subscribe(200, 700)], $xs->getSubscriptions());
+        $this->assertSubscriptions([subscribe(200, 450)], $ys->getSubscriptions());
     }
 }

--- a/test/Rx/Functional/Operator/MergeTest.php
+++ b/test/Rx/Functional/Operator/MergeTest.php
@@ -12,7 +12,7 @@ class MergeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_the_last_on_complete()
+    public function it_passes_the_last_on_complete(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),

--- a/test/Rx/Functional/Operator/MinTest.php
+++ b/test/Rx/Functional/Operator/MinTest.php
@@ -120,7 +120,7 @@ class MinTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->min(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -142,7 +142,7 @@ class MinTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->min(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -167,7 +167,7 @@ class MinTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->min(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -191,7 +191,7 @@ class MinTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->min(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -211,7 +211,7 @@ class MinTest extends FunctionalTestCase
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
             return $xs->min(function ($a, $b) {
-                return $a > $b ? -1 : ($a < $b ? 1 : 0);
+                return $b <=> $a;
             });
         });
 
@@ -234,7 +234,7 @@ class MinTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $error) {
-            return $xs->min(function () use ($error) {
+            return $xs->min(function () use ($error): void {
                 throw $error;
             });
         });

--- a/test/Rx/Functional/Operator/MinTest.php
+++ b/test/Rx/Functional/Operator/MinTest.php
@@ -11,7 +11,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_number_empty()
+    public function min_number_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -30,7 +30,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_number_Return()
+    public function min_number_Return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -51,7 +51,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_number_Some()
+    public function min_number_Some(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -74,7 +74,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_number_throw()
+    public function min_number_throw(): void
     {
         $error = new \Exception();
 
@@ -95,7 +95,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_number_Never()
+    public function min_number_Never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)
@@ -111,7 +111,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_comparer_empty()
+    public function min_comparer_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -132,7 +132,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_comparer_return()
+    public function min_comparer_return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'z'),
@@ -155,7 +155,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_comparer_some()
+    public function min_comparer_some(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'z'),
@@ -180,7 +180,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_comparer_throw()
+    public function min_comparer_throw(): void
     {
         $error = new \Exception();
 
@@ -203,7 +203,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_comparer_never()
+    public function min_comparer_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 'z')
@@ -221,7 +221,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_comparer_throws()
+    public function min_comparer_throws(): void
     {
         $error = new \Exception();
 
@@ -247,7 +247,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_never_dispose()
+    public function min_never_dispose(): void
     {
         $error = new \Exception();
 
@@ -269,7 +269,7 @@ class MinTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function min_some_dispose()
+    public function min_some_dispose(): void
     {
         $error = new \Exception();
 

--- a/test/Rx/Functional/Operator/MulticastTest.php
+++ b/test/Rx/Functional/Operator/MulticastTest.php
@@ -46,19 +46,19 @@ class MulticastTest extends FunctionalTestCase
         $d2       = null;
         $subject  = new Subject();
 
-        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject) {
+        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject): void {
             $ys = $xs->multicast($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$d1, &$ys, $observer) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$d1, &$ys, $observer): void {
             $d1 = $ys->subscribe($observer);
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$d1) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$d1): void {
             $d1->dispose();
         });
 
@@ -105,20 +105,20 @@ class MulticastTest extends FunctionalTestCase
         $d2       = null;
         $subject  = new Subject();
 
-        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject) {
+        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject): void {
             $ys = $xs->multicast($subject);
         });
 
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$d1, &$ys, $observer) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$d1, &$ys, $observer): void {
             $d1 = $ys->subscribe($observer);
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$d1) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$d1): void {
             $d1->dispose();
         });
 
@@ -165,23 +165,23 @@ class MulticastTest extends FunctionalTestCase
         $d2       = null;
         $subject  = new Subject();
 
-        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject) {
+        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject): void {
             $ys = $xs->multicast($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$d1, &$ys, $observer) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$d1, &$ys, $observer): void {
             $d1 = $ys->subscribe($observer);
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$d2) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$d2): void {
             $d2->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(335, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(335, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
@@ -230,23 +230,23 @@ class MulticastTest extends FunctionalTestCase
         $d2       = null;
         $subject  = new Subject();
 
-        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject) {
+        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject): void {
             $ys = $xs->multicast($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$d1, &$ys, $observer) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$d1, &$ys, $observer): void {
             $d1 = $ys->subscribe($observer);
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$d2) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$d2): void {
             $d2->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(335, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(335, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
@@ -297,15 +297,15 @@ class MulticastTest extends FunctionalTestCase
         $d2       = null;
         $subject  = new Subject();
 
-        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject) {
+        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject): void {
             $ys = $xs->multicast($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$d1, &$ys, $observer) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$d1, &$ys, $observer): void {
             $d1 = $ys->subscribe($observer);
         });
 
@@ -349,15 +349,15 @@ class MulticastTest extends FunctionalTestCase
         $d2       = null;
         $subject  = new Subject();
 
-        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject) {
+        $this->scheduler->scheduleAbsolute(50, function () use (&$ys, $xs, $subject): void {
             $ys = $xs->multicast($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$d2, &$ys): void {
             $d2 = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$d1, &$ys, $observer) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$d1, &$ys, $observer): void {
             $d1 = $ys->subscribe($observer);
         });
 

--- a/test/Rx/Functional/Operator/MulticastTest.php
+++ b/test/Rx/Functional/Operator/MulticastTest.php
@@ -25,7 +25,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_hot_1()
+    public function multicast_hot_1(): void
     {
 
         $xs = $this->createHotObservable([
@@ -84,7 +84,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_hot_2()
+    public function multicast_hot_2(): void
     {
 
         $xs = $this->createHotObservable([
@@ -144,7 +144,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_hot_3()
+    public function multicast_hot_3(): void
     {
 
         $xs = $this->createHotObservable([
@@ -208,7 +208,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_hot_error_1()
+    public function multicast_hot_error_1(): void
     {
         $error = new \Exception();
 
@@ -275,7 +275,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_hot_error_2()
+    public function multicast_hot_error_2(): void
     {
         $error = new \Exception();
 
@@ -328,7 +328,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_hot_completed()
+    public function multicast_hot_completed(): void
     {
 
         $xs = $this->createHotObservable([
@@ -379,7 +379,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_cold_completed()
+    public function multicast_cold_completed(): void
     {
 
         $xs = $this->createHotObservable([
@@ -426,7 +426,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_cold_error()
+    public function multicast_cold_error(): void
     {
         $error = new \Exception();
 
@@ -473,7 +473,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_cold_dispose()
+    public function multicast_cold_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -517,7 +517,7 @@ class MulticastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function multicast_cold_zip()
+    public function multicast_cold_zip(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/NeverTest.php
+++ b/test/Rx/Functional/Operator/NeverTest.php
@@ -13,7 +13,7 @@ class NeverTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function never_basic()
+    public function never_basic(): void
     {
         $xs = Observable::never();
 

--- a/test/Rx/Functional/Operator/PartitionTest.php
+++ b/test/Rx/Functional/Operator/PartitionTest.php
@@ -19,7 +19,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionEmpty()
+    public function partitionEmpty(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -64,7 +64,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionSingle()
+    public function partitionSingle(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -122,7 +122,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionEach()
+    public function partitionEach(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -182,7 +182,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionCompleted()
+    public function partitionCompleted(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -246,7 +246,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionNotCompleted()
+    public function partitionNotCompleted(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -307,7 +307,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionError()
+    public function partitionError(): void
     {
         $error = new \Exception('error1');
 
@@ -371,7 +371,7 @@ class PartitionTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function partitionDisposed()
+    public function partitionDisposed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),

--- a/test/Rx/Functional/Operator/PartitionTest.php
+++ b/test/Rx/Functional/Operator/PartitionTest.php
@@ -33,16 +33,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });
@@ -79,16 +79,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });
@@ -138,16 +138,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });
@@ -200,16 +200,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });
@@ -263,16 +263,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });
@@ -327,16 +327,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });
@@ -389,16 +389,16 @@ class PartitionTest extends FunctionalTestCase
         $r1 = $this->scheduler->createObserver();
         $r2 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::CREATED, function () use (&$observables, $xs): void {
             $observables = $xs->partition([$this, 'isEven']);
         });
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::SUBSCRIBED, function () use (&$observables, &$s1, &$s2, $r1, $r2): void {
             $s1 = $observables[0]->subscribe($r1);
             $s2 = $observables[1]->subscribe($r2);
         });
 
-        $this->scheduler->scheduleAbsolute(280, function () use (&$s1, &$s2) {
+        $this->scheduler->scheduleAbsolute(280, function () use (&$s1, &$s2): void {
             $s1->dispose();
             $s2->dispose();
         });

--- a/test/Rx/Functional/Operator/PluckTest.php
+++ b/test/Rx/Functional/Operator/PluckTest.php
@@ -11,7 +11,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_completed()
+    public function pluck_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, (object)['prop' => 1]),
@@ -45,7 +45,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_error()
+    public function pluck_error(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, ['prop' => 1]),
@@ -76,7 +76,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_completed_array()
+    public function pluck_completed_array(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, ['prop' => 1]),
@@ -107,7 +107,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_array_index_missing()
+    public function pluck_array_index_missing(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, ['prop' => 1]),
@@ -136,7 +136,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_object_property_missing()
+    public function pluck_object_property_missing(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, (object)['prop' => 1]),
@@ -165,7 +165,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_array_numeric_index()
+    public function pluck_array_numeric_index(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, [-1,-1,-1,-1]),
@@ -196,7 +196,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_nested()
+    public function pluck_nested(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, [-1,-1,-1,-1]),
@@ -227,7 +227,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_nested_numeric_key_with_object_properties()
+    public function pluck_nested_numeric_key_with_object_properties(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, [-1,-1,-1,-1]),
@@ -258,7 +258,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_object_property_null()
+    public function pluck_object_property_null(): void
     {
         $xs = $this->createHotObservable([
                                              onNext(180, (object)['prop' => 1]),
@@ -289,7 +289,7 @@ class PluckTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function pluck_array_assoc_null()
+    public function pluck_array_assoc_null(): void
     {
         $xs = $this->createHotObservable([
                                              onNext(180, ['prop' => 1]),

--- a/test/Rx/Functional/Operator/PublishLastTest.php
+++ b/test/Rx/Functional/Operator/PublishLastTest.php
@@ -46,39 +46,39 @@ class PublishLastTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishLast();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -130,31 +130,31 @@ class PublishLastTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishLast();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -206,31 +206,31 @@ class PublishLastTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishLast();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -284,39 +284,39 @@ class PublishLastTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishLast();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(350, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(350, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 

--- a/test/Rx/Functional/Operator/PublishLastTest.php
+++ b/test/Rx/Functional/Operator/PublishLastTest.php
@@ -19,7 +19,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_basic()
+    public function publishLast_basic(): void
     {
 
         $xs = $this->createHotObservable([
@@ -101,7 +101,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_error()
+    public function publishLast_error(): void
     {
 
         $error = new \Exception();
@@ -179,7 +179,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_complete()
+    public function publishLast_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -257,7 +257,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_dispose()
+    public function publishLast_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -338,7 +338,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_multiple_connections()
+    public function publishLast_multiple_connections(): void
     {
         $xs = new NeverObservable();
         $ys = $xs->publishLast();
@@ -360,7 +360,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_zip_complete()
+    public function publishLast_zip_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -403,7 +403,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_zip_errorr()
+    public function publishLast_zip_errorr(): void
     {
 
         $error = new \Exception();
@@ -447,7 +447,7 @@ class PublishLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_zip_dispose()
+    public function publishLast_zip_dispose(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/PublishTest.php
+++ b/test/Rx/Functional/Operator/PublishTest.php
@@ -23,7 +23,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_cold_zip()
+    public function publish_cold_zip(): void
     {
 
         $xs = $this->createHotObservable([
@@ -66,7 +66,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function refCount_connects_on_first()
+    public function refCount_connects_on_first(): void
     {
 
         $xs = $this->createHotObservable([
@@ -100,7 +100,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function refCount_not_connected()
+    public function refCount_not_connected(): void
     {
 
         $disconnected = false;
@@ -156,7 +156,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function refCount_publish_basic()
+    public function refCount_publish_basic(): void
     {
 
         $xs = $this->createHotObservable([
@@ -246,7 +246,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_error()
+    public function publish_error(): void
     {
 
         $error = new \Exception();
@@ -330,7 +330,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_complete()
+    public function publish_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -413,7 +413,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_dispose()
+    public function publish_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -498,7 +498,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_lambda_zip_complete()
+    public function publish_lambda_zip_complete(): void
     {
         $xs = $this->createHotObservable([
           onNext(110, 7),
@@ -550,7 +550,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_lambda_zip_error()
+    public function publish_lambda_zip_error(): void
     {
 
         $error = new \Exception();
@@ -605,7 +605,7 @@ class PublishTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publish_lambda_zip_dispose()
+    public function publish_lambda_zip_dispose(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/PublishTest.php
+++ b/test/Rx/Functional/Operator/PublishTest.php
@@ -111,7 +111,7 @@ class PublishTest extends FunctionalTestCase
             $count++;
 
             return new AnonymousObservable(function () use (&$disconnected) {
-                return new CallbackDisposable(function () use (&$disconnected) {
+                return new CallbackDisposable(function () use (&$disconnected): void {
                     $disconnected = true;
                 });
             });
@@ -183,39 +183,39 @@ class PublishTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publish();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -275,31 +275,31 @@ class PublishTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publish();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -357,31 +357,31 @@ class PublishTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publish();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -440,39 +440,39 @@ class PublishTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publish();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(350, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(350, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 

--- a/test/Rx/Functional/Operator/PublishValueTest.php
+++ b/test/Rx/Functional/Operator/PublishValueTest.php
@@ -19,7 +19,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishLast_basic()
+    public function publishLast_basic(): void
     {
 
         $xs = $this->createHotObservable([
@@ -109,7 +109,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_error()
+    public function publishValue_error(): void
     {
 
         $error = new \Exception();
@@ -194,7 +194,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_complete()
+    public function publishValue_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -278,7 +278,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_dispose()
+    public function publishValue_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -362,7 +362,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_multiple_connections()
+    public function publishValue_multiple_connections(): void
     {
         $xs = new NeverObservable();
         $ys = $xs->publishValue(1979);
@@ -384,7 +384,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_zip_complete()
+    public function publishValue_zip_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -438,7 +438,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_zip_error()
+    public function publishValue_zip_error(): void
     {
 
         $error = new \Exception();
@@ -494,7 +494,7 @@ class PublishValueTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function publishValue_zip_dispose()
+    public function publishValue_zip_dispose(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/PublishValueTest.php
+++ b/test/Rx/Functional/Operator/PublishValueTest.php
@@ -46,39 +46,39 @@ class PublishValueTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishValue(1979);
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -138,31 +138,31 @@ class PublishValueTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishValue(1979);
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -221,31 +221,31 @@ class PublishValueTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishValue(1979);
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -305,39 +305,39 @@ class PublishValueTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->publishValue(1979);
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(350, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(350, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 

--- a/test/Rx/Functional/Operator/RaceTest.php
+++ b/test/Rx/Functional/Operator/RaceTest.php
@@ -105,7 +105,7 @@ class RaceTest extends FunctionalTestCase
             onNext(150, 1),
             onNext(220, 2),
             onError(230, $error)
-        ])->doOnNext(function () use (&$sourceNotDisposed) {
+        ])->doOnNext(function () use (&$sourceNotDisposed): void {
             $sourceNotDisposed = true;
         });
 
@@ -148,7 +148,7 @@ class RaceTest extends FunctionalTestCase
             onNext(150, 1),
             onNext(220, 3),
             onCompleted(250)
-        ])->doOnNext(function () use (&$sourceNotDisposed) {
+        ])->doOnNext(function () use (&$sourceNotDisposed): void {
             $sourceNotDisposed = true;
         });
 

--- a/test/Rx/Functional/Operator/RaceTest.php
+++ b/test/Rx/Functional/Operator/RaceTest.php
@@ -12,7 +12,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_never_2()
+    public function race_never_2(): void
     {
         $n1 = Observable::never();
         $n2 = Observable::never();
@@ -30,7 +30,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_never_3()
+    public function race_never_3(): void
     {
         $n1 = Observable::never();
         $n2 = Observable::never();
@@ -49,7 +49,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_never_empty()
+    public function race_never_empty(): void
     {
         $n1 = Observable::never();
         $e  = $this->createHotObservable([
@@ -72,7 +72,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_empty_never()
+    public function race_empty_never(): void
     {
         $n1 = Observable::never();
         $e  = $this->createHotObservable([
@@ -95,7 +95,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_regular_should_dispose_loser()
+    public function race_regular_should_dispose_loser(): void
     {
         $sourceNotDisposed = false;
 
@@ -133,7 +133,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_throws_before_election()
+    public function race_throws_before_election(): void
     {
         $sourceNotDisposed = false;
 
@@ -169,7 +169,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_none()
+    public function race_none(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::race([], $this->scheduler);
@@ -181,7 +181,7 @@ class RaceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function race_one()
+    public function race_one(): void
     {
         $e = $this->createHotObservable([
             onNext(150, 1),

--- a/test/Rx/Functional/Operator/RangeTest.php
+++ b/test/Rx/Functional/Operator/RangeTest.php
@@ -14,7 +14,7 @@ class RangeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function range_zero()
+    public function range_zero(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -32,7 +32,7 @@ class RangeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function range_one()
+    public function range_one(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -51,7 +51,7 @@ class RangeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function range_five()
+    public function range_five(): void
     {
 
         $results = $this->scheduler->startWithCreate(function () {
@@ -74,7 +74,7 @@ class RangeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function range_dispose()
+    public function range_dispose(): void
     {
 
         $results = $this->scheduler->startWithDispose(function () {

--- a/test/Rx/Functional/Operator/ReduceTest.php
+++ b/test/Rx/Functional/Operator/ReduceTest.php
@@ -235,7 +235,7 @@ class ReduceTest extends FunctionalTestCase
           ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->reduce(function () {
+            return $xs->reduce(function (): void {
                 throw new \Exception();
             });
         });
@@ -257,7 +257,7 @@ class ReduceTest extends FunctionalTestCase
           ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->reduce(function () {
+            return $xs->reduce(function (): void {
                 throw new \Exception();
             }, 42);
         });

--- a/test/Rx/Functional/Operator/ReduceTest.php
+++ b/test/Rx/Functional/Operator/ReduceTest.php
@@ -16,7 +16,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_with_seed_empty()
+    public function reduce_with_seed_empty(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -36,7 +36,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_with_seed_return()
+    public function reduce_with_seed_return(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -56,7 +56,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_with_seed_throw()
+    public function reduce_with_seed_throw(): void
     {
         $ex = new \Exception('ex');
         $xs = $this->createHotObservable([
@@ -76,7 +76,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_with_seed_never()
+    public function reduce_with_seed_never(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1)
@@ -94,7 +94,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_with_seed_range()
+    public function reduce_with_seed_range(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -118,7 +118,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_without_seed_empty()
+    public function reduce_without_seed_empty(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -142,7 +142,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_without_seed_return()
+    public function reduce_without_seed_return(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -162,7 +162,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_without_seed_throw()
+    public function reduce_without_seed_throw(): void
     {
         $ex = new \Exception('ex');
         $xs = $this->createHotObservable([
@@ -182,7 +182,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_without_seed_never()
+    public function reduce_without_seed_never(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1)
@@ -200,7 +200,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_without_seed_range()
+    public function reduce_without_seed_range(): void
     {
         $xs = $this->createHotObservable([
           onNext(150, 1),
@@ -224,7 +224,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_accumulator_throws()
+    public function reduce_accumulator_throws(): void
     {
         $xs = $this->createHotObservable(
           [
@@ -246,7 +246,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_accumulator_throws_with_seed()
+    public function reduce_accumulator_throws_with_seed(): void
     {
         $xs = $this->createHotObservable(
           [
@@ -268,7 +268,7 @@ class ReduceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function reduce_with_falsy_seed_range()
+    public function reduce_with_falsy_seed_range(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),

--- a/test/Rx/Functional/Operator/RepeatTest.php
+++ b/test/Rx/Functional/Operator/RepeatTest.php
@@ -134,7 +134,7 @@ class RepeatTest extends FunctionalTestCase
         $xs = (new ReturnObservable(1, $scheduler1))->repeat();
 
         $xs->subscribe(new CallbackObserver(
-            function ($x) {
+            function ($x): void {
                 throw new \Exception();
             }
         ));
@@ -154,7 +154,7 @@ class RepeatTest extends FunctionalTestCase
 
         $xs->subscribe(new CallbackObserver(
             null,
-            function ($x) {
+            function ($x): void {
                 throw new \Exception();
             }
         ));
@@ -174,12 +174,12 @@ class RepeatTest extends FunctionalTestCase
         $disp = $xs->subscribe(new CallbackObserver(
             null,
             null,
-            function () {
+            function (): void {
                 throw new \Exception;
             }
         ));
 
-        $scheduler3->scheduleAbsolute(210, function () use ($disp) {
+        $scheduler3->scheduleAbsolute(210, function () use ($disp): void {
             $disp->dispose();
         });
 
@@ -192,7 +192,7 @@ class RepeatTest extends FunctionalTestCase
     public function repeat_Observable_throws_4()
     {
         $this->expectException(\Exception::class);
-        $xs = (new AnonymousObservable(function () {
+        $xs = (new AnonymousObservable(function (): void {
             throw new \Exception;
         }))->repeat();
 
@@ -356,7 +356,7 @@ class RepeatTest extends FunctionalTestCase
         $xs         = (new ReturnObservable(1, $scheduler1))->repeat(3);
 
         $xs->subscribe(new CallbackObserver(
-            function ($x) {
+            function ($x): void {
                 throw new \Exception('from onNext');
             }
         ));
@@ -377,7 +377,7 @@ class RepeatTest extends FunctionalTestCase
 
         $xs->subscribe(new CallbackObserver(
             null,
-            function ($x) {
+            function ($x): void {
                 throw new \Exception('from onError');
             }
         ));
@@ -398,7 +398,7 @@ class RepeatTest extends FunctionalTestCase
         $xs->subscribe(new CallbackObserver(
             null,
             null,
-            function () {
+            function (): void {
                 throw new \Exception('from onCompleted');
             }
         ));
@@ -413,7 +413,7 @@ class RepeatTest extends FunctionalTestCase
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('from Anon');
-        $xss = (new AnonymousObservable(function () {
+        $xss = (new AnonymousObservable(function (): void {
             throw new \Exception('from Anon');
         }))->repeat(3);
 

--- a/test/Rx/Functional/Operator/RepeatTest.php
+++ b/test/Rx/Functional/Operator/RepeatTest.php
@@ -16,7 +16,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_basic()
+    public function repeat_Observable_basic(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -58,7 +58,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_infinite()
+    public function repeat_Observable_infinite(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -90,7 +90,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_error()
+    public function repeat_Observable_error(): void
     {
         $error = new \Exception();
 
@@ -126,7 +126,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_throws_1()
+    public function repeat_Observable_throws_1(): void
     {
         $this->expectException(\Exception::class);
         $scheduler1 = new TestScheduler();
@@ -145,7 +145,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_throws_2()
+    public function repeat_Observable_throws_2(): void
     {
         $this->expectException(\Exception::class);
         $scheduler2 = new TestScheduler();
@@ -166,7 +166,7 @@ class RepeatTest extends FunctionalTestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function repeat_Observable_throws_3()
+    public function repeat_Observable_throws_3(): void
     {
         $scheduler3 = new TestScheduler();
         $xs         = (new ReturnObservable(1, $scheduler3))->repeat();
@@ -189,7 +189,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_throws_4()
+    public function repeat_Observable_throws_4(): void
     {
         $this->expectException(\Exception::class);
         $xs = (new AnonymousObservable(function (): void {
@@ -202,7 +202,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_basic()
+    public function repeat_Observable_repeat_count_basic(): void
     {
         $xs = $this->createColdObservable([
             onNext(5, 1),
@@ -244,7 +244,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_dispose()
+    public function repeat_Observable_repeat_count_dispose(): void
     {
         $xs = $this->createColdObservable([
             onNext(5, 1),
@@ -280,7 +280,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_infinite()
+    public function repeat_Observable_repeat_count_infinite(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -312,7 +312,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_error()
+    public function repeat_Observable_repeat_count_error(): void
     {
         $error = new \Exception();
 
@@ -348,7 +348,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_throws_1()
+    public function repeat_Observable_repeat_count_throws_1(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('from onNext');
@@ -367,7 +367,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_throws_2()
+    public function repeat_Observable_repeat_count_throws_2(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('from onError');
@@ -388,7 +388,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_throws_3()
+    public function repeat_Observable_repeat_count_throws_3(): void
     {
         $this->expectException(\Exception::class);
         $scheduler3 = new TestScheduler();
@@ -409,7 +409,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_Observable_repeat_count_throws_4()
+    public function repeat_Observable_repeat_count_throws_4(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('from Anon');
@@ -423,7 +423,7 @@ class RepeatTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeat_returns_empty_when_count_is_zero()
+    public function repeat_returns_empty_when_count_is_zero(): void
     {
         $xs = $this->createColdObservable([
             onNext(5, 1),

--- a/test/Rx/Functional/Operator/RepeatWhenTest.php
+++ b/test/Rx/Functional/Operator/RepeatWhenTest.php
@@ -339,7 +339,7 @@ class RepeatWhenTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->repeatWhen(function (Observable $attempts) {
+            return $xs->repeatWhen(function (Observable $attempts): void {
                 throw new Exception('error');
             });
         });

--- a/test/Rx/Functional/Operator/RepeatWhenTest.php
+++ b/test/Rx/Functional/Operator/RepeatWhenTest.php
@@ -13,7 +13,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_never()
+    public function repeatWhen_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -38,7 +38,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_never()
+    public function repeatWhen_Observable_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -70,7 +70,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_empty()
+    public function repeatWhen_Observable_empty(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -100,7 +100,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_next_error()
+    public function repeatWhen_next_error(): void
     {
 
         $error = new Exception("test");
@@ -137,7 +137,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_complete()
+    public function repeatWhen_Observable_complete(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -165,7 +165,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_next_complete()
+    public function repeatWhen_Observable_next_complete(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -202,7 +202,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_infinite()
+    public function repeatWhen_Observable_infinite(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -229,7 +229,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_dispose()
+    public function repeatWhen_Observable_dispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -259,7 +259,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_dispose_second()
+    public function repeatWhen_Observable_dispose_second(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -294,7 +294,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_Observable_dispose_between()
+    public function repeatWhen_Observable_dispose_between(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -327,7 +327,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_notifier_throws()
+    public function repeatWhen_notifier_throws(): void
     {
         $xs = $this->createColdObservable([
             onNext(150, 1),
@@ -354,7 +354,7 @@ class RepeatWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function repeatWhen_notifier_returns_invalid_string()
+    public function repeatWhen_notifier_returns_invalid_string(): void
     {
         $xs = $this->createColdObservable([
             onNext(150, 1),

--- a/test/Rx/Functional/Operator/ReplayTest.php
+++ b/test/Rx/Functional/Operator/ReplayTest.php
@@ -13,7 +13,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_basic()
+    public function replay_count_basic(): void
     {
 
         $xs = $this->createHotObservable([
@@ -102,7 +102,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_error()
+    public function replay_count_error(): void
     {
 
         $error = new \Exception();
@@ -185,7 +185,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_complete()
+    public function replay_count_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -267,7 +267,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_dispose()
+    public function replay_count_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -353,7 +353,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_multiple_connections()
+    public function replay_count_multiple_connections(): void
     {
         $xs = new NeverObservable();
         $ys = $xs->replay(null, 3);
@@ -375,7 +375,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_zip_complete()
+    public function replay_count_zip_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -443,7 +443,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_zip_error()
+    public function replay_count_zip_error(): void
     {
 
         $error = new \Exception();
@@ -508,7 +508,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_count_zip_dispose()
+    public function replay_count_zip_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -563,7 +563,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_basic()
+    public function replay_time_basic(): void
     {
 
         $xs = $this->createHotObservable([
@@ -652,7 +652,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_error()
+    public function replay_time_error(): void
     {
 
         $error = new \Exception();
@@ -733,7 +733,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_complete()
+    public function replay_time_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -812,7 +812,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_dispose()
+    public function replay_time_dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -898,7 +898,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_multiple_connections()
+    public function replay_time_multiple_connections(): void
     {
         $xs = new NeverObservable();
         $ys = $xs->replay(null, null, 100);
@@ -920,7 +920,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_zip_complete()
+    public function replay_time_zip_complete(): void
     {
 
         $xs = $this->createHotObservable([
@@ -985,7 +985,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_zip_errorr()
+    public function replay_time_zip_errorr(): void
     {
 
         $error = new \Exception();
@@ -1049,7 +1049,7 @@ class ReplayTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function replay_time_zip_dispose()
+    public function replay_time_zip_dispose(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/ReplayTest.php
+++ b/test/Rx/Functional/Operator/ReplayTest.php
@@ -40,39 +40,39 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, 3, null, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -131,31 +131,31 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, 3, null, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -212,31 +212,31 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, 3, null, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -294,39 +294,39 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, 3, null, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(475, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(475, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -590,39 +590,39 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, null, 150, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -681,31 +681,31 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, null, 75, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -760,31 +760,31 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, null, 85, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 
@@ -839,39 +839,39 @@ class ReplayTest extends FunctionalTestCase
 
         $results = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->replay(null, null, 100, $this->scheduler);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$ys, $xs, $results, &$subscription): void {
             $subscription = $ys->subscribe($results);
         });
 
-        $this->scheduler->scheduleAbsolute(475, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(475, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$connection): void {
             $connection->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$connection, &$ys): void {
             $connection = $ys->connect();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$connection) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$connection): void {
             $connection->dispose();
         });
 

--- a/test/Rx/Functional/Operator/RetryTest.php
+++ b/test/Rx/Functional/Operator/RetryTest.php
@@ -126,7 +126,7 @@ class RetryTest extends FunctionalTestCase
 
         $xs->subscribe(
             new CallbackObserver(
-                function () {
+                function (): void {
                     throw new \Exception();
                 }
             ));
@@ -151,7 +151,7 @@ class RetryTest extends FunctionalTestCase
         $d = $ys->subscribe(
             new CallbackObserver(
                 null,
-                function ($err) {
+                function ($err): void {
                     throw $err;
                 }
             ));
@@ -170,7 +170,7 @@ class RetryTest extends FunctionalTestCase
             new CallbackObserver(
                 null,
                 null,
-                function () {
+                function (): void {
                     throw new \Exception();
                 }
             ));
@@ -335,7 +335,7 @@ class RetryTest extends FunctionalTestCase
 
         $xs = (new ReturnObservable(1, $scheduler1))->retry(3);
 
-        $xs->subscribe(function () {
+        $xs->subscribe(function (): void {
             throw new \Exception();
         });
 
@@ -351,7 +351,7 @@ class RetryTest extends FunctionalTestCase
 
         $ys = (new ErrorObservable(new \Exception(), $scheduler2))->retry(100);
 
-        $d = $ys->subscribe(null, function ($err) {
+        $d = $ys->subscribe(null, function ($err): void {
             throw $err;
         });
 
@@ -365,7 +365,7 @@ class RetryTest extends FunctionalTestCase
 
         $zs = (new ReturnObservable(1, $scheduler3))->retry(100);
 
-        $zs->subscribe(null, null, function () {
+        $zs->subscribe(null, null, function (): void {
             throw new \Exception();
         });
 
@@ -377,7 +377,7 @@ class RetryTest extends FunctionalTestCase
         }
         $this->assertNotNull($exception);
 
-        $xss = (new AnonymousObservable(function () {
+        $xss = (new AnonymousObservable(function (): void {
             throw new \Exception();
         }))->retry(100);
 
@@ -405,11 +405,11 @@ class RetryTest extends FunctionalTestCase
             ->retry(3)
             ->take(1)
             ->subscribe(new CallbackObserver(
-                function ($x) use (&$emitted) {
+                function ($x) use (&$emitted): void {
                     $emitted = $x;
                 },
                 null,
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));

--- a/test/Rx/Functional/Operator/RetryTest.php
+++ b/test/Rx/Functional/Operator/RetryTest.php
@@ -14,7 +14,7 @@ use Rx\Testing\TestScheduler;
 
 class RetryTest extends FunctionalTestCase
 {
-    public function testRetryObservableBasic()
+    public function testRetryObservableBasic(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -45,7 +45,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryObservableInfinite()
+    public function testRetryObservableInfinite(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -74,7 +74,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryObservableError()
+    public function testRetryObservableError(): void
     {
         $error = new \Exception();
 
@@ -118,7 +118,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryObservableThrows()
+    public function testRetryObservableThrows(): void
     {
         $scheduler1 = new TestScheduler();
 
@@ -185,7 +185,7 @@ class RetryTest extends FunctionalTestCase
         $this->assertNotNull($exception);
     }
 
-    public function testRetryObservableRetryCountBasic()
+    public function testRetryObservableRetryCountBasic(): void
     {
         $error = new \Exception();
 
@@ -228,7 +228,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryObservableRetryCountDispose()
+    public function testRetryObservableRetryCountDispose(): void
     {
         $error = new \Exception();
 
@@ -265,7 +265,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryRetryCountDispose()
+    public function testRetryRetryCountDispose(): void
     {
         $xs = $this->createColdObservable(
             [
@@ -296,7 +296,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryObservableCompletes()
+    public function testRetryObservableCompletes(): void
     {
         $xs = $this->createColdObservable(
             [
@@ -329,7 +329,7 @@ class RetryTest extends FunctionalTestCase
         );
     }
 
-    public function testRetryObservableRetryCountThrows()
+    public function testRetryObservableRetryCountThrows(): void
     {
         $scheduler1 = new TestScheduler();
 
@@ -390,7 +390,7 @@ class RetryTest extends FunctionalTestCase
         $this->assertNotNull($exception);
     }
 
-    public function testWithImmediateSchedulerWithRecursion()
+    public function testWithImmediateSchedulerWithRecursion(): void
     {
         $completed = false;
         $emitted   = null;

--- a/test/Rx/Functional/Operator/RetryWhenTest.php
+++ b/test/Rx/Functional/Operator/RetryWhenTest.php
@@ -12,7 +12,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_never()
+    public function retryWhen_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -37,7 +37,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_Observable_never()
+    public function retryWhen_Observable_never(): void
     {
         $error = new \Exception();
 
@@ -71,7 +71,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_never_completed()
+    public function retryWhen_never_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -104,7 +104,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_Observable_Empty()
+    public function retryWhen_Observable_Empty(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -134,7 +134,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_Observable_Next_Error()
+    public function retryWhen_Observable_Next_Error(): void
     {
         $error = new \Exception();
 
@@ -173,7 +173,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_Observable_complete()
+    public function retryWhen_Observable_complete(): void
     {
         $error = new \Exception();
 
@@ -204,7 +204,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_Observable_next_complete()
+    public function retryWhen_Observable_next_complete(): void
     {
         $error = new \Exception();
 
@@ -242,7 +242,7 @@ class RetryWhenTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function retryWhen_Observable_infinite()
+    public function retryWhen_Observable_infinite(): void
     {
         $error = new \Exception();
 
@@ -269,7 +269,7 @@ class RetryWhenTest extends FunctionalTestCase
         ], $xs->getSubscriptions());
     }
 
-    public function testRetryWhenDispose()
+    public function testRetryWhenDispose(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -306,7 +306,7 @@ class RetryWhenTest extends FunctionalTestCase
         ], $xs->getSubscriptions());
     }
 
-    public function testRetryWhenDisposeBetweenSourceSubscriptions()
+    public function testRetryWhenDisposeBetweenSourceSubscriptions(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -337,7 +337,7 @@ class RetryWhenTest extends FunctionalTestCase
         ], $xs->getSubscriptions());
     }
 
-    public function testRetryWhenInnerEmitsBeforeOuterError()
+    public function testRetryWhenInnerEmitsBeforeOuterError(): void
     {
         $xs = $this->createColdObservable([
             onNext(10, 1),
@@ -366,7 +366,7 @@ class RetryWhenTest extends FunctionalTestCase
         ], $xs->getSubscriptions());
     }
 
-    public function testRetryWhenSelectorThrows()
+    public function testRetryWhenSelectorThrows(): void
     {
         $error = new \Exception();
 
@@ -391,7 +391,7 @@ class RetryWhenTest extends FunctionalTestCase
         $this->assertSubscriptions([], $xs->getSubscriptions());
     }
 
-    public function testRetryWhenSelectorReturnsInvalidString()
+    public function testRetryWhenSelectorReturnsInvalidString(): void
     {
         $error = new \Exception();
 

--- a/test/Rx/Functional/Operator/RetryWhenTest.php
+++ b/test/Rx/Functional/Operator/RetryWhenTest.php
@@ -379,7 +379,7 @@ class RetryWhenTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithDispose(function () use ($xs, $error) {
-            return $xs->retryWhen(function () use ($error) {
+            return $xs->retryWhen(function () use ($error): void {
                 throw $error;
             });
         }, 285);

--- a/test/Rx/Functional/Operator/ScanTest.php
+++ b/test/Rx/Functional/Operator/ScanTest.php
@@ -269,7 +269,7 @@ class ScanTest extends FunctionalTestCase
           ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->scan(function () {
+            return $xs->scan(function (): void {
                 throw new \Exception();
             });
         });
@@ -291,7 +291,7 @@ class ScanTest extends FunctionalTestCase
           ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->scan(function () {
+            return $xs->scan(function (): void {
                 throw new \Exception();
             }, 42);
         });

--- a/test/Rx/Functional/Operator/ScanTest.php
+++ b/test/Rx/Functional/Operator/ScanTest.php
@@ -9,7 +9,7 @@ use Rx\Observable;
 
 class ScanTest extends FunctionalTestCase
 {
-    public function testScanSeedNever()
+    public function testScanSeedNever(): void
     {
         $seed = 42;
 
@@ -22,7 +22,7 @@ class ScanTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testScanSeedEmpty()
+    public function testScanSeedEmpty(): void
     {
         $seed = 42;
 
@@ -48,7 +48,7 @@ class ScanTest extends FunctionalTestCase
 
     }
 
-    public function testScanSeedReturn()
+    public function testScanSeedReturn(): void
     {
         $seed = 42;
 
@@ -75,7 +75,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanSeedThrow()
+    public function testScanSeedThrow(): void
     {
         $ex = new \Exception('ex');
 
@@ -102,7 +102,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanSeedSomeData()
+    public function testScanSeedSomeData(): void
 
     {
         $seed = 1;
@@ -136,7 +136,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanNoSeedNever()
+    public function testScanNoSeedNever(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::never()->scan(function ($acc, $x) {
@@ -150,7 +150,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanNoSeedEmpty()
+    public function testScanNoSeedEmpty(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -173,7 +173,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanNoSeedReturn()
+    public function testScanNoSeedReturn(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -198,7 +198,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanNoSeedThrow()
+    public function testScanNoSeedThrow(): void
     {
         $ex = new \Exception('ex');
 
@@ -223,7 +223,7 @@ class ScanTest extends FunctionalTestCase
         );
     }
 
-    public function testScanNoSeedSomeData()
+    public function testScanNoSeedSomeData(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -258,7 +258,7 @@ class ScanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function scan_accumulator_throws()
+    public function scan_accumulator_throws(): void
     {
         $xs = $this->createHotObservable(
           [
@@ -280,7 +280,7 @@ class ScanTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function scan_accumulator_throws_with_seed()
+    public function scan_accumulator_throws_with_seed(): void
     {
         $xs = $this->createHotObservable(
           [

--- a/test/Rx/Functional/Operator/SelectManyTest.php
+++ b/test/Rx/Functional/Operator/SelectManyTest.php
@@ -15,27 +15,27 @@ class SelectManyTest extends FunctionalTestCase
      */
     public function it_passes_the_last_on_complete()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(100, 4),
             onNext(200, 2),
             onNext(300, 3),
             onNext(400, 1),
             onCompleted(500)
-        ));
+        ]);
 
-        $ys = $this->createColdObservable(array(
+        $ys = $this->createColdObservable([
             onNext(50, 'foo'),
             onNext(100, 'bar'),
             onNext(150, 'baz'),
             onNext(200, 'qux'),
             onCompleted(250)
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, $ys) {
             return $xs->selectMany(function() use ($ys) { return $ys; });
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(350, "foo"), // 1
             onNext(400, "bar"), // 1
             onNext(450, "baz"), // 1
@@ -53,10 +53,10 @@ class SelectManyTest extends FunctionalTestCase
             onNext(750, "baz"), // 4
             onNext(800, "qux"), // 4
             onCompleted(850)
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-        $this->assertSubscriptions(array(subscribe(200, 700)), $xs->getSubscriptions());
-        $this->assertSubscriptions(array(subscribe(300, 550), subscribe(400, 650), subscribe(500, 750), subscribe(600, 850)), $ys->getSubscriptions());
+        $this->assertSubscriptions([subscribe(200, 700)], $xs->getSubscriptions());
+        $this->assertSubscriptions([subscribe(300, 550), subscribe(400, 650), subscribe(500, 750), subscribe(600, 850)], $ys->getSubscriptions());
     }
 
     /**
@@ -64,37 +64,37 @@ class SelectManyTest extends FunctionalTestCase
      */
     public function it_passes_on_error()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(100, 4),
             onNext(200, 2),
             onNext(300, 3),
             onNext(400, 1),
             onCompleted(510)
-        ));
+        ]);
 
-        $ys = $this->createColdObservable(array(
+        $ys = $this->createColdObservable([
             onNext(50, 'foo'),
             onNext(100, 'bar'),
             onNext(150, 'baz'),
             onError(210, new Exception()),
             onCompleted(250),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, $ys) {
             return $xs->selectMany(function() use ($ys) { return $ys; });
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(350, "foo"), // 1
             onNext(400, "bar"), // 1
             onNext(450, "baz"), // 1
             onNext(450, "foo"), // 2
             onNext(500, "bar"), // 2
             onError(510, new Exception()), // 1
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-        $this->assertSubscriptions(array(subscribe(200, 510)), $xs->getSubscriptions());
-        $this->assertSubscriptions(array(subscribe(300, 510), subscribe(400, 510), subscribe(500, 510)), $ys->getSubscriptions());
+        $this->assertSubscriptions([subscribe(200, 510)], $xs->getSubscriptions());
+        $this->assertSubscriptions([subscribe(300, 510), subscribe(400, 510), subscribe(500, 510)], $ys->getSubscriptions());
     }
 
     /**
@@ -102,27 +102,27 @@ class SelectManyTest extends FunctionalTestCase
      */
     public function flatMapTo_it_passes_the_last_on_complete()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(100, 4),
             onNext(200, 2),
             onNext(300, 3),
             onNext(400, 1),
             onCompleted(500)
-        ));
+        ]);
 
-        $ys = $this->createColdObservable(array(
+        $ys = $this->createColdObservable([
             onNext(50, 'foo'),
             onNext(100, 'bar'),
             onNext(150, 'baz'),
             onNext(200, 'qux'),
             onCompleted(250)
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, $ys) {
             return $xs->flatMapTo($ys);
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(350, "foo"), // 1
             onNext(400, "bar"), // 1
             onNext(450, "baz"), // 1
@@ -140,10 +140,10 @@ class SelectManyTest extends FunctionalTestCase
             onNext(750, "baz"), // 4
             onNext(800, "qux"), // 4
             onCompleted(850)
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-        $this->assertSubscriptions(array(subscribe(200, 700)), $xs->getSubscriptions());
-        $this->assertSubscriptions(array(subscribe(300, 550), subscribe(400, 650), subscribe(500, 750), subscribe(600, 850)), $ys->getSubscriptions());
+        $this->assertSubscriptions([subscribe(200, 700)], $xs->getSubscriptions());
+        $this->assertSubscriptions([subscribe(300, 550), subscribe(400, 650), subscribe(500, 750), subscribe(600, 850)], $ys->getSubscriptions());
     }
 
     /**
@@ -151,37 +151,37 @@ class SelectManyTest extends FunctionalTestCase
      */
     public function flatMapTo_it_passes_on_error()
     {
-        $xs = $this->createColdObservable(array(
+        $xs = $this->createColdObservable([
             onNext(100, 4),
             onNext(200, 2),
             onNext(300, 3),
             onNext(400, 1),
             onCompleted(510)
-        ));
+        ]);
 
-        $ys = $this->createColdObservable(array(
+        $ys = $this->createColdObservable([
             onNext(50, 'foo'),
             onNext(100, 'bar'),
             onNext(150, 'baz'),
             onError(210, new Exception()),
             onCompleted(250),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs, $ys) {
             return $xs->flatMapTo($ys);
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(350, "foo"), // 1
             onNext(400, "bar"), // 1
             onNext(450, "baz"), // 1
             onNext(450, "foo"), // 2
             onNext(500, "bar"), // 2
             onError(510, new Exception()), // 1
-        ), $results->getMessages());
+        ], $results->getMessages());
 
-        $this->assertSubscriptions(array(subscribe(200, 510)), $xs->getSubscriptions());
-        $this->assertSubscriptions(array(subscribe(300, 510), subscribe(400, 510), subscribe(500, 510)), $ys->getSubscriptions());
+        $this->assertSubscriptions([subscribe(200, 510)], $xs->getSubscriptions());
+        $this->assertSubscriptions([subscribe(300, 510), subscribe(400, 510), subscribe(500, 510)], $ys->getSubscriptions());
     }
 
     /**

--- a/test/Rx/Functional/Operator/SelectManyTest.php
+++ b/test/Rx/Functional/Operator/SelectManyTest.php
@@ -13,7 +13,7 @@ class SelectManyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_the_last_on_complete()
+    public function it_passes_the_last_on_complete(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -62,7 +62,7 @@ class SelectManyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_error()
+    public function it_passes_on_error(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -100,7 +100,7 @@ class SelectManyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapTo_it_passes_the_last_on_complete()
+    public function flatMapTo_it_passes_the_last_on_complete(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -149,7 +149,7 @@ class SelectManyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMapTo_it_passes_on_error()
+    public function flatMapTo_it_passes_on_error(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),
@@ -187,7 +187,7 @@ class SelectManyTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function flatMap_it_errors_with_bad_return()
+    public function flatMap_it_errors_with_bad_return(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 4),

--- a/test/Rx/Functional/Operator/SelectTest.php
+++ b/test/Rx/Functional/Operator/SelectTest.php
@@ -14,7 +14,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function calls_on_error_if_selector_throws_an_exception()
+    public function calls_on_error_if_selector_throws_an_exception(): void
     {
         $xs = $this->createHotObservable([
             onNext(500, 42),
@@ -32,7 +32,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function select_calls_on_completed()
+    public function select_calls_on_completed(): void
     {
         $xs = $this->createHotObservable([
             onCompleted(500),
@@ -48,7 +48,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function select_calls_on_error()
+    public function select_calls_on_error(): void
     {
         $xs = $this->createHotObservable([
             onError(500, new Exception()),
@@ -64,7 +64,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function select_calls_selector()
+    public function select_calls_selector(): void
     {
         $xs = $this->createHotObservable([
             onNext(100, 2),
@@ -92,7 +92,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function map_with_index_dispose_inside_selector()
+    public function map_with_index_dispose_inside_selector(): void
     {
         $xs = $this->createHotObservable([
             onNext(100, 4),
@@ -140,7 +140,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function map_with_index_completed()
+    public function map_with_index_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -182,7 +182,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function map_with_index_not_completed()
+    public function map_with_index_not_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 5),
@@ -219,7 +219,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function map_with_index_error()
+    public function map_with_index_error(): void
     {
         $error = new Exception();
 
@@ -263,7 +263,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function map_with_index_throws()
+    public function map_with_index_throws(): void
     {
         $error = new Exception();
 
@@ -307,7 +307,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function mapTo_value()
+    public function mapTo_value(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -334,7 +334,7 @@ class SelectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function map_and_map_Optimization()
+    public function map_and_map_Optimization(): void
     {
 
         $invoked1 = 0;

--- a/test/Rx/Functional/Operator/SelectTest.php
+++ b/test/Rx/Functional/Operator/SelectTest.php
@@ -21,7 +21,7 @@ class SelectTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs) {
-            return $xs->select(function () {
+            return $xs->select(function (): void {
                 throw new Exception();
             });
         });
@@ -118,7 +118,7 @@ class SelectTest extends FunctionalTestCase
             })->subscribe($results)
         );
 
-        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use ($d) {
+        $this->scheduler->scheduleAbsolute(TestScheduler::DISPOSED, function () use ($d): void {
             $d->dispose();
         });
 

--- a/test/Rx/Functional/Operator/SingleInstanceTest.php
+++ b/test/Rx/Functional/Operator/SingleInstanceTest.php
@@ -27,18 +27,18 @@ class SingleInstanceTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $disposable = null;
 
-        $this->scheduler->scheduleAbsolute($this->scheduler::CREATED, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute($this->scheduler::CREATED, function () use (&$ys, $xs): void {
             $ys = $xs->singleInstance();
         });
 
-        $this->scheduler->scheduleAbsolute($this->scheduler::SUBSCRIBED, function () use (&$ys, &$disposable, $results1, $results2) {
+        $this->scheduler->scheduleAbsolute($this->scheduler::SUBSCRIBED, function () use (&$ys, &$disposable, $results1, $results2): void {
             $disposable = new CompositeDisposable([
                 $ys->subscribe($results1),
                 $ys->subscribe($results2)
             ]);
         });
 
-        $this->scheduler->scheduleAbsolute($this->scheduler::DISPOSED, function () use (&$disposable) {
+        $this->scheduler->scheduleAbsolute($this->scheduler::DISPOSED, function () use (&$disposable): void {
             $disposable->dispose();
         });
 
@@ -80,19 +80,19 @@ class SingleInstanceTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $disposable = new SerialDisposable();
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$ys, $xs): void {
             $ys = $xs->singleInstance();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $disposable, $results1) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$ys, $disposable, $results1): void {
             $disposable->setDisposable($ys->subscribe($results1));
         });
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$ys, $disposable, $results2) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$ys, $disposable, $results2): void {
             $disposable->setDisposable($ys->subscribe($results2));
         });
 
-        $this->scheduler->scheduleAbsolute(900, function () use (&$disposable) {
+        $this->scheduler->scheduleAbsolute(900, function () use (&$disposable): void {
             $disposable->dispose();
         });
 

--- a/test/Rx/Functional/Operator/SingleInstanceTest.php
+++ b/test/Rx/Functional/Operator/SingleInstanceTest.php
@@ -13,7 +13,7 @@ class SingleInstanceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function singleInstance_basic()
+    public function singleInstance_basic(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),
@@ -66,7 +66,7 @@ class SingleInstanceTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function singleInstance_subscribe_after_stopped()
+    public function singleInstance_subscribe_after_stopped(): void
     {
         $xs = $this->createColdObservable([
             onNext(100, 1),

--- a/test/Rx/Functional/Operator/SkipLastTest.php
+++ b/test/Rx/Functional/Operator/SkipLastTest.php
@@ -12,7 +12,7 @@ class SkipLastTest extends FunctionalTestCase
 {
     /**
      */
-    public function testSkipLastNegative()
+    public function testSkipLastNegative(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $xs = $this->createHotObservable(
@@ -36,7 +36,7 @@ class SkipLastTest extends FunctionalTestCase
 
     }
 
-    public function testSkipLastZeroCompleted()
+    public function testSkipLastZeroCompleted(): void
     {
 
         $xs = $this->createHotObservable(
@@ -81,7 +81,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastZeroError()
+    public function testSkipLastZeroError(): void
     {
 
         $ex = new \Exception('ex');
@@ -126,7 +126,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastZeroDisposed()
+    public function testSkipLastZeroDisposed(): void
     {
 
         $xs = $this->createHotObservable(
@@ -169,7 +169,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastOneCompleted()
+    public function testSkipLastOneCompleted(): void
     {
 
         $xs = $this->createHotObservable(
@@ -214,7 +214,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastOneError()
+    public function testSkipLastOneError(): void
     {
 
         $ex = new \Exception('ex');
@@ -260,7 +260,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastOneDisposed()
+    public function testSkipLastOneDisposed(): void
     {
 
         $xs = $this->createHotObservable(
@@ -302,7 +302,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastThreeCompleted()
+    public function testSkipLastThreeCompleted(): void
     {
 
         $xs = $this->createHotObservable(
@@ -344,7 +344,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastThreeError()
+    public function testSkipLastThreeError(): void
     {
 
         $ex = new \Exception('ex');
@@ -387,7 +387,7 @@ class SkipLastTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipLastThreeDisposed()
+    public function testSkipLastThreeDisposed(): void
     {
 
         $xs = $this->createHotObservable(

--- a/test/Rx/Functional/Operator/SkipTest.php
+++ b/test/Rx/Functional/Operator/SkipTest.php
@@ -15,7 +15,7 @@ class SkipTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_throws_an_exception_on_negative_amounts()
+    public function it_throws_an_exception_on_negative_amounts(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $observable = new ReturnObservable(42, $this->scheduler);
@@ -27,7 +27,7 @@ class SkipTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_complete()
+    public function it_passes_on_complete(): void
     {
         $xs = $this->createHotObservable([
             onNext(300, 21),
@@ -51,7 +51,7 @@ class SkipTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_skips_one_value()
+    public function it_skips_one_value(): void
     {
         $scheduler = $this->createTestScheduler();
         $xs        = $this->createHotObservable([
@@ -75,7 +75,7 @@ class SkipTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_skips_multiple_values()
+    public function it_skips_multiple_values(): void
     {
         $scheduler = $this->createTestScheduler();
         $xs        = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/SkipTest.php
+++ b/test/Rx/Functional/Operator/SkipTest.php
@@ -29,23 +29,23 @@ class SkipTest extends FunctionalTestCase
      */
     public function it_passes_on_complete()
     {
-        $xs = $this->createHotObservable(array(
+        $xs = $this->createHotObservable([
             onNext(300, 21),
             onNext(500, 42),
             onNext(800, 84),
             onCompleted(820),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
             return $xs->skip(0);
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(300, 21),
             onNext(500, 42),
             onNext(800, 84),
             onCompleted(820),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -54,22 +54,22 @@ class SkipTest extends FunctionalTestCase
     public function it_skips_one_value()
     {
         $scheduler = $this->createTestScheduler();
-        $xs        = $this->createHotObservable(array(
+        $xs        = $this->createHotObservable([
             onNext(300, 21),
             onNext(500, 42),
             onNext(800, 84),
             onCompleted(820),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
             return $xs->skip(1);
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(500, 42),
             onNext(800, 84),
             onCompleted(820),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -78,22 +78,22 @@ class SkipTest extends FunctionalTestCase
     public function it_skips_multiple_values()
     {
         $scheduler = $this->createTestScheduler();
-        $xs        = $this->createHotObservable(array(
+        $xs        = $this->createHotObservable([
             onNext(300, 21),
             onNext(500, 42),
             onNext(800, 84),
             onNext(850, 168),
             onCompleted(870),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
             return $xs->skip(2);
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(800, 84),
             onNext(850, 168),
             onCompleted(870),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 }

--- a/test/Rx/Functional/Operator/SkipUntilTest.php
+++ b/test/Rx/Functional/Operator/SkipUntilTest.php
@@ -250,7 +250,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
 
         $r = new AnonymousObservable(function () use (&$disposed) {
-            return new CallbackDisposable(function () use (&$disposed) {
+            return new CallbackDisposable(function () use (&$disposed): void {
                 $disposed = true;
             });
         });
@@ -276,14 +276,14 @@ class SkipUntilTest extends FunctionalTestCase
         Observable::of(1)
             ->skipUntil(Observable::of(1))
             ->subscribe(
-                function ($x) use (&$emitted) {
+                function ($x) use (&$emitted): void {
                     if ($emitted !== null) {
                         $this->fail('emitted should be null');
                     }
                     $emitted = $x;
                 },
                 null,
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             );

--- a/test/Rx/Functional/Operator/SkipUntilTest.php
+++ b/test/Rx/Functional/Operator/SkipUntilTest.php
@@ -12,7 +12,7 @@ use Rx\Testing\MockObserver;
 
 class SkipUntilTest extends FunctionalTestCase
 {
-    public function testSkipUntilSomeDataNext()
+    public function testSkipUntilSomeDataNext(): void
     {
 
         $l = $this->createHotObservable(
@@ -49,7 +49,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilSomeDataError()
+    public function testSkipUntilSomeDataError(): void
     {
 
         $error = new \Exception();
@@ -83,7 +83,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilSomeDataEmpty()
+    public function testSkipUntilSomeDataEmpty(): void
     {
 
         $l = $this->createHotObservable(
@@ -117,7 +117,7 @@ class SkipUntilTest extends FunctionalTestCase
 
     }
 
-    public function testSkipUntilNeverNext()
+    public function testSkipUntilNeverNext(): void
     {
 
         $l = Observable::never();
@@ -142,7 +142,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilNeverError()
+    public function testSkipUntilNeverError(): void
     {
 
         $error = new \Exception();
@@ -168,7 +168,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilSomeDataNever()
+    public function testSkipUntilSomeDataNever(): void
     {
 
         $l = $this->createHotObservable(
@@ -194,7 +194,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilNeverEmpty()
+    public function testSkipUntilNeverEmpty(): void
     {
 
         $l = Observable::never();
@@ -216,7 +216,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilNeverNever()
+    public function testSkipUntilNeverNever(): void
     {
 
         $l = Observable::never();
@@ -233,7 +233,7 @@ class SkipUntilTest extends FunctionalTestCase
         );
     }
 
-    public function testSkipUntilHasCompletedCausesDisposal()
+    public function testSkipUntilHasCompletedCausesDisposal(): void
     {
 
         $disposed = false;
@@ -268,7 +268,7 @@ class SkipUntilTest extends FunctionalTestCase
 
     }
 
-    public function testCanCompleteInSubscribeAction()
+    public function testCanCompleteInSubscribeAction(): void
     {
         $completed = false;
         $emitted   = null;

--- a/test/Rx/Functional/Operator/SkipWhileTest.php
+++ b/test/Rx/Functional/Operator/SkipWhileTest.php
@@ -12,7 +12,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_complete_before()
+    public function skipWhile_complete_before(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -62,7 +62,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_complete_after()
+    public function skipWhile_complete_after(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -115,7 +115,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_error_before()
+    public function skipWhile_error_before(): void
     {
         $error = new \Exception();
 
@@ -167,7 +167,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_error_after()
+    public function skipWhile_error_after(): void
     {
         $error = new \Exception();
 
@@ -222,7 +222,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_dispose_before()
+    public function skipWhile_dispose_before(): void
     {
 
         $xs = $this->createHotObservable(
@@ -270,7 +270,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_dispose_after()
+    public function skipWhile_dispose_after(): void
     {
 
         $xs = $this->createHotObservable(
@@ -322,7 +322,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_zero()
+    public function skipWhile_zero(): void
     {
 
         $xs = $this->createHotObservable(
@@ -383,7 +383,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_throw()
+    public function skipWhile_throw(): void
     {
 
         $xs = $this->createHotObservable(
@@ -437,7 +437,7 @@ class SkipWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function skipWhile_index()
+    public function skipWhile_index(): void
     {
 
         $xs = $this->createHotObservable(

--- a/test/Rx/Functional/Operator/SkipWhileTest.php
+++ b/test/Rx/Functional/Operator/SkipWhileTest.php
@@ -506,7 +506,7 @@ class SkipWhileTest extends FunctionalTestCase
          * The sqrt can be an aproximation, hence just for the sake of
          * security, one rounds it to the next highest integer value.
          */
-        for ($i = 3; $i <= ceil(sqrt($num)); $i = $i + 2) {
+        for ($i = 3; $i <= ceil(sqrt($num)); $i += 2) {
             if ($num % $i == 0)
                 return false;
         }

--- a/test/Rx/Functional/Operator/StartTest.php
+++ b/test/Rx/Functional/Operator/StartTest.php
@@ -17,7 +17,7 @@ class StartTest extends FunctionalTestCase
         $done = false;
 
         $results = $this->scheduler->startWithCreate(function () use (&$done) {
-            return Observable::start(function () use (&$done) {
+            return Observable::start(function () use (&$done): void {
                 $done = true;
             }, $this->scheduler);
         });
@@ -60,7 +60,7 @@ class StartTest extends FunctionalTestCase
     {
         $error   = new \Exception();
         $results = $this->scheduler->startWithCreate(function () use ($error) {
-            return Observable::start(function () use ($error) {
+            return Observable::start(function () use ($error): void {
                 throw $error;
             }, $this->scheduler);
         });

--- a/test/Rx/Functional/Operator/StartTest.php
+++ b/test/Rx/Functional/Operator/StartTest.php
@@ -12,7 +12,7 @@ class StartTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function start_action()
+    public function start_action(): void
     {
         $done = false;
 
@@ -36,7 +36,7 @@ class StartTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function start_action_number()
+    public function start_action_number(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::start(function () {
@@ -56,7 +56,7 @@ class StartTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function start_with_error()
+    public function start_with_error(): void
     {
         $error   = new \Exception();
         $results = $this->scheduler->startWithCreate(function () use ($error) {

--- a/test/Rx/Functional/Operator/StartWithTest.php
+++ b/test/Rx/Functional/Operator/StartWithTest.php
@@ -13,7 +13,7 @@ class StartWithTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function startWith_never()
+    public function startWith_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)
@@ -31,7 +31,7 @@ class StartWithTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function startWith_empty()
+    public function startWith_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -51,7 +51,7 @@ class StartWithTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function startWith_one()
+    public function startWith_one(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -73,7 +73,7 @@ class StartWithTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function startWith_multiple()
+    public function startWith_multiple(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -97,7 +97,7 @@ class StartWithTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function startWith_multiple_before()
+    public function startWith_multiple_before(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -120,7 +120,7 @@ class StartWithTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function startWith_error()
+    public function startWith_error(): void
     {
 
         $error = new \Exception();

--- a/test/Rx/Functional/Operator/SubscribeOnTest.php
+++ b/test/Rx/Functional/Operator/SubscribeOnTest.php
@@ -11,7 +11,7 @@ class SubscribeOnTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subscribeOn_normal()
+    public function subscribeOn_normal(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -39,7 +39,7 @@ class SubscribeOnTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subscribeOn_error()
+    public function subscribeOn_error(): void
     {
 
         $error = new \Exception();
@@ -68,7 +68,7 @@ class SubscribeOnTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subscribeOn_empty()
+    public function subscribeOn_empty(): void
     {
         $xs = $this->createHotObservable(
             [
@@ -94,7 +94,7 @@ class SubscribeOnTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function subscribeOn_never()
+    public function subscribeOn_never(): void
     {
         $xs = $this->createHotObservable([onNext(150, 1)]);
 

--- a/test/Rx/Functional/Operator/SumTest.php
+++ b/test/Rx/Functional/Operator/SumTest.php
@@ -13,7 +13,7 @@ class SumTest extends FunctionalTestCase
      *
      * @test
      */
-    public function sum_number_empty()
+    public function sum_number_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -35,7 +35,7 @@ class SumTest extends FunctionalTestCase
      *
      * @test
      */
-    public function sum_number_return()
+    public function sum_number_return(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -58,7 +58,7 @@ class SumTest extends FunctionalTestCase
      *
      * @test
      */
-    public function sum_number_some()
+    public function sum_number_some(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -83,7 +83,7 @@ class SumTest extends FunctionalTestCase
      *
      * @test
      */
-    public function sum_number_throw()
+    public function sum_number_throw(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -104,7 +104,7 @@ class SumTest extends FunctionalTestCase
      *
      * @test
      */
-    public function sum_number_never()
+    public function sum_number_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)

--- a/test/Rx/Functional/Operator/SwitchFirstTest.php
+++ b/test/Rx/Functional/Operator/SwitchFirstTest.php
@@ -11,7 +11,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_Data()
+    public function switchFirst_Data(): void
     {
 
         $xs = $this->createHotObservable([
@@ -62,7 +62,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_inner_throws()
+    public function switchFirst_inner_throws(): void
     {
 
         $error = new \Exception();
@@ -116,7 +116,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_first_inner_throws()
+    public function switchFirst_first_inner_throws(): void
     {
 
         $error = new \Exception();
@@ -165,7 +165,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_outer_throws()
+    public function switchFirst_outer_throws(): void
     {
 
         $error = new \Exception();
@@ -209,7 +209,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_no_inner()
+    public function switchFirst_no_inner(): void
     {
 
         $xs = $this->createHotObservable([
@@ -231,7 +231,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_inner_completes()
+    public function switchFirst_inner_completes(): void
     {
 
         $xs = $this->createHotObservable([
@@ -269,7 +269,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_Dispose()
+    public function switchFirst_Dispose(): void
     {
 
         $xs = $this->createHotObservable([
@@ -317,7 +317,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_Inner_Completes_Last()
+    public function switchFirst_Inner_Completes_Last(): void
     {
 
         $xs = $this->createHotObservable([
@@ -368,7 +368,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_Subsequent()
+    public function switchFirst_Subsequent(): void
     {
 
         $xs = $this->createHotObservable([
@@ -415,7 +415,7 @@ class SwitchFirstTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchFirst_SkipsOneObservable()
+    public function switchFirst_SkipsOneObservable(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/SwitchLatestTest.php
+++ b/test/Rx/Functional/Operator/SwitchLatestTest.php
@@ -12,7 +12,7 @@ class SwitchLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchLatest_Data()
+    public function switchLatest_Data(): void
     {
 
         $xs = $this->createHotObservable([
@@ -67,7 +67,7 @@ class SwitchLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchLatest_inner_throws()
+    public function switchLatest_inner_throws(): void
     {
 
         $error = new \Exception();
@@ -120,7 +120,7 @@ class SwitchLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchLatest_outer_throws()
+    public function switchLatest_outer_throws(): void
     {
 
         $error = new \Exception();
@@ -166,7 +166,7 @@ class SwitchLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchLatest_no_inner()
+    public function switchLatest_no_inner(): void
     {
 
         $xs = $this->createHotObservable([
@@ -188,7 +188,7 @@ class SwitchLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchLatest_inner_completes()
+    public function switchLatest_inner_completes(): void
     {
 
         $xs = $this->createHotObservable([
@@ -226,7 +226,7 @@ class SwitchLatestTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function switchLatest_Dispose()
+    public function switchLatest_Dispose(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/TakeLastTest.php
+++ b/test/Rx/Functional/Operator/TakeLastTest.php
@@ -12,7 +12,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_zero_completed()
+    public function takeLast_zero_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 1),
@@ -43,7 +43,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_zero_error()
+    public function takeLast_zero_error(): void
     {
 
         $error = new Exception('error');
@@ -77,7 +77,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_zero_disposed()
+    public function takeLast_zero_disposed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 1),
@@ -105,7 +105,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_one_completed()
+    public function takeLast_one_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 1),
@@ -137,7 +137,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_one_error()
+    public function takeLast_one_error(): void
     {
 
         $error = new Exception('error');
@@ -172,7 +172,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_one_disposed()
+    public function takeLast_one_disposed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 1),
@@ -200,7 +200,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_three_completed()
+    public function takeLast_three_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 1),
@@ -234,7 +234,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_three_error()
+    public function takeLast_three_error(): void
     {
 
         $error = new Exception('error');
@@ -269,7 +269,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_three_disposed()
+    public function takeLast_three_disposed(): void
     {
         $xs = $this->createHotObservable([
             onNext(180, 1),
@@ -297,7 +297,7 @@ class TakeLastTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeLast_invalid_count()
+    public function takeLast_invalid_count(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/TakeTest.php
+++ b/test/Rx/Functional/Operator/TakeTest.php
@@ -15,7 +15,7 @@ class TakeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_throws_an_exception_on_negative_amounts()
+    public function it_throws_an_exception_on_negative_amounts(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $observable = new ReturnObservable(42, $this->scheduler);
@@ -27,7 +27,7 @@ class TakeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_complete()
+    public function it_passes_on_complete(): void
     {
         $xs = $this->createHotObservable([
             onNext(300, 21),
@@ -51,7 +51,7 @@ class TakeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_calls_on_complete_after_last_value()
+    public function it_calls_on_complete_after_last_value(): void
     {
         $scheduler = $this->createTestScheduler();
         $xs        = $this->createHotObservable([
@@ -75,7 +75,7 @@ class TakeTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function take_zero_calls_on_completed()
+    public function take_zero_calls_on_completed(): void
     {
 
         $xs = $this->createHotObservable([

--- a/test/Rx/Functional/Operator/TakeUntilTest.php
+++ b/test/Rx/Functional/Operator/TakeUntilTest.php
@@ -290,7 +290,7 @@ class TakeUntilTest extends FunctionalTestCase
             onNext(150, 1),
             onError(215, new \Exception()),
             onCompleted(240)
-        ])->doOnNext(function () use (&$sourceNotDisposed) {
+        ])->doOnNext(function () use (&$sourceNotDisposed): void {
             $sourceNotDisposed = true;
         });
 
@@ -334,7 +334,7 @@ class TakeUntilTest extends FunctionalTestCase
             onNext(150, 1),
             onNext(250, 2),
             onCompleted(260)
-        ])->doOnNext(function () use (&$sourceNotDisposed) {
+        ])->doOnNext(function () use (&$sourceNotDisposed): void {
             $sourceNotDisposed = true;
         });
 
@@ -363,7 +363,7 @@ class TakeUntilTest extends FunctionalTestCase
         $source = Observable::range(1, 10);
         $notification = new Subject();
         $source->takeUntil($notification)
-            ->subscribe(new CallbackObserver(function($value) use (&$emissions, $notification) {
+            ->subscribe(new CallbackObserver(function($value) use (&$emissions, $notification): void {
                 if ($value === 5) {
                     $notification->onNext(true);
                 }

--- a/test/Rx/Functional/Operator/TakeUntilTest.php
+++ b/test/Rx/Functional/Operator/TakeUntilTest.php
@@ -15,7 +15,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_some_data_next()
+    public function takeUntil_preempt_some_data_next(): void
     {
         $l = $this->createHotObservable([
             onNext(150, 1),
@@ -57,7 +57,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_some_data_error()
+    public function takeUntil_preempt_some_data_error(): void
     {
         $error = new \Exception();
 
@@ -93,7 +93,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_some_data_empty()
+    public function takeUntil_preempt_some_data_empty(): void
     {
         $l = $this->createHotObservable([
             onNext(150, 1),
@@ -130,7 +130,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_some_data_never()
+    public function takeUntil_preempt_some_data_never(): void
     {
         $l = $this->createHotObservable([
             onNext(150, 1),
@@ -163,7 +163,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_never_next()
+    public function takeUntil_preempt_never_next(): void
     {
         $l = Observable::never();
 
@@ -188,7 +188,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_never_error()
+    public function takeUntil_preempt_never_error(): void
     {
 
         $error = new \Exception();
@@ -216,7 +216,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_never_empty()
+    public function takeUntil_preempt_never_empty(): void
     {
         $l = Observable::never();
 
@@ -235,7 +235,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_preempt_never_never()
+    public function takeUntil_preempt_never_never(): void
     {
         $l = Observable::never();
 
@@ -251,7 +251,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_before_first_produced()
+    public function takeUntil_before_first_produced(): void
     {
         $l = $this->createHotObservable([
             onNext(150, 1),
@@ -281,7 +281,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_before_first_produced_remain_silent_and_proper_disposed()
+    public function takeUntil_before_first_produced_remain_silent_and_proper_disposed(): void
     {
 
         $sourceNotDisposed = false;
@@ -319,7 +319,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_no_preempt_after_last_produced_proper_disposed_signal()
+    public function takeUntil_no_preempt_after_last_produced_proper_disposed_signal(): void
     {
 
         $sourceNotDisposed = false;
@@ -357,7 +357,7 @@ class TakeUntilTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeUntil_should_subscribe_to_the_notifier_first_with_immediate_scheduler()
+    public function takeUntil_should_subscribe_to_the_notifier_first_with_immediate_scheduler(): void
     {
         $emissions = 0;
         $source = Observable::range(1, 10);

--- a/test/Rx/Functional/Operator/TakeWhileTest.php
+++ b/test/Rx/Functional/Operator/TakeWhileTest.php
@@ -432,7 +432,7 @@ class TakeWhileTest extends FunctionalTestCase
          * The sqrt can be an aproximation, hence just for the sake of
          * security, one rounds it to the next highest integer value.
          */
-        for ($i = 3; $i <= ceil(sqrt($num)); $i = $i + 2) {
+        for ($i = 3; $i <= ceil(sqrt($num)); $i += 2) {
             if ($num % $i === 0) {
                 return false;
             }

--- a/test/Rx/Functional/Operator/TakeWhileTest.php
+++ b/test/Rx/Functional/Operator/TakeWhileTest.php
@@ -12,7 +12,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_never()
+    public function takeWhile_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, -1),
@@ -57,7 +57,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_complete_after()
+    public function takeWhile_complete_after(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, -1),
@@ -102,7 +102,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_error_before()
+    public function takeWhile_error_before(): void
     {
         $error = new \Exception();
 
@@ -146,7 +146,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_error_after()
+    public function takeWhile_error_after(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, -1),
@@ -191,7 +191,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_dispose_before()
+    public function takeWhile_dispose_before(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, -1),
@@ -233,7 +233,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_dispose_after()
+    public function takeWhile_dispose_after(): void
     {
 
         $xs = $this->createHotObservable([
@@ -279,7 +279,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_zero()
+    public function takeWhile_zero(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, -1),
@@ -321,7 +321,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_throw()
+    public function takeWhile_throw(): void
     {
         $error = new \Exception();
 
@@ -368,7 +368,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_index()
+    public function takeWhile_index(): void
     {
         $xs = $this->createHotObservable([
             onNext(90, -1),
@@ -444,7 +444,7 @@ class TakeWhileTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function takeWhile_inclusive()
+    public function takeWhile_inclusive(): void
     {
         $error = new \Exception();
 

--- a/test/Rx/Functional/Operator/ThrottleTest.php
+++ b/test/Rx/Functional/Operator/ThrottleTest.php
@@ -15,7 +15,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_completed()
+    public function throttle_completed(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -47,7 +47,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_never()
+    public function throttle_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1)
@@ -67,7 +67,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_empty()
+    public function throttle_empty(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -90,7 +90,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_error()
+    public function throttle_error(): void
     {
         $error = new \Exception();
 
@@ -122,7 +122,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_no_end()
+    public function throttle_no_end(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -152,7 +152,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_dispose()
+    public function throttle_dispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -181,7 +181,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_dispose_with_value_waiting()
+    public function throttle_dispose_with_value_waiting(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -210,7 +210,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_quiet_observable_emits_immediately()
+    public function throttle_quiet_observable_emits_immediately(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -235,7 +235,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_noisy_observable_drops_items()
+    public function throttle_noisy_observable_drops_items(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -270,7 +270,7 @@ class ThrottleTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function throttle_scheduler_overrides_subscribe_scheduler()
+    public function throttle_scheduler_overrides_subscribe_scheduler(): void
     {
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects($this->exactly(2))

--- a/test/Rx/Functional/Operator/TimeoutTest.php
+++ b/test/Rx/Functional/Operator/TimeoutTest.php
@@ -13,7 +13,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_in_time()
+    public function timeout_in_time(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -45,7 +45,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_relative_time_timeout_occurs_with_default_error()
+    public function timeout_relative_time_timeout_occurs_with_default_error(): void
     {
         $xs = $this->createHotObservable([
             onNext(410, 1)
@@ -73,7 +73,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_relative_time_timeout_occurs_with_custom_error()
+    public function timeout_relative_time_timeout_occurs_with_custom_error(): void
     {
         $errObs = new ErrorObservable(new \Exception(), $this->scheduler);
 
@@ -107,7 +107,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_out_of_time()
+    public function timeout_out_of_time(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -146,7 +146,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_occurs_1()
+    public function timeout_timeout_occurs_1(): void
     {
         $xs = $this->createHotObservable([
             onNext(70, 1),
@@ -195,7 +195,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_occurs_2()
+    public function timeout_timeout_occurs_2(): void
     {
         $xs = $this->createHotObservable([
             onNext(70, 1),
@@ -247,7 +247,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_occurs_never()
+    public function timeout_timeout_occurs_never(): void
     {
         $xs = $this->createHotObservable([
             onNext(70, 1),
@@ -290,7 +290,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_occurs_completed()
+    public function timeout_timeout_occurs_completed(): void
     {
         $xs = $this->createHotObservable([
             onCompleted(500)
@@ -329,7 +329,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_occurs_Error()
+    public function timeout_timeout_occurs_Error(): void
     {
         $xs = $this->createHotObservable([
             onError(500, new \Exception())
@@ -368,7 +368,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_does_not_occur_completed()
+    public function timeout_timeout_does_not_occur_completed(): void
     {
         $xs = $this->createHotObservable([
             onCompleted(250)
@@ -406,7 +406,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_does_not_occur_Error()
+    public function timeout_timeout_does_not_occur_Error(): void
     {
         $xs = $this->createHotObservable([
             onError(250, new \Exception())
@@ -444,7 +444,7 @@ class TimeoutTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timeout_timeout_does_not_occur()
+    public function timeout_timeout_does_not_occur(): void
     {
         $xs = $this->createHotObservable([
             onNext(70, 1),

--- a/test/Rx/Functional/Operator/TimestampTest.php
+++ b/test/Rx/Functional/Operator/TimestampTest.php
@@ -13,7 +13,7 @@ class TimestampTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timestamp_regular()
+    public function timestamp_regular(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),
@@ -42,7 +42,7 @@ class TimestampTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timestamp_empty()
+    public function timestamp_empty(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::empty($this->scheduler)->timestamp($this->scheduler);
@@ -56,7 +56,7 @@ class TimestampTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timestamp_error()
+    public function timestamp_error(): void
     {
         $error = new \Exception();
 
@@ -72,7 +72,7 @@ class TimestampTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timestamp_never()
+    public function timestamp_never(): void
     {
         $results = $this->scheduler->startWithCreate(function () {
             return Observable::never()->timestamp($this->scheduler);
@@ -84,7 +84,7 @@ class TimestampTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function timestamp_dispose()
+    public function timestamp_dispose(): void
     {
         $xs = $this->createHotObservable([
             onNext(150, 1),

--- a/test/Rx/Functional/Operator/ToArrayTest.php
+++ b/test/Rx/Functional/Operator/ToArrayTest.php
@@ -11,7 +11,7 @@ use Rx\Testing\MockObserver;
 
 class ToArrayTest extends FunctionalTestCase
 {
-    public function testToArrayCompleted()
+    public function testToArrayCompleted(): void
     {
 
         $xs = $this->createHotObservable(
@@ -39,7 +39,7 @@ class ToArrayTest extends FunctionalTestCase
 
     }
 
-    public function testToArrayError()
+    public function testToArrayError(): void
     {
         $error = new \Exception();
 
@@ -74,7 +74,7 @@ class ToArrayTest extends FunctionalTestCase
         );
     }
 
-    public function testToArrayDisposed()
+    public function testToArrayDisposed(): void
     {
 
         $xs = $this->createHotObservable(

--- a/test/Rx/Functional/Operator/WhereTest.php
+++ b/test/Rx/Functional/Operator/WhereTest.php
@@ -22,9 +22,9 @@ class WhereTest extends FunctionalTestCase
         });
 
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onCompleted(820),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -38,12 +38,12 @@ class WhereTest extends FunctionalTestCase
             return $xs->where(function($elem) { return true; });
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(300, 21),
             onNext(500, 42),
             onNext(800, 84),
             onCompleted(820),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
 
@@ -53,19 +53,19 @@ class WhereTest extends FunctionalTestCase
     public function it_passes_on_error()
     {
         $exception = new Exception();
-        $xs = $this->createHotObservable(array(
+        $xs = $this->createHotObservable([
             onNext(500, 42),
             onError(820, $exception),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
             return $xs->where(function($elem) { return $elem === 42; });
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(500, 42),
             onError(820, $exception),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -73,25 +73,25 @@ class WhereTest extends FunctionalTestCase
      */
     public function calls_on_error_if_predicate_throws_an_exception()
     {
-        $xs = $this->createHotObservable(array(
+        $xs = $this->createHotObservable([
             onNext(500, 42),
-        ));
+        ]);
 
         $results = $this->scheduler->startWithCreate(function() use ($xs) {
-            return $xs->where(function() { throw new Exception(); });
+            return $xs->where(function(): void { throw new Exception(); });
         });
 
-        $this->assertMessages(array(onError(500, new Exception())), $results->getMessages());
+        $this->assertMessages([onError(500, new Exception())], $results->getMessages());
     }
 
     protected function createHotObservableWithData()
     {
-        return $this->createHotObservable(array(
+        return $this->createHotObservable([
             onNext(100,  2),
             onNext(300, 21),
             onNext(500, 42),
             onNext(800, 84),
             onCompleted(820),
-        ));
+        ]);
     }
 }

--- a/test/Rx/Functional/Operator/WhereTest.php
+++ b/test/Rx/Functional/Operator/WhereTest.php
@@ -13,7 +13,7 @@ class WhereTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_filters_all_on_false()
+    public function it_filters_all_on_false(): void
     {
         $xs = $this->createHotObservableWithData();
 
@@ -30,7 +30,7 @@ class WhereTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_all_on_true() 
+    public function it_passes_all_on_true(): void 
     {
         $xs = $this->createHotObservableWithData();
 
@@ -50,7 +50,7 @@ class WhereTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_passes_on_error()
+    public function it_passes_on_error(): void
     {
         $exception = new Exception();
         $xs = $this->createHotObservable([
@@ -71,7 +71,7 @@ class WhereTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function calls_on_error_if_predicate_throws_an_exception()
+    public function calls_on_error_if_predicate_throws_an_exception(): void
     {
         $xs = $this->createHotObservable([
             onNext(500, 42),

--- a/test/Rx/Functional/Operator/WithLatestFromTest.php
+++ b/test/Rx/Functional/Operator/WithLatestFromTest.php
@@ -17,7 +17,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_never_never()
+    public function withLatestFrom_never_never(): void
     {
         $e1 = new NeverObservable();
         $e2 = new NeverObservable();
@@ -32,7 +32,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_never_empty()
+    public function withLatestFrom_never_empty(): void
     {
         $e1 = new NeverObservable();
         $e2 = $this->createHotObservable(
@@ -52,7 +52,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_empty_never()
+    public function withLatestFrom_empty_never(): void
     {
         $e1 = new NeverObservable();
         $e2 = $this->createHotObservable(
@@ -72,7 +72,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_empty_empty()
+    public function withLatestFrom_empty_empty(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -107,7 +107,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_empty_return()
+    public function withLatestFrom_empty_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -142,7 +142,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_return_empty()
+    public function withLatestFrom_return_empty(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -177,7 +177,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_never_return()
+    public function withLatestFrom_never_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -203,7 +203,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_return_never()
+    public function withLatestFrom_return_never(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -225,7 +225,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_return_return()
+    public function withLatestFrom_return_return(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -267,7 +267,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_return_return_no_selector()
+    public function withLatestFrom_return_return_no_selector(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -309,7 +309,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_empty_error()
+    public function withLatestFrom_empty_error(): void
     {
         $error = new \Exception();
 
@@ -350,7 +350,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_error_empty()
+    public function withLatestFrom_error_empty(): void
     {
         $error = new \Exception();
 
@@ -391,7 +391,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_return_throw()
+    public function withLatestFrom_return_throw(): void
     {
         $error = new \Exception();
 
@@ -433,7 +433,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_return()
+    public function withLatestFrom_throw_return(): void
     {
         $error = new \Exception();
 
@@ -475,7 +475,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_throw()
+    public function withLatestFrom_throw_throw(): void
     {
         $error1 = new \Exception('first');
         $error2 = new \Exception('second');
@@ -517,7 +517,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_error_throw()
+    public function withLatestFrom_error_throw(): void
     {
         $error1 = new \Exception();
         $error2 = new \Exception();
@@ -560,7 +560,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_error()
+    public function withLatestFrom_throw_error(): void
     {
         $error1 = new \Exception();
         $error2 = new \Exception();
@@ -603,7 +603,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_never_throw()
+    public function withLatestFrom_never_throw(): void
     {
         $error = new \Exception();
 
@@ -631,7 +631,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_never()
+    public function withLatestFrom_throw_never(): void
     {
         $error = new \Exception();
 
@@ -659,7 +659,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_some_throw()
+    public function withLatestFrom_some_throw(): void
     {
         $error = new \Exception();
 
@@ -701,7 +701,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_some()
+    public function withLatestFrom_throw_some(): void
     {
         $error = new \Exception();
 
@@ -743,7 +743,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_after_complete_left()
+    public function withLatestFrom_throw_after_complete_left(): void
     {
         $error = new \Exception();
 
@@ -785,7 +785,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_throw_after_complete_right()
+    public function withLatestFrom_throw_after_complete_right(): void
     {
         $error = new \Exception();
 
@@ -819,7 +819,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_interleaved_with_tail()
+    public function withLatestFrom_interleaved_with_tail(): void
     {
 
         $e1 = $this->createHotObservable(
@@ -866,7 +866,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_consecutive()
+    public function withLatestFrom_consecutive(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -910,7 +910,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_consecutive_array()
+    public function withLatestFrom_consecutive_array(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -954,7 +954,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_consecutive_end_with_error_left()
+    public function withLatestFrom_consecutive_end_with_error_left(): void
     {
         $error = new \Exception();
 
@@ -999,7 +999,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_consecutive_end_with_error_right()
+    public function withLatestFrom_consecutive_end_with_error_right(): void
     {
         $error = new \Exception();
 
@@ -1038,7 +1038,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_selector_throws()
+    public function withLatestFrom_selector_throws(): void
     {
         $error = new \Exception();
 
@@ -1083,7 +1083,7 @@ class WithLatestFromTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function withLatestFrom_return_return_dispose()
+    public function withLatestFrom_return_return_dispose(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -1121,7 +1121,7 @@ class WithLatestFromTest extends FunctionalTestCase
         ], $e2->getSubscriptions());
     }
 
-    public function testWithLatestFrom_multiple_dispose_no_selector()
+    public function testWithLatestFrom_multiple_dispose_no_selector(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -1171,7 +1171,7 @@ class WithLatestFromTest extends FunctionalTestCase
         ], $e3->getSubscriptions());
     }
 
-    public function testWithLatestFrom_multiple_dispose_with_selector()
+    public function testWithLatestFrom_multiple_dispose_with_selector(): void
     {
         $e1 = $this->createHotObservable(
             [
@@ -1223,7 +1223,7 @@ class WithLatestFromTest extends FunctionalTestCase
         ], $e3->getSubscriptions());
     }
 
-    public function testWithLatestFrom_multiple_with_selector()
+    public function testWithLatestFrom_multiple_with_selector(): void
     {
         $e1 = $this->createHotObservable(
             [

--- a/test/Rx/Functional/Operator/WithLatestFromTest.php
+++ b/test/Rx/Functional/Operator/WithLatestFromTest.php
@@ -1059,7 +1059,7 @@ class WithLatestFromTest extends FunctionalTestCase
         );
 
         $results = $this->scheduler->startWithCreate(function () use ($e1, $e2) {
-            return $e1->withLatestFrom([$e2], function () {
+            return $e1->withLatestFrom([$e2], function (): void {
                 throw new \Exception();
             });
         });

--- a/test/Rx/Functional/Operator/ZipTest.php
+++ b/test/Rx/Functional/Operator/ZipTest.php
@@ -429,7 +429,7 @@ class ZipTest extends FunctionalTestCase
         $result = null;
 
         $source->toArray()->subscribe(new CallbackObserver(
-            function ($x) use (&$result) {
+            function ($x) use (&$result): void {
                 $result = $x;
             }
         ));
@@ -446,7 +446,7 @@ class ZipTest extends FunctionalTestCase
         $result = null;
 
         $source->count()->subscribe(new CallbackObserver(
-            function ($x) use (&$result) {
+            function ($x) use (&$result): void {
                 $result = $x;
             }
         ));

--- a/test/Rx/Functional/Operator/ZipTest.php
+++ b/test/Rx/Functional/Operator/ZipTest.php
@@ -12,7 +12,7 @@ use Rx\Scheduler\ImmediateScheduler;
 
 class ZipTest extends FunctionalTestCase
 {
-    public function testZipNArySymmetric()
+    public function testZipNArySymmetric(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -55,7 +55,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 420)], $e0->getSubscriptions());
     }
 
-    public function testZipNArySymmetricSelector()
+    public function testZipNArySymmetricSelector(): void
     {
         $e0 = $this->createHotObservable([
             onNext(150, 1),
@@ -100,7 +100,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertSubscriptions([subscribe(200, 420)], $e0->getSubscriptions());
     }
 
-    public function testZipNeverNever()
+    public function testZipNeverNever(): void
     {
         $o1 = new NeverObservable();
         $o2 = new NeverObservable();
@@ -112,7 +112,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testZipNeverEmpty()
+    public function testZipNeverEmpty(): void
     {
         $o1 = new NeverObservable();
         $o2 = $this->createHotObservable([
@@ -127,7 +127,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testZipEmptyEmpty()
+    public function testZipEmptyEmpty(): void
     {
         $o1 = $this->createHotObservable([
             onNext(150, 1),
@@ -145,7 +145,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertMessages([onCompleted(210)], $results->getMessages());
     }
 
-    public function testZipEmptyNonEmpty()
+    public function testZipEmptyNonEmpty(): void
     {
         $o1 = $this->createHotObservable([
             onNext(150, 1),
@@ -164,7 +164,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertMessages([onCompleted(215)], $results->getMessages());
     }
 
-    public function testZipNonEmptyEmpty()
+    public function testZipNonEmptyEmpty(): void
     {
         $e1 = $this->createHotObservable([
             onNext(150, 1),
@@ -183,7 +183,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertMessages([onCompleted(215)], $results->getMessages());
     }
 
-    public function testZipNeverNonEmpty()
+    public function testZipNeverNonEmpty(): void
     {
         $e1 = $this->createHotObservable([
             onNext(150, 1),
@@ -199,7 +199,7 @@ class ZipTest extends FunctionalTestCase
         $this->assertMessages([], $results->getMessages());
     }
 
-    public function testZipEmptyError()
+    public function testZipEmptyError(): void
     {
         $error = new \Exception();
 
@@ -221,7 +221,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipNeverError()
+    public function testZipNeverError(): void
     {
         $error = new \Exception();
 
@@ -240,7 +240,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipErrorError()
+    public function testZipErrorError(): void
     {
         $error1 = new \Exception("error1");
         $error2 = new \Exception("error2");
@@ -263,7 +263,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipSomeError()
+    public function testZipSomeError(): void
     {
         $error = new \Exception();
 
@@ -286,7 +286,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipSomeDataAsymmetric()
+    public function testZipSomeDataAsymmetric(): void
     {
         $msgs1 = [
             onNext(205, 0),
@@ -316,7 +316,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipSomeDataSymmetric()
+    public function testZipSomeDataSymmetric(): void
     {
         $msgs1 = [
             onNext(205, 0),
@@ -344,7 +344,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipSelectorThrows()
+    public function testZipSelectorThrows(): void
     {
         $error = new \Exception();
 
@@ -377,7 +377,7 @@ class ZipTest extends FunctionalTestCase
         ], $results->getMessages());
     }
 
-    public function testZipRightCompletesFirst()
+    public function testZipRightCompletesFirst(): void
     {
         $o = $this->createHotObservable([
             onNext(150, 1),
@@ -414,7 +414,7 @@ class ZipTest extends FunctionalTestCase
         return $x + $y;
     }
 
-    public function testZipWithImmediateScheduler()
+    public function testZipWithImmediateScheduler(): void
     {
         $scheduler = new ImmediateScheduler();
 

--- a/test/Rx/Functional/Promise/FromPromiseTest.php
+++ b/test/Rx/Functional/Promise/FromPromiseTest.php
@@ -16,7 +16,7 @@ class FromPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function from_promise_success()
+    public function from_promise_success(): void
     {
         $p = \React\Promise\resolve(42);
 
@@ -38,7 +38,7 @@ class FromPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function from_promise_failure()
+    public function from_promise_failure(): void
     {
         $p = \React\Promise\reject(new RejectedPromiseException('error'));
 
@@ -59,7 +59,7 @@ class FromPromiseTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function two_observables_one_delayed()
+    public function two_observables_one_delayed(): void
     {
         $p = \React\Promise\resolve(1);
 

--- a/test/Rx/Functional/Promise/FromPromiseTest.php
+++ b/test/Rx/Functional/Promise/FromPromiseTest.php
@@ -23,13 +23,13 @@ class FromPromiseTest extends FunctionalTestCase
         $source = Observable::fromPromise($p);
 
         $source->subscribe(
-            function ($x) {
+            function ($x): void {
                 $this->assertEquals(42, $x);
             },
-            function ($error) {
+            function ($error): void {
                 $this->assertFalse(true);
             },
-            function () {
+            function (): void {
                 $this->assertTrue(true);
             });
     }
@@ -45,13 +45,13 @@ class FromPromiseTest extends FunctionalTestCase
         $source = Observable::fromPromise($p);
 
         $source->subscribe(
-            function ($x) {
+            function ($x): void {
                 $this->assertFalse(true);
             },
-            function (Exception $error) {
+            function (Exception $error): void {
                 $this->assertInstanceOf(RejectedPromiseException::class, $error);
             },
-            function () {
+            function (): void {
                 $this->assertFalse(true);
             });
     }

--- a/test/Rx/Functional/Promise/ToPromiseTest.php
+++ b/test/Rx/Functional/Promise/ToPromiseTest.php
@@ -20,7 +20,7 @@ class ToPromiseTest extends FunctionalTestCase
 
         $result = null;
 
-        $promise->then(function ($value) use (&$result) {
+        $promise->then(function ($value) use (&$result): void {
             $result = $value;
         });
 
@@ -38,9 +38,9 @@ class ToPromiseTest extends FunctionalTestCase
         $error = null;
 
         $promise->then(
-            function () {
+            function (): void {
             },
-            function ($ex) use (&$error) {
+            function ($ex) use (&$error): void {
                 $error = $ex;
             });
 
@@ -59,7 +59,7 @@ class ToPromiseTest extends FunctionalTestCase
 
         $result = null;
 
-        $promise2->then(function ($value) use (&$result) {
+        $promise2->then(function ($value) use (&$result): void {
             $result = $value;
         });
 
@@ -79,9 +79,9 @@ class ToPromiseTest extends FunctionalTestCase
         $error = null;
 
         $promise2->then(
-            function () {
+            function (): void {
             },
-            function (Exception $ex) use (&$error) {
+            function (Exception $ex) use (&$error): void {
                 $error = $ex;
             });
 
@@ -98,7 +98,7 @@ class ToPromiseTest extends FunctionalTestCase
 
         $promise = Observable::timer(1000)
             ->mapTo(42)
-            ->finally(function () use (&$disposed) {
+            ->finally(function () use (&$disposed): void {
                 $disposed = true;
             })
             ->toPromise();
@@ -107,7 +107,7 @@ class ToPromiseTest extends FunctionalTestCase
 
         $promise->cancel();
 
-        $promise->then(function ($value) use (&$result) {
+        $promise->then(function ($value) use (&$result): void {
             $result = $value;
         });
 

--- a/test/Rx/Functional/Promise/ToPromiseTest.php
+++ b/test/Rx/Functional/Promise/ToPromiseTest.php
@@ -14,7 +14,7 @@ class ToPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_success()
+    public function promise_success(): void
     {
         $promise = Observable::of(42)->toPromise();
 
@@ -31,7 +31,7 @@ class ToPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_failure()
+    public function promise_failure(): void
     {
         $promise = Observable::error(new Exception('some error'))->toPromise();
 
@@ -51,7 +51,7 @@ class ToPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_within_promise_success()
+    public function promise_within_promise_success(): void
     {
         $promise1 = \React\Promise\resolve(42);
 
@@ -70,7 +70,7 @@ class ToPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_within_promise_failure()
+    public function promise_within_promise_failure(): void
     {
         $promise1 = \React\Promise\reject(new Exception('some error'));
 
@@ -92,7 +92,7 @@ class ToPromiseTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_cancel()
+    public function promise_cancel(): void
     {
         $disposed = false;
 

--- a/test/Rx/Functional/React/PromiseFactoryTest.php
+++ b/test/Rx/Functional/React/PromiseFactoryTest.php
@@ -13,7 +13,7 @@ class PromiseFactoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function from_promise_success()
+    public function from_promise_success(): void
     {
         $source = PromiseFactory::toObservable(function() {
             return Promise::resolved(42);
@@ -32,7 +32,7 @@ class PromiseFactoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function from_promise_reject_non_exception()
+    public function from_promise_reject_non_exception(): void
     {
         $source = PromiseFactory::toObservable(function () {
             return Promise::rejected(42);
@@ -58,7 +58,7 @@ class PromiseFactoryTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function from_promise_reject()
+    public function from_promise_reject(): void
     {
         $error = new Exception("Test exception");
 

--- a/test/Rx/Functional/React/PromiseFactoryTest.php
+++ b/test/Rx/Functional/React/PromiseFactoryTest.php
@@ -23,10 +23,10 @@ class PromiseFactoryTest extends FunctionalTestCase
             return $source;
         });
 
-        $this->assertMessages(array(
+        $this->assertMessages([
             onNext(200, 42),
             onCompleted(200),
-        ), $results->getMessages());
+        ], $results->getMessages());
     }
 
     /**
@@ -42,7 +42,7 @@ class PromiseFactoryTest extends FunctionalTestCase
 
         $source->subscribe(
             [$this, 'fail'],
-            function ($err) use (&$theException) {
+            function ($err) use (&$theException): void {
                 $theException = $err;
             },
             [$this, 'fail'],
@@ -70,7 +70,7 @@ class PromiseFactoryTest extends FunctionalTestCase
 
         $source->subscribe(
             [$this, 'fail'],
-            function ($err) use (&$theException) {
+            function ($err) use (&$theException): void {
                 $theException = $err;
             },
             [$this, 'fail'],

--- a/test/Rx/Functional/React/PromiseFromObservableTest.php
+++ b/test/Rx/Functional/React/PromiseFromObservableTest.php
@@ -22,10 +22,10 @@ class PromiseFromObservableTest extends FunctionalTestCase
         $promise = Promise::fromObservable($source);
 
         $promise->then(
-          function ($value) {
+          function ($value): void {
               $this->assertEquals(42, $value);
           },
-          function () {
+          function (): void {
               $this->assertTrue(false);
           });
     }
@@ -42,10 +42,10 @@ class PromiseFromObservableTest extends FunctionalTestCase
         $promise = Promise::fromObservable($source);
 
         $promise->then(
-          function ($value) {
+          function ($value): void {
               $this->assertTrue(false);
           },
-          function ($error) {
+          function ($error): void {
               $this->assertEquals($error, new Exception("some error"));
           });
     }

--- a/test/Rx/Functional/React/PromiseFromObservableTest.php
+++ b/test/Rx/Functional/React/PromiseFromObservableTest.php
@@ -15,7 +15,7 @@ class PromiseFromObservableTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_success()
+    public function promise_success(): void
     {
         $source = Observable::of(42);
 
@@ -34,7 +34,7 @@ class PromiseFromObservableTest extends FunctionalTestCase
      * @test
      *
      */
-    public function promise_failure()
+    public function promise_failure(): void
     {
         $source = (new Subject());
         $source->onError(new Exception("some error"));

--- a/test/Rx/Functional/React/PromiseToObservableTest.php
+++ b/test/Rx/Functional/React/PromiseToObservableTest.php
@@ -16,7 +16,7 @@ class PromiseToObservableTest extends FunctionalTestCase
      * @test
      *
      */
-    public function from_promise_success()
+    public function from_promise_success(): void
     {
         $p = Promise::resolved(42);
 
@@ -38,7 +38,7 @@ class PromiseToObservableTest extends FunctionalTestCase
      * @test
      *
      */
-    public function from_promise_failure()
+    public function from_promise_failure(): void
     {
         $p = new ReactPromise(function (): void {
             1 / 0;
@@ -63,7 +63,7 @@ class PromiseToObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function to_observable_cancels_on_dispose()
+    public function to_observable_cancels_on_dispose(): void
     {
         $canceled = false;
 
@@ -93,7 +93,7 @@ class PromiseToObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function two_observables_one_delayed()
+    public function two_observables_one_delayed(): void
     {
         $canceled = false;
         
@@ -131,7 +131,7 @@ class PromiseToObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function two_observables_one_disposed_before_resolve()
+    public function two_observables_one_disposed_before_resolve(): void
     {
         $canceled = false;
 
@@ -174,7 +174,7 @@ class PromiseToObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function observable_dispose_after_complete()
+    public function observable_dispose_after_complete(): void
     {
         $canceled = false;
 

--- a/test/Rx/Functional/React/PromiseToObservableTest.php
+++ b/test/Rx/Functional/React/PromiseToObservableTest.php
@@ -23,13 +23,13 @@ class PromiseToObservableTest extends FunctionalTestCase
         $source = Promise::toObservable($p);
 
         $source->subscribe(new CallbackObserver(
-          function ($x) {
+          function ($x): void {
               $this->assertEquals(42, $x);
           },
-          function ($error) {
+          function ($error): void {
               $this->assertFalse(true);
           },
-          function () {
+          function (): void {
               $this->assertTrue(true);
           }));
     }
@@ -40,21 +40,21 @@ class PromiseToObservableTest extends FunctionalTestCase
      */
     public function from_promise_failure()
     {
-        $p = new ReactPromise(function () {
+        $p = new ReactPromise(function (): void {
             1 / 0;
         });
 
         $source = Promise::toObservable($p);
 
         $source->subscribe(new CallbackObserver(
-          function ($x) {
+          function ($x): void {
               $this->assertFalse(true);
 
           },
-          function (\Throwable $error) {
+          function (\Throwable $error): void {
               $this->assertStringContainsStringIgnoringCase('division by zero', $error->getMessage());
           },
-          function () {
+          function (): void {
               $this->assertFalse(true);
           }));
 
@@ -67,13 +67,13 @@ class PromiseToObservableTest extends FunctionalTestCase
     {
         $canceled = false;
 
-        $deferred = new Deferred(function () use (&$canceled) {
+        $deferred = new Deferred(function () use (&$canceled): void {
             $canceled = true;
         });
 
         $o = Promise::toObservable($deferred->promise());
 
-        $this->scheduler->schedule(function () use ($deferred) {
+        $this->scheduler->schedule(function () use ($deferred): void {
             $deferred->resolve(1);
         }, 300);
         
@@ -97,7 +97,7 @@ class PromiseToObservableTest extends FunctionalTestCase
     {
         $canceled = false;
         
-        $deferred = new Deferred(function () use (&$canceled) {
+        $deferred = new Deferred(function () use (&$canceled): void {
             $canceled = true;
         });
         
@@ -135,14 +135,14 @@ class PromiseToObservableTest extends FunctionalTestCase
     {
         $canceled = false;
 
-        $deferred = new Deferred(function () use (&$canceled) {
+        $deferred = new Deferred(function () use (&$canceled): void {
             $canceled = true;
         });
 
         $o1 = Promise::toObservable($deferred->promise());
         $o2 = Promise::toObservable($deferred->promise())->delay(100, $this->scheduler);
 
-        $this->scheduler->schedule(function () use ($deferred) {
+        $this->scheduler->schedule(function () use ($deferred): void {
             $deferred->resolve(1);
         }, 100);
         
@@ -151,7 +151,7 @@ class PromiseToObservableTest extends FunctionalTestCase
 
         $s1 = $o1->subscribe($results1);
         
-        $this->scheduler->schedule(function () use ($s1) {
+        $this->scheduler->schedule(function () use ($s1): void {
             $s1->dispose();
         }, 50);
 
@@ -178,13 +178,13 @@ class PromiseToObservableTest extends FunctionalTestCase
     {
         $canceled = false;
 
-        $deferred = new Deferred(function () use (&$canceled) {
+        $deferred = new Deferred(function () use (&$canceled): void {
             $canceled = true;
         });
 
         $o = Promise::toObservable($deferred->promise());
         
-        $this->scheduler->schedule(function () use ($deferred) {
+        $this->scheduler->schedule(function () use ($deferred): void {
             $deferred->resolve(1);
         }, 200);
         
@@ -192,7 +192,7 @@ class PromiseToObservableTest extends FunctionalTestCase
 
         $s = $o->subscribe($results);
 
-        $this->scheduler->schedule(function () use ($s) {
+        $this->scheduler->schedule(function () use ($s): void {
             $s->dispose();
         }, 250);
         

--- a/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
@@ -22,13 +22,13 @@ class EventLoopSchedulerTest extends FunctionalTestCase
         Observable::interval(50, new EventLoopScheduler($loop))
             ->take(1)
             ->subscribe(new CallbackObserver(
-                function ($x) use (&$nextCount) {
+                function ($x) use (&$nextCount): void {
                     $nextCount++;
                 },
-                function ($err) {
+                function ($err): void {
                     throw $err;
                 },
-                function () use (&$completed) {
+                function () use (&$completed): void {
                     $completed = true;
                 }
             ));

--- a/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Functional/Scheduler/EventLoopSchedulerTest.php
@@ -12,7 +12,7 @@ use Rx\Scheduler\EventLoopScheduler;
 
 class EventLoopSchedulerTest extends FunctionalTestCase
 {
-    public function testDisposeInsideFirstSchedulePeriodicAction()
+    public function testDisposeInsideFirstSchedulePeriodicAction(): void
     {
         $completed = false;
         $nextCount = 0;

--- a/test/Rx/Functional/Subject/AsyncSubjectTest.php
+++ b/test/Rx/Functional/Subject/AsyncSubjectTest.php
@@ -42,43 +42,43 @@ class AsyncSubjectTest extends FunctionalTestCase
         $subscription2 = null;
         $subscription3 = null;
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$subject): void {
             $subject = new AsyncSubject();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use ($xs, &$subscription, &$subject) {
+        $this->scheduler->scheduleAbsolute(200, function () use ($xs, &$subscription, &$subject): void {
             $subscription = $xs->subscribe($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$results1, &$subscription1, &$subject) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$results1, &$subscription1, &$subject): void {
             $subscription1 = $subject->subscribe($results1);
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$results2, &$subscription2, &$subject) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$results2, &$subscription2, &$subject): void {
             $subscription2 = $subject->subscribe($results2);
         });
 
-        $this->scheduler->scheduleAbsolute(900, function () use (&$results3, &$subscription3, &$subject) {
+        $this->scheduler->scheduleAbsolute(900, function () use (&$results3, &$subscription3, &$subject): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsolute(950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -118,43 +118,43 @@ class AsyncSubjectTest extends FunctionalTestCase
         $subscription2 = null;
         $subscription3 = null;
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$subject): void {
             $subject = new AsyncSubject();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use ($xs, &$subscription, &$subject) {
+        $this->scheduler->scheduleAbsolute(200, function () use ($xs, &$subscription, &$subject): void {
             $subscription = $xs->subscribe($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$results1, &$subscription1, &$subject) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$results1, &$subscription1, &$subject): void {
             $subscription1 = $subject->subscribe($results1);
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$results2, &$subscription2, &$subject) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$results2, &$subscription2, &$subject): void {
             $subscription2 = $subject->subscribe($results2);
         });
 
-        $this->scheduler->scheduleAbsolute(900, function () use (&$results3, &$subscription3, &$subject) {
+        $this->scheduler->scheduleAbsolute(900, function () use (&$results3, &$subscription3, &$subject): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsolute(950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -195,43 +195,43 @@ class AsyncSubjectTest extends FunctionalTestCase
         $subscription2 = null;
         $subscription3 = null;
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$subject): void {
             $subject = new AsyncSubject();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use ($xs, &$subscription, &$subject) {
+        $this->scheduler->scheduleAbsolute(200, function () use ($xs, &$subscription, &$subject): void {
             $subscription = $xs->subscribe($subject);
         });
 
-        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsolute(1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$results1, &$subscription1, &$subject) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$results1, &$subscription1, &$subject): void {
             $subscription1 = $subject->subscribe($results1);
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$results2, &$subscription2, &$subject) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$results2, &$subscription2, &$subject): void {
             $subscription2 = $subject->subscribe($results2);
         });
 
-        $this->scheduler->scheduleAbsolute(900, function () use (&$results3, &$subscription3, &$subject) {
+        $this->scheduler->scheduleAbsolute(900, function () use (&$results3, &$subscription3, &$subject): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
-        $this->scheduler->scheduleAbsolute(950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsolute(950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -260,88 +260,88 @@ class AsyncSubjectTest extends FunctionalTestCase
         $subscription2 = null;
         $subscription3 = null;
 
-        $this->scheduler->scheduleAbsolute(100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(100, function () use (&$subject): void {
             $subject = new AsyncSubject();
         });
 
-        $this->scheduler->scheduleAbsolute(200, function () use (&$subscription1, &$subject, $results1) {
+        $this->scheduler->scheduleAbsolute(200, function () use (&$subscription1, &$subject, $results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
 
 
-        $this->scheduler->scheduleAbsolute(300, function () use (&$subscription2, &$subject, $results2) {
+        $this->scheduler->scheduleAbsolute(300, function () use (&$subscription2, &$subject, $results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
 
-        $this->scheduler->scheduleAbsolute(400, function () use (&$subscription3, &$subject, $results3) {
+        $this->scheduler->scheduleAbsolute(400, function () use (&$subscription3, &$subject, $results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
 
-        $this->scheduler->scheduleAbsolute(500, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsolute(500, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
 
 
-        $this->scheduler->scheduleAbsolute(600, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(600, function () use (&$subject): void {
             $subject->dispose();
         });
 
 
-        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsolute(700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
 
 
-        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsolute(800, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
 
-        $this->scheduler->scheduleAbsolute(150, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(150, function () use (&$subject): void {
             $subject->onNext(1);
         });
 
-        $this->scheduler->scheduleAbsolute(250, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(250, function () use (&$subject): void {
             $subject->onNext(2);
         });
 
-        $this->scheduler->scheduleAbsolute(350, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(350, function () use (&$subject): void {
             $subject->onNext(3);
         });
 
-        $this->scheduler->scheduleAbsolute(450, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(450, function () use (&$subject): void {
             $subject->onNext(4);
         });
 
-        $this->scheduler->scheduleAbsolute(550, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(550, function () use (&$subject): void {
             $subject->onNext(5);
         });
 
-        $this->scheduler->scheduleAbsolute(650, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(650, function () use (&$subject): void {
 
-            $this->assertException(function () use (&$subject) {
+            $this->assertException(function () use (&$subject): void {
                 $subject->onNext(6);
             });
 
         });
 
-        $this->scheduler->scheduleAbsolute(750, function () use (&$subject) {
-            $this->assertException(function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(750, function () use (&$subject): void {
+            $this->assertException(function () use (&$subject): void {
                 $subject->onCompleted();
             });
         });
 
-        $this->scheduler->scheduleAbsolute(850, function () use (&$subject) {
-            $this->assertException(function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(850, function () use (&$subject): void {
+            $this->assertException(function () use (&$subject): void {
                 $subject->onError(new \Exception());
             });
 
         });
 
-        $this->scheduler->scheduleAbsolute(950, function () use (&$subject) {
+        $this->scheduler->scheduleAbsolute(950, function () use (&$subject): void {
 
-            $this->assertException(function () use (&$subject) {
+            $this->assertException(function () use (&$subject): void {
                 $subject->subscribe(new CallbackObserver());
             });
         });

--- a/test/Rx/Functional/Subject/AsyncSubjectTest.php
+++ b/test/Rx/Functional/Subject/AsyncSubjectTest.php
@@ -15,7 +15,7 @@ class AsyncSubjectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function infinite()
+    public function infinite(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -92,7 +92,7 @@ class AsyncSubjectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function finite()
+    public function finite(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -169,7 +169,7 @@ class AsyncSubjectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function error()
+    public function error(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -247,7 +247,7 @@ class AsyncSubjectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function dispose()
+    public function dispose(): void
     {
 
 

--- a/test/Rx/Functional/Subject/ReplaySubjectTest.php
+++ b/test/Rx/Functional/Subject/ReplaySubjectTest.php
@@ -34,36 +34,36 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $results3 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(3, 100, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subscription, &$xs, &$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subscription, &$xs, &$subject): void {
             $subscription = $xs->subscribe($subject);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subscription1, &$subject, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subscription1, &$subject, &$results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subscription2, &$subject, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subscription2, &$subject, &$results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subscription3, &$subject, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subscription3, &$subject, &$results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -123,36 +123,36 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $results3 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(3, 100, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs): void {
             $subscription = $xs->subscribe($subject);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -207,36 +207,36 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $results3 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(3, 100, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs): void {
             $subscription = $xs->subscribe($subject);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -284,36 +284,36 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $results3 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(3, 100, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs): void {
             $subscription = $xs->subscribe($subject);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -352,36 +352,36 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $results3 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(3, 100, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription, $xs): void {
             $subscription = $xs->subscribe($subject);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 1000, function () use (&$subscription): void {
             $subscription->dispose();
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription1, &$results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription2, &$results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$subscription3, &$results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
@@ -405,63 +405,63 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results2 = $this->scheduler->createObserver();
         $results3 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(null, null, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription1, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use (&$subject, &$subscription1, &$results1): void {
             $subscription1 = $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription2, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$subscription2, &$results2): void {
             $subscription2 = $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription3, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$subscription3, &$results3): void {
             $subscription3 = $subject->subscribe($results3);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 500, function () use (&$subject, &$subscription1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 500, function () use (&$subject, &$subscription1): void {
             $subscription1->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subject): void {
             $subject->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 700, function () use (&$subscription2): void {
             $subscription2->dispose();
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 800, function () use (&$subscription3): void {
             $subscription3->dispose();
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 150, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 150, function () use (&$subject): void {
             $subject->onNext(1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 250, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 250, function () use (&$subject): void {
             $subject->onNext(2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 350, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 350, function () use (&$subject): void {
             $subject->onNext(3);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 450, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 450, function () use (&$subject): void {
             $subject->onNext(4);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 550, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 550, function () use (&$subject): void {
             $subject->onNext(5);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 650, function () use (&$subject) {
-            $this->assertException(function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 650, function () use (&$subject): void {
+            $this->assertException(function () use (&$subject): void {
                 $subject->onNext(6);
             });
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 750, function () use (&$subject) {
-            $this->assertException(function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 750, function () use (&$subject): void {
+            $this->assertException(function () use (&$subject): void {
                 $subject->onCompleted();
             });
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 850, function () use (&$subject) {
-            $this->assertException(function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 850, function () use (&$subject): void {
+            $this->assertException(function () use (&$subject): void {
                 $subject->onError(new \Exception());
             });
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subject) {
-            $this->assertException(function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 950, function () use (&$subject): void {
+            $this->assertException(function () use (&$subject): void {
                 $subject->subscribe(new CallbackObserver());
             });
         });
@@ -512,23 +512,23 @@ class ReplaySubjectTest extends FunctionalTestCase
         $results3 = $this->scheduler->createObserver();
         $results4 = $this->scheduler->createObserver();
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 100, function () use (&$subject): void {
             $subject = new ReplaySubject(9007199254740991, 100, $this->scheduler);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use ($xs, &$subject) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 200, function () use ($xs, &$subject): void {
             $xs->subscribe($subject);
         });
 
-        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$results1) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 300, function () use (&$subject, &$results1): void {
             $subject->subscribe($results1);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$results2) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 400, function () use (&$subject, &$results2): void {
             $subject->subscribe($results2);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subject, &$results3) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 600, function () use (&$subject, &$results3): void {
             $subject->subscribe($results3);
         });
-        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$results4) {
+        $this->scheduler->scheduleAbsoluteWithState(null, 900, function () use (&$subject, &$results4): void {
             $subject->subscribe($results4);
         });
 
@@ -575,13 +575,13 @@ class ReplaySubjectTest extends FunctionalTestCase
         $result = [];
         $completed = false;
 
-        $rs->subscribe(function ($x) use (&$result) {
+        $rs->subscribe(function ($x) use (&$result): void {
                 $result[] = $x;
             },
-            function ($e) {
+            function ($e): void {
                 $this->fail('Should not have failed');
             },
-            function () use (&$result, &$completed) {
+            function () use (&$result, &$completed): void {
                 $completed = true;
                 $this->assertEquals($result, range(1,5));
             }

--- a/test/Rx/Functional/Subject/ReplaySubjectTest.php
+++ b/test/Rx/Functional/Subject/ReplaySubjectTest.php
@@ -12,7 +12,7 @@ use Rx\Subject\ReplaySubject;
 
 class ReplaySubjectTest extends FunctionalTestCase
 {
-    public function testInfinite()
+    public function testInfinite(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -99,7 +99,7 @@ class ReplaySubjectTest extends FunctionalTestCase
         );
     }
 
-    public function testInfinite2()
+    public function testInfinite2(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -186,7 +186,7 @@ class ReplaySubjectTest extends FunctionalTestCase
 
     }
 
-    public function testFinite()
+    public function testFinite(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -262,7 +262,7 @@ class ReplaySubjectTest extends FunctionalTestCase
 
     }
 
-    public function testError()
+    public function testError(): void
     {
         $error = new \Exception();
 
@@ -339,7 +339,7 @@ class ReplaySubjectTest extends FunctionalTestCase
         ], $results3->getMessages());
     }
 
-    public function testCanceled()
+    public function testCanceled(): void
     {
         $xs = $this->createHotObservable([
           onCompleted(630),
@@ -399,7 +399,7 @@ class ReplaySubjectTest extends FunctionalTestCase
 
     }
 
-    public function testDisposed()
+    public function testDisposed(): void
     {
         $results1 = $this->scheduler->createObserver();
         $results2 = $this->scheduler->createObserver();
@@ -493,7 +493,7 @@ class ReplaySubjectTest extends FunctionalTestCase
 
     }
 
-    public function testDiesOut()
+    public function testDiesOut(): void
     {
         $xs = $this->createHotObservable([
           onNext(70, 1),
@@ -565,7 +565,7 @@ class ReplaySubjectTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function it_replays_with_immediate_scheduler() {
+    public function it_replays_with_immediate_scheduler(): void {
         $rs = new ReplaySubject();
 
         $o = Observable::fromArray(range(1,5));

--- a/test/Rx/Observable/AnonymousObservableTest.php
+++ b/test/Rx/Observable/AnonymousObservableTest.php
@@ -19,7 +19,7 @@ class AnonymousObservableTest extends TestCase
         $called = 0;
         $observable = new AnonymousObservable(function() use (&$called) { $called++; return new EmptyDisposable(); });
 
-        $observerMock = $this->createMock('Rx\ObserverInterface');
+        $observerMock = $this->createMock(\Rx\ObserverInterface::class);
         $observable->subscribe($observerMock);
 
         $this->assertEquals(1, $called);
@@ -33,12 +33,12 @@ class AnonymousObservableTest extends TestCase
         $disposed = false;
 
         $observable = new AnonymousObservable(function() use (&$disposed) {
-            return new CallbackDisposable(function() use (&$disposed) {
+            return new CallbackDisposable(function() use (&$disposed): void {
                 $disposed = true;
             });
         });
 
-        $observerMock = $this->createMock('Rx\ObserverInterface');
+        $observerMock = $this->createMock(\Rx\ObserverInterface::class);
         $disposable = $observable->subscribe($observerMock);
 
         $disposable->dispose();
@@ -52,7 +52,7 @@ class AnonymousObservableTest extends TestCase
     public function it_throws_when_args_invalid()
     {
         $this->expectException(\InvalidArgumentException::class);
-        $observable = new AnonymousObservable(function () {
+        $observable = new AnonymousObservable(function (): void {
         });
 
         $observable->subscribe('invalid arg');

--- a/test/Rx/Observable/AnonymousObservableTest.php
+++ b/test/Rx/Observable/AnonymousObservableTest.php
@@ -14,7 +14,7 @@ class AnonymousObservableTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_subscribe_action_on_subscribe()
+    public function it_calls_the_subscribe_action_on_subscribe(): void
     {
         $called = 0;
         $observable = new AnonymousObservable(function() use (&$called) { $called++; return new EmptyDisposable(); });
@@ -28,7 +28,7 @@ class AnonymousObservableTest extends TestCase
     /**
      * @test
      */
-    public function the_returned_disposable_disposes()
+    public function the_returned_disposable_disposes(): void
     {
         $disposed = false;
 
@@ -49,7 +49,7 @@ class AnonymousObservableTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_when_args_invalid()
+    public function it_throws_when_args_invalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $observable = new AnonymousObservable(function (): void {

--- a/test/Rx/Observable/ArrayObservableTest.php
+++ b/test/Rx/Observable/ArrayObservableTest.php
@@ -22,14 +22,14 @@ class ArrayObservableTest extends TestCase
         $goodCount = 0;
 
         $o->toArray()->subscribe(new CallbackObserver(
-            function ($x) use ($a, &$goodCount) {
+            function ($x) use ($a, &$goodCount): void {
                 $goodCount++;
                 $this->assertEquals($a, $x);
             }
         ));
 
         $o->toArray()->subscribe(new CallbackObserver(
-            function ($x) use ($a, &$goodCount) {
+            function ($x) use ($a, &$goodCount): void {
                 $goodCount++;
                 $this->assertEquals($a, $x);
             }
@@ -43,8 +43,8 @@ class ArrayObservableTest extends TestCase
         //todo: refactor
         $observable = new ArrayObservable(range(1, 10), Scheduler::getDefault());
 
-        $record = array();
-        $observable->subscribe(function($v) use (&$record) {$record[] = $v; });
+        $record = [];
+        $observable->subscribe(function($v) use (&$record): void {$record[] = $v; });
 
         $this->assertEquals(range(1, 10), $record);
     }
@@ -52,10 +52,10 @@ class ArrayObservableTest extends TestCase
     public function testOnCompleteIsCalled()
     {
         //todo: refactor
-        $observable = new ArrayObservable(array(), Scheduler::getDefault());
+        $observable = new ArrayObservable([], Scheduler::getDefault());
 
         $isCalled = false;
-        $observable->subscribe(null, null, function() use (&$isCalled) { $isCalled = true; });
+        $observable->subscribe(null, null, function() use (&$isCalled): void { $isCalled = true; });
 
         $this->assertTrue($isCalled, 'onComplete should be called.');
     }

--- a/test/Rx/Observable/ArrayObservableTest.php
+++ b/test/Rx/Observable/ArrayObservableTest.php
@@ -13,7 +13,7 @@ class ArrayObservableTest extends TestCase
     /**
      * @test
      */
-    public function it_starts_again_if_you_subscribe_again()
+    public function it_starts_again_if_you_subscribe_again(): void
     {
         $a = [1,2,3];
 
@@ -38,7 +38,7 @@ class ArrayObservableTest extends TestCase
         $this->assertEquals(2, $goodCount);
     }
 
-    public function testRange()
+    public function testRange(): void
     {
         //todo: refactor
         $observable = new ArrayObservable(range(1, 10), Scheduler::getDefault());
@@ -49,7 +49,7 @@ class ArrayObservableTest extends TestCase
         $this->assertEquals(range(1, 10), $record);
     }
 
-    public function testOnCompleteIsCalled()
+    public function testOnCompleteIsCalled(): void
     {
         //todo: refactor
         $observable = new ArrayObservable([], Scheduler::getDefault());

--- a/test/Rx/Observable/ConnectableObservableTest.php
+++ b/test/Rx/Observable/ConnectableObservableTest.php
@@ -16,7 +16,7 @@ class ConnectableObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function connectable_observable_creation()
+    public function connectable_observable_creation(): void
     {
         $y   = 0;
         $s2  = new Subject();
@@ -37,7 +37,7 @@ class ConnectableObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function connectable_observable_connected()
+    public function connectable_observable_connected(): void
     {
         $xs = $this->createHotObservable(
           [
@@ -73,7 +73,7 @@ class ConnectableObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function connectable_observable_disconnected()
+    public function connectable_observable_disconnected(): void
     {
         $xs = $this->createHotObservable(
           [
@@ -101,7 +101,7 @@ class ConnectableObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function connectable_observable_disconnect_future()
+    public function connectable_observable_disconnect_future(): void
     {
         $xs = $this->createHotObservable(
           [
@@ -134,7 +134,7 @@ class ConnectableObservableTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function connectable_observable_multiple_non_overlapped_connections()
+    public function connectable_observable_multiple_non_overlapped_connections(): void
     {
         $xs = $this->createHotObservable(
           [

--- a/test/Rx/Observable/ConnectableObservableTest.php
+++ b/test/Rx/Observable/ConnectableObservableTest.php
@@ -22,7 +22,7 @@ class ConnectableObservableTest extends FunctionalTestCase
         $s2  = new Subject();
         $co2 = new ConnectableObservable(Observable::of(1), $s2);
 
-        $co2->subscribe(new CallbackObserver(function ($x) use (&$y) {
+        $co2->subscribe(new CallbackObserver(function ($x) use (&$y): void {
             $y = $x;
         }));
 
@@ -155,21 +155,21 @@ class ConnectableObservableTest extends FunctionalTestCase
         $conn = $xs->multicast($subject);
 
         $c1 = null;
-        $this->scheduler->scheduleAbsolute(225, function () use(&$c1, $conn){ $c1 = $conn->connect(); });
-        $this->scheduler->scheduleAbsolute(241, function () use(&$c1){ $c1->dispose(); });
-        $this->scheduler->scheduleAbsolute(245, function () use(&$c1){ $c1->dispose(); }); // idempotency test
-        $this->scheduler->scheduleAbsolute(251, function () use(&$c1){ $c1->dispose(); }); // idempotency test
-        $this->scheduler->scheduleAbsolute(260, function () use(&$c1){ $c1->dispose(); }); // idempotency test
+        $this->scheduler->scheduleAbsolute(225, function () use(&$c1, $conn): void{ $c1 = $conn->connect(); });
+        $this->scheduler->scheduleAbsolute(241, function () use(&$c1): void{ $c1->dispose(); });
+        $this->scheduler->scheduleAbsolute(245, function () use(&$c1): void{ $c1->dispose(); }); // idempotency test
+        $this->scheduler->scheduleAbsolute(251, function () use(&$c1): void{ $c1->dispose(); }); // idempotency test
+        $this->scheduler->scheduleAbsolute(260, function () use(&$c1): void{ $c1->dispose(); }); // idempotency test
 
         $c2 = null;
-        $this->scheduler->scheduleAbsolute(249, function () use(&$c2, $conn){ $c2 = $conn->connect(); });
-        $this->scheduler->scheduleAbsolute(255, function () use(&$c2){ $c2->dispose(); });
-        $this->scheduler->scheduleAbsolute(265, function () use(&$c2){ $c2->dispose(); }); // idempotency test
-        $this->scheduler->scheduleAbsolute(280, function () use(&$c2){ $c2->dispose(); }); // idempotency test
+        $this->scheduler->scheduleAbsolute(249, function () use(&$c2, $conn): void{ $c2 = $conn->connect(); });
+        $this->scheduler->scheduleAbsolute(255, function () use(&$c2): void{ $c2->dispose(); });
+        $this->scheduler->scheduleAbsolute(265, function () use(&$c2): void{ $c2->dispose(); }); // idempotency test
+        $this->scheduler->scheduleAbsolute(280, function () use(&$c2): void{ $c2->dispose(); }); // idempotency test
 
         $c3 = null;
-        $this->scheduler->scheduleAbsolute(275, function () use(&$c3, $conn){ $c3 = $conn->connect(); });
-        $this->scheduler->scheduleAbsolute(295, function () use(&$c3){ $c3->dispose(); });
+        $this->scheduler->scheduleAbsolute(275, function () use(&$c3, $conn): void{ $c3 = $conn->connect(); });
+        $this->scheduler->scheduleAbsolute(295, function () use(&$c3): void{ $c3->dispose(); });
 
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $conn) {

--- a/test/Rx/Observable/ErrorObservableTest.php
+++ b/test/Rx/Observable/ErrorObservableTest.php
@@ -18,12 +18,12 @@ class ErrorObservableTest extends TestCase
 
         $recordedException = null;
         $observable->subscribe(
-            function () {
+            function (): void {
             },
-            function ($ex) use (&$recordedException) {
+            function ($ex) use (&$recordedException): void {
                 $recordedException = $ex;
             },
-            function () {
+            function (): void {
             }
         );
 

--- a/test/Rx/Observable/ErrorObservableTest.php
+++ b/test/Rx/Observable/ErrorObservableTest.php
@@ -11,7 +11,7 @@ use Rx\TestCase;
 class ErrorObservableTest extends TestCase
 {
     /** @test */
-    public function it_calls_observers_with_error()
+    public function it_calls_observers_with_error(): void
     {
         $ex         = new RuntimeException('boom!');
         $observable = new ErrorObservable($ex, Scheduler::getDefault());

--- a/test/Rx/Observable/GroupedObservableTest.php
+++ b/test/Rx/Observable/GroupedObservableTest.php
@@ -16,7 +16,7 @@ class GroupedObservableTest extends TestCase
      */
     public function it_returns_the_disposable_of_the_underlying_disposable()
     {
-        $disposable = $this->createMock('Rx\DisposableInterface');
+        $disposable = $this->createMock(\Rx\DisposableInterface::class);
         
         $disposable->expects($this->once())
             ->method('dispose');
@@ -35,7 +35,7 @@ class GroupedObservableTest extends TestCase
      */
     public function it_exposes_its_key()
     {
-        $observable = new AnonymousObservable(function(){});
+        $observable = new AnonymousObservable(function(): void{});
 
         $groupedObservable = new GroupedObservable('key', $observable);
         $this->assertEquals('key', $groupedObservable->getKey());

--- a/test/Rx/Observable/GroupedObservableTest.php
+++ b/test/Rx/Observable/GroupedObservableTest.php
@@ -14,7 +14,7 @@ class GroupedObservableTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_the_disposable_of_the_underlying_disposable()
+    public function it_returns_the_disposable_of_the_underlying_disposable(): void
     {
         $disposable = $this->createMock(\Rx\DisposableInterface::class);
         
@@ -33,7 +33,7 @@ class GroupedObservableTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_its_key()
+    public function it_exposes_its_key(): void
     {
         $observable = new AnonymousObservable(function(): void{});
 

--- a/test/Rx/Observable/RefCountObservableTest.php
+++ b/test/Rx/Observable/RefCountObservableTest.php
@@ -11,7 +11,7 @@ use Rx\TestCase;
 
 class RefCountObservableTest extends TestCase
 {
-    public function testRefCountDisposableOnlyDisposesOnce()
+    public function testRefCountDisposableOnlyDisposesOnce(): void
     {
         $source = $this->createMock(ConnectableObservable::class);
 
@@ -36,7 +36,7 @@ class RefCountObservableTest extends TestCase
 
     }
 
-    public function testDisposesWhenRefcountReachesZero()
+    public function testDisposesWhenRefcountReachesZero(): void
     {
         $source = $this->createMock(ConnectableObservable::class);
 

--- a/test/Rx/ObservableFactoryWrapperTest.php
+++ b/test/Rx/ObservableFactoryWrapperTest.php
@@ -15,7 +15,7 @@ class ObservableFactoryWrapperTest extends TestCase
             return resolve(true);
         });
         $true = null;
-        $afw()->subscribe(function ($v) use (&$true) {
+        $afw()->subscribe(function ($v) use (&$true): void {
             $true = $v;
         });
 
@@ -28,7 +28,7 @@ class ObservableFactoryWrapperTest extends TestCase
             return Observable::fromArray([true], Scheduler::getImmediate());
         });
         $true = null;
-        $afw()->subscribe(function ($v) use (&$true) {
+        $afw()->subscribe(function ($v) use (&$true): void {
             $true = $v;
         });
 

--- a/test/Rx/ObservableFactoryWrapperTest.php
+++ b/test/Rx/ObservableFactoryWrapperTest.php
@@ -9,7 +9,7 @@ use function React\Promise\resolve;
 
 class ObservableFactoryWrapperTest extends TestCase
 {
-    public function testPromiseIsConvertedToObservable()
+    public function testPromiseIsConvertedToObservable(): void
     {
         $afw = new ObservableFactoryWrapper(static function (): PromiseInterface {
             return resolve(true);
@@ -22,7 +22,7 @@ class ObservableFactoryWrapperTest extends TestCase
         self::assertTrue($true);
     }
 
-    public function testObservable()
+    public function testObservable(): void
     {
         $afw = new ObservableFactoryWrapper(static function (): Observable {
             return Observable::fromArray([true], Scheduler::getImmediate());
@@ -35,7 +35,7 @@ class ObservableFactoryWrapperTest extends TestCase
         self::assertTrue($true);
     }
 
-    public function testNotAnObservableOrPromise()
+    public function testNotAnObservableOrPromise(): void
     {
         self::expectException(\Exception::class);
         self::expectExceptionMessageMatches('/You must return an Observable or Promise in/');

--- a/test/Rx/ObservableTest.php
+++ b/test/Rx/ObservableTest.php
@@ -152,7 +152,7 @@ class ObservableTest extends TestCase
             ->setMethods(['catch'])
             ->getMockForAbstractClass();
 
-        $callable = function () {
+        $callable = function (): void {
 
         };
 
@@ -186,7 +186,7 @@ class ObservableTest extends TestCase
      */
     public function it_sends_throwables_in_onnext_to_onerror()
     {
-        $onNext = function ($x) {
+        $onNext = function ($x): void {
             throw new TestException();
         };
 
@@ -195,7 +195,7 @@ class ObservableTest extends TestCase
         Observable::of(0)
             ->subscribe(
                 $onNext,
-                function (\Throwable $e) use (&$error) {
+                function (\Throwable $e) use (&$error): void {
                     $error = $e;
                 }
             );

--- a/test/Rx/ObservableTest.php
+++ b/test/Rx/ObservableTest.php
@@ -14,7 +14,7 @@ use Rx\Testing\TestScheduler;
 
 class ObservableTest extends TestCase
 {
-    public function testJustIsAliasForOf()
+    public function testJustIsAliasForOf(): void
     {
         $o = new class extends Observable {
             private static $ofCalled = false;
@@ -42,7 +42,7 @@ class ObservableTest extends TestCase
         $this->assertTrue($o::ofWasCalled());
     }
 
-    public function testEmptyObservableIsAliasForEmpty()
+    public function testEmptyObservableIsAliasForEmpty(): void
     {
         $o = new class extends Observable {
             private static $emptyCalled = false;
@@ -70,7 +70,7 @@ class ObservableTest extends TestCase
         $this->assertTrue($o::emptyWasCalled());
     }
 
-    public function testShareCallsPublishRefCount()
+    public function testShareCallsPublishRefCount(): void
     {
         $o        = $this->getMockBuilder(Observable::class)
             ->setMethods(['publish'])
@@ -93,7 +93,7 @@ class ObservableTest extends TestCase
         $o->share();
     }
 
-    public function testShareValueCallsPublishValueRefCount()
+    public function testShareValueCallsPublishValueRefCount(): void
     {
         $o        = $this->getMockBuilder(Observable::class)
             ->setMethods(['publishValue'])
@@ -117,7 +117,7 @@ class ObservableTest extends TestCase
         $o->shareValue(1);
     }
 
-    public function testShareReplayCallsReplayRefCount()
+    public function testShareReplayCallsReplayRefCount(): void
     {
         $o        = $this->getMockBuilder(Observable::class)
             ->setMethods(['replay'])
@@ -146,7 +146,7 @@ class ObservableTest extends TestCase
         $o->shareReplay(123, 456);
     }
 
-    public function testCatchErrorCallsCatch()
+    public function testCatchErrorCallsCatch(): void
     {
         $o = $this->getMockBuilder(Observable::class)
             ->setMethods(['catch'])
@@ -167,7 +167,7 @@ class ObservableTest extends TestCase
         $o->catchError($callable);
     }
 
-    public function testSwitchLatestCallsSwitch()
+    public function testSwitchLatestCallsSwitch(): void
     {
         $o = $this->getMockBuilder(Observable::class)
             ->setMethods(['switch'])
@@ -184,7 +184,7 @@ class ObservableTest extends TestCase
     /**
      * @test
      */
-    public function it_sends_throwables_in_onnext_to_onerror()
+    public function it_sends_throwables_in_onnext_to_onerror(): void
     {
         $onNext = function ($x): void {
             throw new TestException();

--- a/test/Rx/ObservableTest.php
+++ b/test/Rx/ObservableTest.php
@@ -24,7 +24,7 @@ class ObservableTest extends TestCase
                 return static::$ofCalled;
             }
 
-            public static function of($value, SchedulerInterface $scheduler = null): ReturnObservable
+            public static function of($value, ?SchedulerInterface $scheduler = null): ReturnObservable
             {
                 static::$ofCalled = true;
                 return new ReturnObservable(123, new ImmediateScheduler());
@@ -52,7 +52,7 @@ class ObservableTest extends TestCase
                 return static::$emptyCalled;
             }
 
-            public static function empty(SchedulerInterface $scheduler = null): EmptyObservable
+            public static function empty(?SchedulerInterface $scheduler = null): EmptyObservable
             {
                 static::$emptyCalled = true;
                 return new EmptyObservable(new TestScheduler());

--- a/test/Rx/Observer/AutoDetachObserverTest.php
+++ b/test/Rx/Observer/AutoDetachObserverTest.php
@@ -13,7 +13,7 @@ class AutoDetachObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_dispose_on_completed()
+    public function it_calls_dispose_on_completed(): void
     {
         $disposed   = false;
         $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
@@ -28,7 +28,7 @@ class AutoDetachObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_dispose_on_error()
+    public function it_calls_dispose_on_error(): void
     {
         $disposed   = false;
         $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
@@ -43,7 +43,7 @@ class AutoDetachObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_if_observer_on_completed_throws()
+    public function it_disposes_if_observer_on_completed_throws(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('fail');
@@ -60,7 +60,7 @@ class AutoDetachObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_if_observer_on_error_throws()
+    public function it_disposes_if_observer_on_error_throws(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('fail');
@@ -77,7 +77,7 @@ class AutoDetachObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_disposes_if_observer_on_next_throws()
+    public function it_disposes_if_observer_on_next_throws(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('fail');

--- a/test/Rx/Observer/AutoDetachObserverTest.php
+++ b/test/Rx/Observer/AutoDetachObserverTest.php
@@ -16,7 +16,7 @@ class AutoDetachObserverTest extends TestCase
     public function it_calls_dispose_on_completed()
     {
         $disposed   = false;
-        $disposable = new CallbackDisposable(function() use (&$disposed){ $disposed = true; });
+        $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
 
         $observer   = new AutoDetachObserver(new CallbackObserver());
         $observer->setDisposable($disposable);
@@ -31,9 +31,9 @@ class AutoDetachObserverTest extends TestCase
     public function it_calls_dispose_on_error()
     {
         $disposed   = false;
-        $disposable = new CallbackDisposable(function() use (&$disposed){ $disposed = true; });
+        $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
 
-        $observer   = new AutoDetachObserver(new CallbackObserver(null, function(){}));
+        $observer   = new AutoDetachObserver(new CallbackObserver(null, function(): void{}));
         $observer->setDisposable($disposable);
 
         $observer->onError(new Exception());
@@ -48,9 +48,9 @@ class AutoDetachObserverTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('fail');
         $disposed   = false;
-        $disposable = new CallbackDisposable(function() use (&$disposed){ $disposed = true; });
+        $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
 
-        $observer   = new AutoDetachObserver(new CallbackObserver(null, null, function() { throw new Exception('fail'); }));
+        $observer   = new AutoDetachObserver(new CallbackObserver(null, null, function(): void { throw new Exception('fail'); }));
         $observer->setDisposable($disposable);
 
         $observer->onCompleted();
@@ -65,9 +65,9 @@ class AutoDetachObserverTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('fail');
         $disposed   = false;
-        $disposable = new CallbackDisposable(function() use (&$disposed){ $disposed = true; });
+        $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
 
-        $observer   = new AutoDetachObserver(new CallbackObserver(null, function() { throw new Exception('fail'); }));
+        $observer   = new AutoDetachObserver(new CallbackObserver(null, function(): void { throw new Exception('fail'); }));
         $observer->setDisposable($disposable);
 
         $observer->onError(new Exception());
@@ -82,9 +82,9 @@ class AutoDetachObserverTest extends TestCase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('fail');
         $disposed   = false;
-        $disposable = new CallbackDisposable(function() use (&$disposed){ $disposed = true; });
+        $disposable = new CallbackDisposable(function() use (&$disposed): void{ $disposed = true; });
 
-        $observer   = new AutoDetachObserver(new CallbackObserver(function() { throw new Exception('fail'); }));
+        $observer   = new AutoDetachObserver(new CallbackObserver(function(): void { throw new Exception('fail'); }));
         $observer->setDisposable($disposable);
 
         $observer->onNext(42);

--- a/test/Rx/Observer/CallbackObserverTest.php
+++ b/test/Rx/Observer/CallbackObserverTest.php
@@ -12,7 +12,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_given_callable_on_next()
+    public function it_calls_the_given_callable_on_next(): void
     {
         $called = false;
         $observer = new CallbackObserver(function() use (&$called): void { $called = true; });
@@ -24,7 +24,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_given_callable_on_error()
+    public function it_calls_the_given_callable_on_error(): void
     {
         $called = false;
         $observer = new CallbackObserver(function(): void{}, function() use (&$called): void { $called = true; });
@@ -36,7 +36,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_given_callable_on_complete()
+    public function it_calls_the_given_callable_on_complete(): void
     {
         $called = false;
         $observer = new CallbackObserver(function(): void{}, function(): void{}, function() use (&$called): void { $called = true; });
@@ -48,7 +48,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function default_on_error_callable_rethrows_exception()
+    public function default_on_error_callable_rethrows_exception(): void
     {
         $this->expectException(\Rx\Observer\TestException::class);
         $observer = new CallbackObserver();
@@ -59,7 +59,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_on_next_with_the_given_value()
+    public function it_calls_on_next_with_the_given_value(): void
     {
         $called = null;
         $observer = new CallbackObserver(function($value) use (&$called): void { $called = $value; });
@@ -72,7 +72,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_next_after_an_error()
+    public function it_does_not_call_on_next_after_an_error(): void
     {
         $called = false;
         $record = function() use (&$called): void { $called = true; };
@@ -89,7 +89,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_completed_after_an_error()
+    public function it_does_not_call_on_completed_after_an_error(): void
     {
         $called = false;
         $record = function() use (&$called): void { $called = true; };
@@ -106,7 +106,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_error_after_an_error()
+    public function it_does_not_call_on_error_after_an_error(): void
     {
         $called = false;
         $record = function() use (&$called): void { $called = true; };
@@ -123,7 +123,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_next_after_completion()
+    public function it_does_not_call_on_next_after_completion(): void
     {
         $called = false;
         $record = function() use (&$called): void { $called = true; };
@@ -140,7 +140,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_completed_after_completion()
+    public function it_does_not_call_on_completed_after_completion(): void
     {
         $called = false;
         $record = function() use (&$called): void { $called = true; };
@@ -157,7 +157,7 @@ class CallbackObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_error_after_completion()
+    public function it_does_not_call_on_error_after_completion(): void
     {
         $called = false;
         $record = function() use (&$called): void { $called = true; };

--- a/test/Rx/Observer/CallbackObserverTest.php
+++ b/test/Rx/Observer/CallbackObserverTest.php
@@ -15,7 +15,7 @@ class CallbackObserverTest extends TestCase
     public function it_calls_the_given_callable_on_next()
     {
         $called = false;
-        $observer = new CallbackObserver(function() use (&$called) { $called = true; });
+        $observer = new CallbackObserver(function() use (&$called): void { $called = true; });
 
         $observer->onNext(42);
         $this->assertTrue($called);
@@ -27,7 +27,7 @@ class CallbackObserverTest extends TestCase
     public function it_calls_the_given_callable_on_error()
     {
         $called = false;
-        $observer = new CallbackObserver(function(){}, function() use (&$called) { $called = true; });
+        $observer = new CallbackObserver(function(): void{}, function() use (&$called): void { $called = true; });
 
         $observer->onError(new Exception());
         $this->assertTrue($called);
@@ -39,7 +39,7 @@ class CallbackObserverTest extends TestCase
     public function it_calls_the_given_callable_on_complete()
     {
         $called = false;
-        $observer = new CallbackObserver(function(){}, function(){}, function() use (&$called) { $called = true; });
+        $observer = new CallbackObserver(function(): void{}, function(): void{}, function() use (&$called): void { $called = true; });
 
         $observer->onCompleted();
         $this->assertTrue($called);
@@ -62,7 +62,7 @@ class CallbackObserverTest extends TestCase
     public function it_calls_on_next_with_the_given_value()
     {
         $called = null;
-        $observer = new CallbackObserver(function($value) use (&$called) { $called = $value; });
+        $observer = new CallbackObserver(function($value) use (&$called): void { $called = $value; });
 
         $observer->onNext(42);
 
@@ -75,9 +75,9 @@ class CallbackObserverTest extends TestCase
     public function it_does_not_call_on_next_after_an_error()
     {
         $called = false;
-        $record = function() use (&$called) { $called = true; };
+        $record = function() use (&$called): void { $called = true; };
 
-        $observer = new CallbackObserver($record, function(){});
+        $observer = new CallbackObserver($record, function(): void{});
         $observer->onError(new Exception());
 
         $called = false;
@@ -92,9 +92,9 @@ class CallbackObserverTest extends TestCase
     public function it_does_not_call_on_completed_after_an_error()
     {
         $called = false;
-        $record = function() use (&$called) { $called = true; };
+        $record = function() use (&$called): void { $called = true; };
 
-        $observer = new CallbackObserver(function(){}, function(){}, $record);
+        $observer = new CallbackObserver(function(): void{}, function(): void{}, $record);
         $observer->onError(new Exception());
 
         $called = false;
@@ -109,9 +109,9 @@ class CallbackObserverTest extends TestCase
     public function it_does_not_call_on_error_after_an_error()
     {
         $called = false;
-        $record = function() use (&$called) { $called = true; };
+        $record = function() use (&$called): void { $called = true; };
 
-        $observer = new CallbackObserver(function(){}, $record);
+        $observer = new CallbackObserver(function(): void{}, $record);
         $observer->onError(new Exception());
 
         $called = false;
@@ -126,9 +126,9 @@ class CallbackObserverTest extends TestCase
     public function it_does_not_call_on_next_after_completion()
     {
         $called = false;
-        $record = function() use (&$called) { $called = true; };
+        $record = function() use (&$called): void { $called = true; };
 
-        $observer = new CallbackObserver($record, function(){});
+        $observer = new CallbackObserver($record, function(): void{});
         $observer->onCompleted();
 
         $called = false;
@@ -143,9 +143,9 @@ class CallbackObserverTest extends TestCase
     public function it_does_not_call_on_completed_after_completion()
     {
         $called = false;
-        $record = function() use (&$called) { $called = true; };
+        $record = function() use (&$called): void { $called = true; };
 
-        $observer = new CallbackObserver(function(){}, function(){}, $record);
+        $observer = new CallbackObserver(function(): void{}, function(): void{}, $record);
         $observer->onCompleted();
 
         $called = false;
@@ -160,9 +160,9 @@ class CallbackObserverTest extends TestCase
     public function it_does_not_call_on_error_after_completion()
     {
         $called = false;
-        $record = function() use (&$called) { $called = true; };
+        $record = function() use (&$called): void { $called = true; };
 
-        $observer = new CallbackObserver(function(){}, $record);
+        $observer = new CallbackObserver(function(): void{}, $record);
         $observer->onCompleted();
 
         $called = false;

--- a/test/Rx/Observer/ScheduledObserverTest.php
+++ b/test/Rx/Observer/ScheduledObserverTest.php
@@ -17,7 +17,7 @@ class ScheduledObserverTest extends TestCase
     {
         $called    = false;
         $scheduler = new TestScheduler();
-        $observer  = new CallbackObserver(function () use (&$called) {
+        $observer  = new CallbackObserver(function () use (&$called): void {
             $called = true;
         });
 
@@ -44,9 +44,9 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () {
+            function (): void {
             },
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             });
 
@@ -73,11 +73,11 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () {
+            function (): void {
             },
-            function () {
+            function (): void {
             },
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             });
 
@@ -105,10 +105,10 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             },
-            function () {
+            function (): void {
             }
         );
 
@@ -143,11 +143,11 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () {
+            function (): void {
             },
-            function () {
+            function (): void {
             },
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             }
         );
@@ -183,12 +183,12 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () {
+            function (): void {
             },
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             },
-            function () {
+            function (): void {
             }
         );
 
@@ -225,12 +225,12 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             },
-            function () {
+            function (): void {
             },
-            function () {
+            function (): void {
             }
         );
 
@@ -267,11 +267,11 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () {
+            function (): void {
             },
-            function () {
+            function (): void {
             },
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             }
         );
@@ -309,12 +309,12 @@ class ScheduledObserverTest extends TestCase
         $called    = false;
         $scheduler = new TestScheduler();
         $observer  = new CallbackObserver(
-            function () {
+            function (): void {
             },
-            function () use (&$called) {
+            function () use (&$called): void {
                 $called = true;
             },
-            function () {
+            function (): void {
             }
         );
 
@@ -355,7 +355,7 @@ class ScheduledObserverTest extends TestCase
         $scheduledObserver = new ScheduledObserver(
             $scheduler,
             new CallbackObserver(
-                function ($x) {
+                function ($x): void {
                     throw new Exception("onNext($x) exception");
                 }
             )

--- a/test/Rx/Observer/ScheduledObserverTest.php
+++ b/test/Rx/Observer/ScheduledObserverTest.php
@@ -13,7 +13,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_given_callable_on_next()
+    public function it_calls_the_given_callable_on_next(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -39,7 +39,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_given_callable_on_error()
+    public function it_calls_the_given_callable_on_error(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -68,7 +68,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_calls_the_given_callable_on_complete()
+    public function it_calls_the_given_callable_on_complete(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -100,7 +100,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_next_after_an_error()
+    public function it_does_not_call_on_next_after_an_error(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -138,7 +138,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_completed_after_an_error()
+    public function it_does_not_call_on_completed_after_an_error(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -178,7 +178,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_error_after_an_error()
+    public function it_does_not_call_on_error_after_an_error(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -220,7 +220,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_next_after_completion()
+    public function it_does_not_call_on_next_after_completion(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -262,7 +262,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_completed_after_completion()
+    public function it_does_not_call_on_completed_after_completion(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -304,7 +304,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_call_on_error_after_completion()
+    public function it_does_not_call_on_error_after_completion(): void
     {
         $called    = false;
         $scheduler = new TestScheduler();
@@ -346,7 +346,7 @@ class ScheduledObserverTest extends TestCase
     /**
      * @test
      */
-    public function throw_inside_onnext_throws()
+    public function throw_inside_onnext_throws(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('onNext(0) exception');

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -38,10 +38,10 @@ class EventLoopSchedulerTest extends TestCase
 
         $disposable = $scheduler->schedule($action);
 
-        $this->assertInstanceOf('Rx\DisposableInterface', $disposable);
+        $this->assertInstanceOf(\Rx\DisposableInterface::class, $disposable);
         $this->assertFalse($actionCalled);
 
-        $loop->futureTick(function () use ($loop) {
+        $loop->futureTick(function () use ($loop): void {
             $loop->stop();
         });
 
@@ -62,7 +62,7 @@ class EventLoopSchedulerTest extends TestCase
         $actionCalled = false;
         $count        = 0;
 
-        $action = function ($reschedule) use (&$actionCalled, &$count, $loop) {
+        $action = function ($reschedule) use (&$actionCalled, &$count, $loop): void {
             $actionCalled = true;
             $count++;
             if ($count < 5) {
@@ -74,7 +74,7 @@ class EventLoopSchedulerTest extends TestCase
 
         $disposable = $scheduler->scheduleRecursive($action);
 
-        $this->assertInstanceOf('Rx\DisposableInterface', $disposable);
+        $this->assertInstanceOf(\Rx\DisposableInterface::class, $disposable);
         $this->assertFalse($actionCalled);
         $this->assertEquals(0, $count);
 
@@ -96,15 +96,15 @@ class EventLoopSchedulerTest extends TestCase
 
         // the way that these are scheduled, if the scheduler runs (by calling start a few times),
         // calls should be [2] because 0 is disposed and 1 shouldn't be called for 10s
-        $disposable = $scheduler->schedule(function () use (&$calls) {
+        $disposable = $scheduler->schedule(function () use (&$calls): void {
             $calls[] = 0;
         }, 0);
 
-        $scheduler->schedule(function () use (&$calls) {
+        $scheduler->schedule(function () use (&$calls): void {
             $calls[] = 1;
         }, 10000);
 
-        $scheduler->schedule(function () use (&$calls) {
+        $scheduler->schedule(function () use (&$calls): void {
             $calls[] = 2;
         }, 0);
 
@@ -125,8 +125,8 @@ class EventLoopSchedulerTest extends TestCase
         $scheduler->start();
         $called = null;
 
-        $loop->addTimer(0.100, function () use ($scheduler, &$called) {
-            $scheduler->schedule(function () use (&$called) {
+        $loop->addTimer(0.100, function () use ($scheduler, &$called): void {
+            $scheduler->schedule(function () use (&$called): void {
                 $called = microtime(true);
             }, 100);
         });
@@ -143,21 +143,21 @@ class EventLoopSchedulerTest extends TestCase
         $loop           = Factory::create();
         $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
             $timersCreated++;
-            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted) {
+            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted): void {
                 $timersExecuted++;
                 $action();
             });
-            return new CallbackDisposable(function () use ($loop, $timer) {
+            return new CallbackDisposable(function () use ($loop, $timer): void {
                 $loop->cancelTimer($timer);
             });
         });
 
-        $scheduler->schedule(function () {}, 40);
+        $scheduler->schedule(function (): void {}, 40);
 
-        $scheduler->schedule(function () {}, 35)->dispose();
-        $scheduler->schedule(function () {}, 34)->dispose();
+        $scheduler->schedule(function (): void {}, 35)->dispose();
+        $scheduler->schedule(function (): void {}, 34)->dispose();
 
-        $scheduler->schedule(function () {}, 20);
+        $scheduler->schedule(function (): void {}, 20);
 
         $loop->run();
 
@@ -172,23 +172,23 @@ class EventLoopSchedulerTest extends TestCase
         $loop           = Factory::create();
         $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
             $timersCreated++;
-            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted) {
+            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted): void {
                 $timersExecuted++;
                 $action();
             });
-            return new CallbackDisposable(function () use ($loop, $timer) {
+            return new CallbackDisposable(function () use ($loop, $timer): void {
                 $loop->cancelTimer($timer);
             });
         });
 
-        $scheduler->schedule(function () {}, 20);
-        $loop->addTimer(0.01, function () use ($scheduler) {
-            $scheduler->schedule(function () {}, 30);
+        $scheduler->schedule(function (): void {}, 20);
+        $loop->addTimer(0.01, function () use ($scheduler): void {
+            $scheduler->schedule(function (): void {}, 30);
 
-            $scheduler->schedule(function () {}, 25)->dispose();
-            $scheduler->schedule(function () {}, 24)->dispose();
-            $scheduler->schedule(function () {}, 23)->dispose();
-            $scheduler->schedule(function () {}, 25)->dispose();
+            $scheduler->schedule(function (): void {}, 25)->dispose();
+            $scheduler->schedule(function (): void {}, 24)->dispose();
+            $scheduler->schedule(function (): void {}, 23)->dispose();
+            $scheduler->schedule(function (): void {}, 25)->dispose();
         });
 
         $loop->run();
@@ -202,18 +202,18 @@ class EventLoopSchedulerTest extends TestCase
         $loop           = Factory::create();
         $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
             $timersCreated++;
-            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted) {
+            $timer = $loop->addTimer($delay * 0.001, function () use ($action, &$timersExecuted): void {
                 $timersExecuted++;
                 $action();
             });
-            return new CallbackDisposable(function () use ($loop, $timer) {
+            return new CallbackDisposable(function () use ($loop, $timer): void {
                 $loop->cancelTimer($timer);
             });
         });
 
-        $disp = $scheduler->schedule(function () {}, 3000);
-        $loop->addTimer(0.01, function () use ($scheduler, $disp) {
-            $scheduler->schedule(function () use ($disp) {
+        $disp = $scheduler->schedule(function (): void {}, 3000);
+        $loop->addTimer(0.01, function () use ($scheduler, $disp): void {
+            $scheduler->schedule(function () use ($disp): void {
                 $disp->dispose();
             });
         });
@@ -232,8 +232,8 @@ class EventLoopSchedulerTest extends TestCase
 
         $startTime = microtime(true);
 
-        $disp = $scheduler->schedule(function () {}, 3000);
-        $loop->addTimer(0.01, function () use ($disp) {
+        $disp = $scheduler->schedule(function (): void {}, 3000);
+        $loop->addTimer(0.01, function () use ($disp): void {
             $disp->dispose();
         });
 
@@ -250,9 +250,9 @@ class EventLoopSchedulerTest extends TestCase
 
         $startTime = microtime(true);
 
-        $scheduler->schedule(function () {}, 30);
-        $disp  = $scheduler->schedule(function () {}, 3000);
-        $loop->addTimer(0.050, function () use ($disp) {
+        $scheduler->schedule(function (): void {}, 30);
+        $disp  = $scheduler->schedule(function (): void {}, 3000);
+        $loop->addTimer(0.050, function () use ($disp): void {
             $disp->dispose();
         });
 

--- a/test/Rx/Scheduler/EventLoopSchedulerTest.php
+++ b/test/Rx/Scheduler/EventLoopSchedulerTest.php
@@ -14,7 +14,7 @@ class EventLoopSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function now_returns_time_since_epoch_in_ms()
+    public function now_returns_time_since_epoch_in_ms(): void
     {
         $scheduler = new EventLoopScheduler(function () { return new EmptyDisposable(); });
 
@@ -24,7 +24,7 @@ class EventLoopSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function eventloop_schedule()
+    public function eventloop_schedule(): void
     {
         $loop = Factory::create();
 
@@ -54,7 +54,7 @@ class EventLoopSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function eventloop_schedule_recursive()
+    public function eventloop_schedule_recursive(): void
     {
 
         $loop = Factory::create();
@@ -84,7 +84,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertTrue($actionCalled);
     }
 
-    public function testDisposedEventDoesNotCauseSkip()
+    public function testDisposedEventDoesNotCauseSkip(): void
     {
         // create a scheduler - timing is not important for this test
         // so we can just use an empty callable
@@ -117,7 +117,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertEquals([2], $calls);
     }
 
-    public function testSchedulerWorkedWithScheduledEventOutsideItself()
+    public function testSchedulerWorkedWithScheduledEventOutsideItself(): void
     {
         $loop      = Factory::create();
         $scheduler = new EventLoopScheduler($loop);
@@ -136,7 +136,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertNotNull($called);
     }
 
-    public function testScheduledItemsFromOutsideOfSchedulerDontCreateExtraTimers()
+    public function testScheduledItemsFromOutsideOfSchedulerDontCreateExtraTimers(): void
     {
         $timersCreated   = 0;
         $timersExecuted = 0;
@@ -165,7 +165,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertLessThanOrEqual(3, $timersExecuted);
     }
 
-    public function testMultipleSchedulesFromOutsideInSameTickDontCreateExtraTimers()
+    public function testMultipleSchedulesFromOutsideInSameTickDontCreateExtraTimers(): void
     {
         $timersCreated   = 0;
         $timersExecuted = 0;
@@ -197,7 +197,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertEquals(3, $timersExecuted);
     }
 
-    public function testThatStuffScheduledWayInTheFutureDoesntKeepTheLoopRunningIfDisposed()
+    public function testThatStuffScheduledWayInTheFutureDoesntKeepTheLoopRunningIfDisposed(): void
     {
         $loop           = Factory::create();
         $scheduler      = new EventLoopScheduler(function ($delay, $action) use ($loop, &$timersCreated, &$timersExecuted) {
@@ -225,7 +225,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertLessThan(2, $loopTime);
     }
 
-    public function testThatDisposalOfSingleScheduledItemOutsideOfInvokeCancelsTimer()
+    public function testThatDisposalOfSingleScheduledItemOutsideOfInvokeCancelsTimer(): void
     {
         $loop      = Factory::create();
         $scheduler = new EventLoopScheduler($loop);
@@ -243,7 +243,7 @@ class EventLoopSchedulerTest extends TestCase
         $this->assertLessThan(2, $endTime - $startTime);
     }
 
-    public function testScheduledItemPastNextScheduledItemKillsItOwnTimerIfItBecomesTheNextOneAndIsDisposed()
+    public function testScheduledItemPastNextScheduledItemKillsItOwnTimerIfItBecomesTheNextOneAndIsDisposed(): void
     {
         $loop      = Factory::create();
         $scheduler = new EventLoopScheduler($loop);

--- a/test/Rx/Scheduler/ImmediateSchedulerTest.php
+++ b/test/Rx/Scheduler/ImmediateSchedulerTest.php
@@ -26,7 +26,7 @@ class ImmediateSchedulerTest extends TestCase
         $this->expectException(\Exception::class);
         $scheduler = new ImmediateScheduler();
 
-        $scheduler->schedule(function () {
+        $scheduler->schedule(function (): void {
             $this->fail("This should never get called");
         }, 1);
     }
@@ -40,7 +40,7 @@ class ImmediateSchedulerTest extends TestCase
         $this->expectExceptionMessage('ImmediateScheduler does not support a non-zero delay.');
         $scheduler = new ImmediateScheduler();
 
-        $scheduler->schedulePeriodic(function () {
+        $scheduler->schedulePeriodic(function (): void {
             $this->fail("This should never get called");
         }, 1, 1);
     }

--- a/test/Rx/Scheduler/ImmediateSchedulerTest.php
+++ b/test/Rx/Scheduler/ImmediateSchedulerTest.php
@@ -11,7 +11,7 @@ class ImmediateSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function now_returns_the_time()
+    public function now_returns_the_time(): void
     {
         $scheduler = new ImmediateScheduler();
 
@@ -21,7 +21,7 @@ class ImmediateSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function non_zero_delay_throws()
+    public function non_zero_delay_throws(): void
     {
         $this->expectException(\Exception::class);
         $scheduler = new ImmediateScheduler();
@@ -34,7 +34,7 @@ class ImmediateSchedulerTest extends TestCase
     /**
      * @test
      */
-    public function schedule_periodic_throws()
+    public function schedule_periodic_throws(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('ImmediateScheduler does not support a non-zero delay.');

--- a/test/Rx/Scheduler/PriorityQueueTest.php
+++ b/test/Rx/Scheduler/PriorityQueueTest.php
@@ -11,7 +11,7 @@ class PriorityQueueTest extends TestCase
     /**
      * @test
      */
-    public function it_should_remove_a_scheduled_item()
+    public function it_should_remove_a_scheduled_item(): void
     {
         $queue          = new PriorityQueue();
         $scheduledItem  = $this->createScheduledItem(1);
@@ -38,7 +38,7 @@ class PriorityQueueTest extends TestCase
     /**
      * @test
      */
-    public function it_orders_the_items()
+    public function it_orders_the_items(): void
     {
         $queue          = new PriorityQueue();
         $scheduledItem  = $this->createScheduledItem(3);
@@ -57,7 +57,7 @@ class PriorityQueueTest extends TestCase
     /**
      * @test
      */
-    public function peek_returns_the_top_item()
+    public function peek_returns_the_top_item(): void
     {
         $queue          = new PriorityQueue();
         $scheduledItem  = $this->createScheduledItem(3);
@@ -74,7 +74,7 @@ class PriorityQueueTest extends TestCase
     /**
      * @test
      */
-    public function dequeue_removes_the_top_item_from_the_queue()
+    public function dequeue_removes_the_top_item_from_the_queue(): void
     {
         $queue          = new PriorityQueue();
         $scheduledItem  = $this->createScheduledItem(1);
@@ -96,7 +96,7 @@ class PriorityQueueTest extends TestCase
     /**
      * @test
      */
-    public function first_scheduled_item_with_same_priority_comes_first()
+    public function first_scheduled_item_with_same_priority_comes_first(): void
     {
         $queue          = new PriorityQueue();
         $scheduledItem  = $this->createScheduledItem(1);
@@ -115,7 +115,7 @@ class PriorityQueueTest extends TestCase
     /**
      * @test
      */
-    public function can_remove_scheduled_items_out_of_order()
+    public function can_remove_scheduled_items_out_of_order(): void
     {
         $queue          = new PriorityQueue();
         $scheduledItem  = $this->createScheduledItem(1);
@@ -135,7 +135,7 @@ class PriorityQueueTest extends TestCase
      * @test
      * @doesNotPerformAssertions
      */
-    public function should_not_remove_nonexistent_item()
+    public function should_not_remove_nonexistent_item(): void
     {
         $queue = new PriorityQueue();
         $queue->remove(

--- a/test/Rx/Scheduler/PriorityQueueTest.php
+++ b/test/Rx/Scheduler/PriorityQueueTest.php
@@ -142,7 +142,7 @@ class PriorityQueueTest extends TestCase
             new ScheduledItem(
                 $this->createMock(ScheduledItem::class),
                 null,
-                function () {
+                function (): void {
                 },
                 0
             )

--- a/test/Rx/SchedulerTest.php
+++ b/test/Rx/SchedulerTest.php
@@ -28,7 +28,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testGetDefaultThrowsIfNotSet()
+    public function testGetDefaultThrowsIfNotSet(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Please set a default scheduler factory');
@@ -37,7 +37,7 @@ class SchedulerTest extends TestCase
         $this->assertInstanceOf(EventLoopScheduler::class, $scheduler);
     }
 
-    public function testSetDefault()
+    public function testSetDefault(): void
     {
         $scheduler = new TestScheduler();
 
@@ -48,7 +48,7 @@ class SchedulerTest extends TestCase
         $this->assertSame($scheduler, Scheduler::getDefault());
     }
 
-    public function testSetDefaultTwiceBeforeGet()
+    public function testSetDefaultTwiceBeforeGet(): void
     {
         $scheduler = new TestScheduler();
 
@@ -65,7 +65,7 @@ class SchedulerTest extends TestCase
         $this->assertSame($scheduler2, Scheduler::getDefault());
     }
 
-    public function testSetAsync()
+    public function testSetAsync(): void
     {
         $scheduler = new TestScheduler();
 
@@ -76,7 +76,7 @@ class SchedulerTest extends TestCase
         $this->assertSame($scheduler, Scheduler::getAsync());
     }
 
-    public function testSetAsyncTwiceBeforeGet()
+    public function testSetAsyncTwiceBeforeGet(): void
     {
         $scheduler = new TestScheduler();
 
@@ -95,7 +95,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testSetDefaultTwiceThrowsException()
+    public function testSetDefaultTwiceThrowsException(): void
     {
         $this->expectException(\Exception::class);
         $scheduler = new TestScheduler();
@@ -114,7 +114,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testSetAsyncTwiceThrowsException()
+    public function testSetAsyncTwiceThrowsException(): void
     {
         $this->expectException(\Exception::class);
         $scheduler = new TestScheduler();
@@ -132,7 +132,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testGetAsyncBeforeSet()
+    public function testGetAsyncBeforeSet(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Please set a default scheduler factory');
@@ -140,7 +140,7 @@ class SchedulerTest extends TestCase
         Scheduler::getAsync();
     }
 
-    public function testGetAsyncAfterSettingDefaultToAsync()
+    public function testGetAsyncAfterSettingDefaultToAsync(): void
     {
         $asyncScheduler = new EventLoopScheduler(function (): void {
         });
@@ -154,7 +154,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testAsyncSchedulerFactorReturnsNonAsyncScheduler()
+    public function testAsyncSchedulerFactorReturnsNonAsyncScheduler(): void
     {
         $this->expectException(\Throwable::class);
         if (phpversion() < '8.0.0') {
@@ -172,7 +172,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testDefaultSchedulerFactorReturnsNonScheduler()
+    public function testDefaultSchedulerFactorReturnsNonScheduler(): void
     {
         $this->expectException(\Throwable::class);
         if (phpversion() < '8.0.0') {
@@ -189,7 +189,7 @@ class SchedulerTest extends TestCase
 
     /**
      */
-    public function testAsyncSchedulerFactorThrowsNonAsyncDefaultScheduler()
+    public function testAsyncSchedulerFactorThrowsNonAsyncDefaultScheduler(): void
     {
         $this->expectException(\Throwable::class);
         $this->expectExceptionMessage('Please set an async scheduler factory');

--- a/test/Rx/SchedulerTest.php
+++ b/test/Rx/SchedulerTest.php
@@ -142,7 +142,7 @@ class SchedulerTest extends TestCase
 
     public function testGetAsyncAfterSettingDefaultToAsync()
     {
-        $asyncScheduler = new EventLoopScheduler(function () {
+        $asyncScheduler = new EventLoopScheduler(function (): void {
         });
 
         Scheduler::setDefaultFactory(function () use ($asyncScheduler) {

--- a/test/Rx/Subject/BehaviorSubjectTest.php
+++ b/test/Rx/Subject/BehaviorSubjectTest.php
@@ -12,7 +12,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_when_subscribing_to_a_disposed_subject()
+    public function it_throws_when_subscribing_to_a_disposed_subject(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject = new BehaviorSubject();
@@ -25,7 +25,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_if_it_has_observers()
+    public function it_exposes_if_it_has_observers(): void
     {
         $subject = new BehaviorSubject();
 
@@ -39,7 +39,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_if_it_is_disposed()
+    public function it_exposes_if_it_is_disposed(): void
     {
         $subject = new BehaviorSubject();
 
@@ -52,7 +52,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_has_no_observers_after_disposing()
+    public function it_has_no_observers_after_disposing(): void
     {
         $subject = new BehaviorSubject();
 
@@ -67,7 +67,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_true_if_an_observer_is_removed()
+    public function it_returns_true_if_an_observer_is_removed(): void
     {
         $subject = new BehaviorSubject();
 
@@ -82,7 +82,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_false_if_an_observer_is_not_subscribed()
+    public function it_returns_false_if_an_observer_is_not_subscribed(): void
     {
         $subject = new BehaviorSubject();
 
@@ -95,7 +95,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_exception_on_subscribe_if_already_stopped()
+    public function it_passes_exception_on_subscribe_if_already_stopped(): void
     {
         $exception = new Exception('fail');
         $subject   = new BehaviorSubject();
@@ -112,7 +112,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_complete_on_subscribe_if_already_stopped()
+    public function it_passes_on_complete_on_subscribe_if_already_stopped(): void
     {
         $subject   = new BehaviorSubject();
         $subject->onCompleted();
@@ -127,7 +127,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_error_if_not_disposed()
+    public function it_passes_on_error_if_not_disposed(): void
     {
         $exception = new Exception('fail');
         $subject   = new BehaviorSubject();
@@ -145,7 +145,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_complete_if_not_disposed()
+    public function it_passes_on_complete_if_not_disposed(): void
     {
         $subject  = new BehaviorSubject();
 
@@ -160,7 +160,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_next_if_not_disposed()
+    public function it_passes_on_next_if_not_disposed(): void
     {
         $subject  = new BehaviorSubject();
         $value    = 42;
@@ -182,7 +182,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_next_if_not_disposed_with_init()
+    public function it_passes_on_next_if_not_disposed_with_init(): void
     {
         $value    = 42;
         $subject  = new BehaviorSubject($value);
@@ -199,7 +199,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_pass_if_already_stopped()
+    public function it_does_not_pass_if_already_stopped(): void
     {
         $subject  = new BehaviorSubject();
 
@@ -224,7 +224,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_on_error_if_disposed()
+    public function it_throws_on_error_if_disposed(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject   = new BehaviorSubject();
@@ -236,7 +236,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_complete_if_disposed()
+    public function it_passes_on_complete_if_disposed(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject  = new BehaviorSubject();
@@ -248,7 +248,7 @@ class BehaviorSubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_next_if_disposed()
+    public function it_passes_on_next_if_disposed(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject  = new BehaviorSubject();

--- a/test/Rx/Subject/BehaviorSubjectTest.php
+++ b/test/Rx/Subject/BehaviorSubjectTest.php
@@ -18,7 +18,7 @@ class BehaviorSubjectTest extends TestCase
         $subject = new BehaviorSubject();
         $subject->dispose();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
     }
 
@@ -31,7 +31,7 @@ class BehaviorSubjectTest extends TestCase
 
         $this->assertFalse($subject->hasObservers());
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
         $this->assertTrue($subject->hasObservers());
     }
@@ -56,7 +56,7 @@ class BehaviorSubjectTest extends TestCase
     {
         $subject = new BehaviorSubject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
         $this->assertTrue($subject->hasObservers());
 
@@ -71,7 +71,7 @@ class BehaviorSubjectTest extends TestCase
     {
         $subject = new BehaviorSubject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
         $this->assertTrue($subject->hasObservers());
 
@@ -86,7 +86,7 @@ class BehaviorSubjectTest extends TestCase
     {
         $subject = new BehaviorSubject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
 
         $this->assertFalse($subject->removeObserver($observer));
         $this->assertFalse($subject->hasObservers());
@@ -101,7 +101,7 @@ class BehaviorSubjectTest extends TestCase
         $subject   = new BehaviorSubject();
         $subject->onError($exception);
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onError')
             ->with($this->equalTo($exception));
@@ -117,7 +117,7 @@ class BehaviorSubjectTest extends TestCase
         $subject   = new BehaviorSubject();
         $subject->onCompleted();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onCompleted');
 
@@ -132,7 +132,7 @@ class BehaviorSubjectTest extends TestCase
         $exception = new Exception('fail');
         $subject   = new BehaviorSubject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onError')
             ->with($this->equalTo($exception));
@@ -149,7 +149,7 @@ class BehaviorSubjectTest extends TestCase
     {
         $subject  = new BehaviorSubject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onCompleted');
 
@@ -165,14 +165,14 @@ class BehaviorSubjectTest extends TestCase
         $subject  = new BehaviorSubject();
         $value    = 42;
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
 
         $observer->expects($this->exactly(2))
             ->method('onNext')
-            ->will($this->returnValueMap(array(
-                array(null),
-                array($value)
-            ))
+            ->will($this->returnValueMap([
+                [null],
+                [$value]
+            ])
         );
 
         $subject->subscribe($observer);
@@ -187,7 +187,7 @@ class BehaviorSubjectTest extends TestCase
         $value    = 42;
         $subject  = new BehaviorSubject($value);
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
 
         $observer->expects($this->once())
             ->method('onNext')
@@ -203,7 +203,7 @@ class BehaviorSubjectTest extends TestCase
     {
         $subject  = new BehaviorSubject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onCompleted');
 

--- a/test/Rx/Subject/SubjectTest.php
+++ b/test/Rx/Subject/SubjectTest.php
@@ -18,7 +18,7 @@ class SubjectTest extends TestCase
         $subject = new Subject();
         $subject->dispose();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
     }
 
@@ -31,7 +31,7 @@ class SubjectTest extends TestCase
 
         $this->assertFalse($subject->hasObservers());
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
         $this->assertTrue($subject->hasObservers());
     }
@@ -56,7 +56,7 @@ class SubjectTest extends TestCase
     {
         $subject = new Subject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
         $this->assertTrue($subject->hasObservers());
 
@@ -71,7 +71,7 @@ class SubjectTest extends TestCase
     {
         $subject = new Subject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $subject->subscribe($observer);
         $this->assertTrue($subject->hasObservers());
 
@@ -86,7 +86,7 @@ class SubjectTest extends TestCase
     {
         $subject = new Subject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
 
         $this->assertFalse($subject->removeObserver($observer));
         $this->assertFalse($subject->hasObservers());
@@ -101,7 +101,7 @@ class SubjectTest extends TestCase
         $subject   = new Subject();
         $subject->onError($exception);
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onError')
             ->with($this->equalTo($exception));
@@ -117,7 +117,7 @@ class SubjectTest extends TestCase
         $subject   = new Subject();
         $subject->onCompleted();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onCompleted');
 
@@ -132,7 +132,7 @@ class SubjectTest extends TestCase
         $exception = new Exception('fail');
         $subject   = new Subject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onError')
             ->with($this->equalTo($exception));
@@ -149,7 +149,7 @@ class SubjectTest extends TestCase
     {
         $subject  = new Subject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onCompleted');
 
@@ -165,7 +165,7 @@ class SubjectTest extends TestCase
         $subject  = new Subject();
         $value    = 42;
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onNext')
             ->with($this->equalTo($value));
@@ -181,7 +181,7 @@ class SubjectTest extends TestCase
     {
         $subject  = new Subject();
 
-        $observer = $this->createMock('Rx\ObserverInterface');
+        $observer = $this->createMock(\Rx\ObserverInterface::class);
         $observer->expects($this->once())
             ->method('onCompleted');
 

--- a/test/Rx/Subject/SubjectTest.php
+++ b/test/Rx/Subject/SubjectTest.php
@@ -12,7 +12,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_when_subscribing_to_a_disposed_subject()
+    public function it_throws_when_subscribing_to_a_disposed_subject(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject = new Subject();
@@ -25,7 +25,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_if_it_has_observers()
+    public function it_exposes_if_it_has_observers(): void
     {
         $subject = new Subject();
 
@@ -39,7 +39,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_exposes_if_it_is_disposed()
+    public function it_exposes_if_it_is_disposed(): void
     {
         $subject = new Subject();
 
@@ -52,7 +52,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_has_no_observers_after_disposing()
+    public function it_has_no_observers_after_disposing(): void
     {
         $subject = new Subject();
 
@@ -67,7 +67,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_true_if_an_observer_is_removed()
+    public function it_returns_true_if_an_observer_is_removed(): void
     {
         $subject = new Subject();
 
@@ -82,7 +82,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_false_if_an_observer_is_not_subscribed()
+    public function it_returns_false_if_an_observer_is_not_subscribed(): void
     {
         $subject = new Subject();
 
@@ -95,7 +95,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_exception_on_subscribe_if_already_stopped()
+    public function it_passes_exception_on_subscribe_if_already_stopped(): void
     {
         $exception = new Exception('fail');
         $subject   = new Subject();
@@ -112,7 +112,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_complete_on_subscribe_if_already_stopped()
+    public function it_passes_on_complete_on_subscribe_if_already_stopped(): void
     {
         $subject   = new Subject();
         $subject->onCompleted();
@@ -127,7 +127,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_error_if_not_disposed()
+    public function it_passes_on_error_if_not_disposed(): void
     {
         $exception = new Exception('fail');
         $subject   = new Subject();
@@ -145,7 +145,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_complete_if_not_disposed()
+    public function it_passes_on_complete_if_not_disposed(): void
     {
         $subject  = new Subject();
 
@@ -160,7 +160,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_next_if_not_disposed()
+    public function it_passes_on_next_if_not_disposed(): void
     {
         $subject  = new Subject();
         $value    = 42;
@@ -177,7 +177,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_does_not_pass_if_already_stopped()
+    public function it_does_not_pass_if_already_stopped(): void
     {
         $subject  = new Subject();
 
@@ -202,7 +202,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_on_error_if_disposed()
+    public function it_throws_on_error_if_disposed(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject   = new Subject();
@@ -214,7 +214,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_complete_if_disposed()
+    public function it_passes_on_complete_if_disposed(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject  = new Subject();
@@ -226,7 +226,7 @@ class SubjectTest extends TestCase
     /**
      * @test
      */
-    public function it_passes_on_next_if_disposed()
+    public function it_passes_on_next_if_disposed(): void
     {
         $this->expectException(\RuntimeException::class);
         $subject  = new Subject();

--- a/test/Rx/Testing/HotObservableTest.php
+++ b/test/Rx/Testing/HotObservableTest.php
@@ -6,7 +6,7 @@ use Rx\TestCase;
 
 class HotObservableTest extends TestCase
 {
-    public function testRemovingObserverThatNeverSubscribed()
+    public function testRemovingObserverThatNeverSubscribed(): void
     {
         $scheduler = new TestScheduler();
 

--- a/test/Rx/Testing/RecordedTest.php
+++ b/test/Rx/Testing/RecordedTest.php
@@ -8,7 +8,7 @@ use Rx\TestCase;
 
 class RecordedTest extends TestCase
 {
-    public function testRecordedWillUseStrictCompareIfNoEqualsMethod()
+    public function testRecordedWillUseStrictCompareIfNoEqualsMethod(): void
     {
         $recorded1 = new Recorded(1, 5);
         $recorded2 = new Recorded(1, "5");
@@ -18,7 +18,7 @@ class RecordedTest extends TestCase
         $this->assertTrue($recorded1->equals($recorded3));
     }
 
-    public function testRecordedToString()
+    public function testRecordedToString(): void
     {
         $recorded = new Recorded(1, 5);
 

--- a/test/Rx/Testing/SubscriptionTest.php
+++ b/test/Rx/Testing/SubscriptionTest.php
@@ -8,7 +8,7 @@ use Rx\TestCase;
 
 class SubscriptionTest extends TestCase
 {
-    public function testSubscriptionGetters()
+    public function testSubscriptionGetters(): void
     {
         $sub = new Subscription(1, 2);
 
@@ -16,7 +16,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals(2, $sub->getUnsubscribed());
     }
 
-    public function testSubscriptionToString()
+    public function testSubscriptionToString(): void
     {
         $this->assertEquals(new Subscription(1, 2), "Subscription(1, 2)");
     }

--- a/test/Rx/TimestampedTest.php
+++ b/test/Rx/TimestampedTest.php
@@ -6,7 +6,7 @@ namespace Rx;
 
 class TimestampedTest extends TestCase
 {
-    public function testEqualWithScalar()
+    public function testEqualWithScalar(): void
     {
         $ts1 = new Timestamped(123, "Hello");
         $ts2 = new Timestamped(123, "Hello");
@@ -14,7 +14,7 @@ class TimestampedTest extends TestCase
         $this->assertTrue($ts1->equals($ts2));
     }
 
-    public function testNotEqualWithScalar()
+    public function testNotEqualWithScalar(): void
     {
         $ts1 = new Timestamped(123, "Hi");
         $ts2 = new Timestamped(123, "Hello");
@@ -22,7 +22,7 @@ class TimestampedTest extends TestCase
         $this->assertTrue(!$ts1->equals($ts2));
     }
 
-    public function testNotEqualInTime()
+    public function testNotEqualInTime(): void
     {
         $ts1 = new Timestamped(124, "Hello");
         $ts2 = new Timestamped(123, "Hello");
@@ -30,21 +30,21 @@ class TimestampedTest extends TestCase
         $this->assertTrue(!$ts1->equals($ts2));
     }
 
-    public function testEqualNotATimestamp()
+    public function testEqualNotATimestamp(): void
     {
         $ts1 = new Timestamped(123, "Hello");
 
         $this->assertTrue(!$ts1->equals("Hello"));
     }
 
-    public function testEqualSameTimestamp()
+    public function testEqualSameTimestamp(): void
     {
         $ts1 = new Timestamped(123, "Hello");
 
         $this->assertTrue($ts1->equals($ts1));
     }
 
-    public function testEqualObjectSameInstance()
+    public function testEqualObjectSameInstance(): void
     {
         $o1 = new \stdClass();
         $o1->x = "y";
@@ -56,7 +56,7 @@ class TimestampedTest extends TestCase
         $this->assertTrue($ts1->equals($ts2));
     }
 
-    public function testNotEqualObjectDiffentInstance()
+    public function testNotEqualObjectDiffentInstance(): void
     {
         $o1 = new \stdClass();
         $o1->x = "y";
@@ -69,7 +69,7 @@ class TimestampedTest extends TestCase
         $this->assertTrue(!$ts1->equals($ts2));
     }
 
-    public function testGetValue()
+    public function testGetValue(): void
     {
         $ts1 = new Timestamped(123, "Hello");
 

--- a/test/helper-functions.php
+++ b/test/helper-functions.php
@@ -8,15 +8,15 @@ use Rx\Notification\OnCompletedNotification;
 use Rx\Notification\OnErrorNotification;
 use Rx\Notification\OnNextNotification;
 
-function onError(int $dueTime, $error, callable $comparer = null) {
+function onError(int $dueTime, $error, ?callable $comparer = null) {
     return new Recorded($dueTime, new OnErrorNotification($error), $comparer);
 }
 
-function onNext(int $dueTime, $value, callable $comparer = null) {
+function onNext(int $dueTime, $value, ?callable $comparer = null) {
     return new Recorded($dueTime, new OnNextNotification($value), $comparer);
 }
 
-function onCompleted(int $dueTime, callable $comparer = null) {
+function onCompleted(int $dueTime, ?callable $comparer = null) {
     return new Recorded($dueTime, new OnCompletedNotification(), $comparer);
 }
 

--- a/test/loop-auto-start.php
+++ b/test/loop-auto-start.php
@@ -11,6 +11,6 @@ Scheduler::setAsyncFactory(function () use ($scheduler) {
     return $scheduler;
 });
 
-register_shutdown_function(function () use ($loop) {
+register_shutdown_function(function () use ($loop): void {
     $loop->run();
 });


### PR DESCRIPTION
- uses Rector to bring the code base up to being PHP 8.4 compliant
- fixes a bug with an optional default scheduler being null