### PR TITLE
Resolve PHP 8.5 deprecation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         php:
+          - 8.5
           - 8.4
           - 8.3
           - 8.2

--- a/src/Scheduler/PriorityQueue.php
+++ b/src/Scheduler/PriorityQueue.php
@@ -72,6 +72,7 @@ class InternalPriorityQueue extends SplPriorityQueue
     // use this value to "stabilize" the priority queue
     private $serial = PHP_INT_MAX;
 
+    #[ReturnTypeWillChange]
     public function insert($item, $priority)
     {
         parent::insert($item, [$priority, $this->serial--]);


### PR DESCRIPTION
This adds PHP 8.5 to the CI PHP version matrix and resolves the only PHP 8.5 deprecation I've ran into while working on https://github.com/voryx/PgAsync/pull/57